### PR TITLE
Map Update | Stewardry 3.0

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -40288,12 +40288,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/taricheamanor)
 "ieQ" = (
-/obj/structure/roguemachine/headeater,
 /obj/effect/decal/edge{
-	color = "#3f3f3f";
-	dir = 4
+	color = "#3f3f3f"
 	},
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/roguemachine/headeater,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "ieS" = (
 /mob/living/carbon/human/species/orc/npc/footsoldier,
@@ -42022,6 +42021,13 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"ivK" = (
+/obj/structure/roguemachine/stockpile{
+	pixel_y = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/steward)
 "ivQ" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/grass,
@@ -80068,14 +80074,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/ocean,
 /area/rogue/indoors/cave/central)
-"pRr" = (
-/obj/structure/roguemachine/stockpile,
-/obj/effect/decal/edge{
-	color = "#3f3f3f";
-	dir = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "pRu" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/grass,
@@ -86108,8 +86106,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "rbf" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
+/obj/structure/roguemachine/mail{
+	mailtag = "Streets (East)";
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/steward)
@@ -277902,8 +277902,8 @@ obm
 mBu
 iyM
 oKV
-oKV
-oKV
+iyM
+iyM
 oKV
 iyM
 fMW
@@ -278354,12 +278354,12 @@ lJF
 iyM
 iyM
 rtc
-rbf
+ivK
 rbf
 fJF
 iyM
 iyM
-lgD
+ieQ
 exD
 xii
 feG
@@ -280619,7 +280619,7 @@ tMh
 tMh
 ruz
 mze
-pRr
+npZ
 exD
 lJF
 mPk
@@ -281523,7 +281523,7 @@ tMh
 tMh
 tMh
 mze
-ieQ
+vQy
 exD
 lJF
 dHL

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -5265,7 +5265,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile/brick,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/steward)
 "bdy" = (
 /obj/structure/bars/passage{
@@ -5914,6 +5914,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"blj" = (
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "blo" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -6437,6 +6442,7 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "bqs" = (
 /obj/structure/chair/bench/couch/r,
+/obj/structure/fluff/wallclock,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "bqv" = (
@@ -14698,7 +14704,7 @@
 	pixel_x = -16;
 	pixel_y = -20
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/steward)
 "cZR" = (
 /obj/structure/closet/crate/chest/loot_chest,
@@ -18928,7 +18934,7 @@
 	lockid = "steward";
 	name = "Stewardry Office"
 	},
-/turf/open/floor/rogue/tile/brick,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/steward)
 "dSi" = (
 /obj/effect/decal/shadow_floor{
@@ -19528,7 +19534,6 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
 "dYF" = (
-/obj/structure/fluff/wallclock,
 /obj/structure/closet/crate/chest{
 	locked = 1;
 	lockid = "steward"
@@ -19810,7 +19815,7 @@
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ebo" = (
 /obj/effect/landmark/start/steward,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/steward)
 "ebs" = (
 /obj/structure/fermentation_keg/random/water,
@@ -21715,8 +21720,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/underdark/north)
 "euZ" = (
-/obj/structure/fluff/railing/corner/north_east,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/steward)
 "eve" = (
 /obj/structure/fluff/statue/gargoyle/candles,
@@ -35370,7 +35374,7 @@
 /obj/structure/roguemachine/scomm/r{
 	scom_tag = "Steward - Office"
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/steward)
 "hhP" = (
 /obj/structure/closet/crate/roguecloset/dark,
@@ -37499,12 +37503,10 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "hDH" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "steward";
-	name = "Steward Bedroom"
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/steward)
 "hDJ" = (
 /obj/structure/ritualcircle/undivided,
@@ -38304,6 +38306,13 @@
 	dir = 4
 	},
 /area/rogue/under/cave/his_vault)
+"hLf" = (
+/obj/structure/fluff/railing/corner{
+	dir = 6
+	},
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "hLg" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /obj/structure/table/wood/poor,
@@ -66389,6 +66398,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"njF" = (
+/obj/structure/fluff/walldeco/rpainting/crown{
+	pixel_y = 33
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/steward)
 "njI" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -84976,6 +84991,13 @@
 "qOD" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"qOI" = (
+/obj/structure/mannequin,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/steward)
 "qON" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -86051,6 +86073,12 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
+"rao" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/steward)
 "ray" = (
 /obj/structure/flora/newtree,
 /obj/item/reagent_containers/food/snacks/smallrat{
@@ -89697,9 +89725,7 @@
 /area/rogue/under/cave/his_vault/two)
 "rNq" = (
 /obj/structure/chair/bench/couch,
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
+/obj/structure/fluff/walldeco/sign/trophy,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "rNx" = (
@@ -94961,6 +94987,10 @@
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
+"sPA" = (
+/obj/structure/curtain/magenta,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/steward)
 "sPB" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains6"
@@ -97886,6 +97916,9 @@
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "ttg" = (
@@ -104999,6 +105032,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/pestra_sanctum)
+"uOB" = (
+/obj/machinery/light/rogue/candle/weak/l,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/steward)
 "uOD" = (
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/carpet/red,
@@ -107117,8 +107154,7 @@
 /obj/structure/stairs{
 	dir = 4
 	},
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/wood,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/steward)
 "vkf" = (
 /obj/structure/table/wood/poor,
@@ -116717,8 +116753,13 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "xfS" = (
-/obj/machinery/light/rogue/candle,
-/turf/open/transparent/openspace,
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "steward";
+	name = "Steward Bedroom";
+	dir = 4
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/steward)
 "xfU" = (
 /obj/structure/table/wood/long_table/right,
@@ -508874,10 +508915,10 @@ bGf
 kSK
 rKJ
 tte
-aVm
-dxv
-dxv
-dxv
+uOB
+euZ
+euZ
+euZ
 wGH
 rjK
 rjK
@@ -509326,10 +509367,10 @@ bGf
 kSK
 rKJ
 rNq
-dxv
+euZ
 cZO
 ebo
-dxv
+euZ
 jdB
 ocm
 umt
@@ -509779,9 +509820,9 @@ kSK
 rKJ
 bqs
 hhO
-dxv
-dxv
-dxv
+euZ
+euZ
+euZ
 fsb
 hKH
 tDn
@@ -510230,9 +510271,9 @@ bGf
 kSK
 rKJ
 rKJ
-rKJ
 sfe
 rKJ
+euZ
 dYF
 ePb
 fIQ
@@ -510680,11 +510721,11 @@ bsh
 bGf
 bGf
 kSK
-kSK
-jMm
-uiu
-euZ
 rKJ
+hLf
+uiu
+rKJ
+xfS
 rKJ
 rKJ
 rKJ
@@ -511131,12 +511172,12 @@ quq
 bsh
 bGf
 bGf
-bGf
 kSK
-rKJ
-xfS
-yaI
-rKJ
+jMm
+osq
+jJC
+sPA
+rao
 eAi
 vDY
 eAi
@@ -511583,12 +511624,12 @@ qfC
 vVI
 bGf
 bGf
-bGf
 kSK
 rKJ
+blj
 vke
-yaI
-rKJ
+sPA
+njF
 fsb
 ikR
 fsb
@@ -512035,11 +512076,11 @@ bMm
 bGf
 bGf
 bGf
-bGf
 kSK
 jMm
 dxv
 dxv
+sPA
 hDH
 qXw
 qXw
@@ -512487,12 +512528,12 @@ bMm
 bGf
 bGf
 bGf
-bGf
 kSK
 rKJ
 vBJ
 oWi
-rKJ
+sPA
+qOI
 iSk
 qXw
 xVm
@@ -512939,8 +512980,8 @@ bMm
 eGS
 bGf
 bGf
-bGf
 kSK
+rKJ
 rKJ
 rKJ
 rKJ
@@ -513391,7 +513432,7 @@ bMm
 bGf
 bGf
 bGf
-bGf
+kSK
 kSK
 kSK
 kSK

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -42022,15 +42022,6 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"ivK" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/steward)
 "ivQ" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/grass,
@@ -396788,7 +396779,7 @@ kSK
 rKJ
 lAt
 tMh
-ivK
+dKZ
 dKZ
 tMh
 jjv

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -990,10 +990,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"ald" = (
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/steward)
 "ali" = (
 /obj/structure/bars{
 	color = "#755f48";
@@ -4124,9 +4120,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "aRS" = (
-/obj/machinery/light/rogue/candle,
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/chair/wood/rogue/chair5,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/steward)
 "aRY" = (
 /obj/structure/closet/crate/coffin,
@@ -4433,7 +4428,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "aVm" = (
-/obj/machinery/light/rogue/candle/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "aVo" = (
@@ -5267,12 +5262,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/druidsgrove)
 "bdw" = (
-/obj/structure/mineral_door/wood/violet{
-	locked = 1;
-	lockid = "steward";
-	name = "Clerk Bedroom"
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/steward)
 "bdy" = (
 /obj/structure/bars/passage{
@@ -6261,9 +6254,16 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault/four)
 "bow" = (
-/obj/machinery/light/rogue/candle/r,
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/rogue/wood,
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/steward)
 "boz" = (
 /obj/effect/decal/edge{
@@ -6436,12 +6436,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "bqs" = (
-/obj/structure/closet/crate/drawer,
-/obj/machinery/light/rogue/candle/r,
-/obj/item/clothing/ring/signet,
-/obj/item/reagent_containers/food/snacks/tallow/black,
-/obj/item/reagent_containers/food/snacks/tallow/black,
-/obj/item/reagent_containers/food/snacks/tallow/black,
+/obj/structure/chair/bench/couch/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "bqv" = (
@@ -6536,8 +6531,8 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "brI" = (
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "brK" = (
 /obj/structure/fluff/railing/wood,
@@ -8690,13 +8685,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/cave/west)
 "bOa" = (
-/obj/structure/table/wood/poor,
-/obj/item/rogueweapon/huntingknife/chefknife,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = -7
-	},
-/obj/item/flint,
-/turf/open/floor/rogue/tile/checkeralt,
+/obj/structure/table/wood/fancy/red,
+/obj/item/bouquet/rosa,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "bOc" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -9597,13 +9588,12 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "bYk" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
+/mob/living/simple_animal/hostile/retaliate/rogue/cat{
+	name = "Mimsy";
+	desc = "The stewards beloved cat."
 	},
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "bYr" = (
 /obj/structure/glowshroom,
@@ -10679,8 +10669,12 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap/banditcamp)
 "ckG" = (
-/obj/structure/fluff/railing/corner/south_east,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/roguemachine/withdraw{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border/north,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/steward)
 "ckH" = (
 /obj/structure/bars/grille,
@@ -11141,13 +11135,6 @@
 "cok" = (
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
-"col" = (
-/obj/effect/decal/edge{
-	color = "#3f3f3f"
-	},
-/obj/structure/roguemachine/headeater,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
 "com" = (
 /obj/effect/wisp/prestidigitation{
 	desc = "You in druidic grove. Be careful";
@@ -13775,11 +13762,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "cQN" = (
-/obj/effect/decal/edge{
-	color = "#3f3f3f";
-	dir = 1
-	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/stairs,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "cQQ" = (
 /obj/structure/bars/pipe{
@@ -14710,11 +14694,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "cZO" = (
-/obj/structure/fluff/railing/border/north{
-	dir = 8
+/obj/structure/bearpelt{
+	pixel_x = -16;
+	pixel_y = -20
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "cZR" = (
 /obj/structure/closet/crate/chest/loot_chest,
 /turf/open/floor/rogue/herringbone,
@@ -15102,7 +15087,10 @@
 /turf/closed/wall/mineral/rogue/decostone/mossy/long,
 /area/rogue/indoors/shelter)
 "deO" = (
-/obj/machinery/light/rogue/candle,
+/obj/structure/lever/wall{
+	pixel_x = 32;
+	redstone_id = "warehouse_shutter"
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "deR" = (
@@ -18309,12 +18297,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
 "dME" = (
-/obj/structure/fluff/railing/corner{
-	dir = 5
+/obj/effect/decal/edge{
+	color = "#3f3f3f"
 	},
-/turf/open/floor/rogue/cobblerock{
-	smooth = 0
-	},
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "dMI" = (
 /obj/structure/fluff/railing/corner,
@@ -18935,8 +18922,13 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
 "dSe" = (
-/obj/structure/fluff/walldeco/bigpainting,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/mineral_door/wood/donjon{
+	dir = 4;
+	locked = 1;
+	lockid = "steward";
+	name = "Stewardry Office"
+	},
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/steward)
 "dSi" = (
 /obj/effect/decal/shadow_floor{
@@ -19276,7 +19268,11 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
 "dWp" = (
-/obj/machinery/gear_painter,
+/obj/structure/closet/crate/roguecloset/crafted,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "dWq" = (
@@ -19532,12 +19528,19 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
 "dYF" = (
-/obj/structure/mineral_door/wood/violet{
+/obj/structure/fluff/wallclock,
+/obj/structure/closet/crate/chest{
 	locked = 1;
-	lockid = "steward";
-	name = "Reception Desk"
+	lockid = "steward"
 	},
-/turf/open/floor/rogue/hexstone,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
+/obj/machinery/light/rogue/candle/weak/r,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "dYG" = (
 /obj/structure/table/church,
@@ -19806,8 +19809,8 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ebo" = (
-/obj/structure/fluff/railing/border/north,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/effect/landmark/start/steward,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "ebs" = (
 /obj/structure/fermentation_keg/random/water,
@@ -20752,7 +20755,7 @@
 /obj/structure/bars/passage/shutter{
 	redstone_id = "warehouse_shutter"
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "elv" = (
 /obj/structure/table/wood/long_table,
@@ -21712,8 +21715,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/underdark/north)
 "euZ" = (
-/obj/structure/table/wood/long_table/right,
-/obj/item/bouquet/salvia,
+/obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "eve" = (
@@ -21957,12 +21959,12 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "exE" = (
-/obj/structure/table/wood/large_table/north_west,
-/obj/item/candle/candlestick/silver{
-	pixel_x = 17;
-	pixel_y = -10
+/obj/structure/mineral_door/wood/violet{
+	locked = 1;
+	lockid = "steward";
+	name = "Clerk Bedroom"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "exG" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -22240,14 +22242,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "eAi" = (
-/obj/structure/fluff/walldeco/alarm,
-/obj/structure/mineral_door/wood/donjon{
-	dir = 8;
-	locked = 1;
-	lockid = "steward";
-	name = "To Stewardry"
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/structure/closet/crate/drawer,
+/obj/machinery/light/rogue/candle/weak/l,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "eAk" = (
 /obj/structure/chair/bench/coucha/r,
@@ -22829,21 +22826,11 @@
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/cave/taricheamanor)
 "eGS" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "steward"
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/obj/item/roguekey/manor,
-/obj/item/roguekey/manor,
-/obj/item/roguekey/manor,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/walls,
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/tile/tilerg,
-/area/rogue/indoors/town/steward)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "eGT" = (
 /obj/structure/chair/bench/church/smallbench{
 	dir = 1
@@ -23552,10 +23539,32 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "ePb" = (
-/obj/effect/decal/edge{
-	color = "#3f3f3f"
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "steward"
 	},
-/turf/open/floor/rogue/concrete,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/steward,
+/obj/item/roguekey/church,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/graveyard,
+/obj/item/roguekey/garrison,
+/obj/item/roguekey/mercenary,
+/obj/item/roguekey/tavern,
+/obj/item/roguekey/physician,
+/obj/item/roguekey/farm,
+/obj/item/roguekey/tailor,
+/obj/item/roguekey/shop,
+/obj/item/roguekey/bathworker,
+/obj/item/roguekey/archive,
+/obj/item/roguekey/apartments/stable1,
+/obj/item/roguekey/apartments/stable2,
+/obj/item/roguekey/tavernkeep,
+/obj/item/roguekey/university,
+/obj/item/roguekey/crafterguild,
+/obj/item/roguekey/crier,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "ePg" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
@@ -24460,14 +24469,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "eYj" = (
-/obj/structure/table/wood/poor,
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/candlestick/silver/lit{
+	pixel_x = -1;
+	pixel_y = 9
 	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 16
-	},
-/turf/open/floor/rogue/tile/checkeralt,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "eYl" = (
 /obj/structure/chair/wood/rogue{
@@ -25089,9 +25096,20 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "fed" = (
-/obj/machinery/light/rogue/hearth,
-/obj/machinery/light/rogue/oven/west,
-/turf/open/floor/rogue/cobble,
+/obj/structure/table/wood/poor,
+/obj/item/flint{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 8;
+	pixel_y = -11
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "fef" = (
 /obj/effect/decal/cleanable/blood,
@@ -26570,16 +26588,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "fsb" = (
-/obj/structure/table/wood/poor/alt_alt,
-/obj/item/candle/gold/lit{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/snacks/tallow/black{
-	pixel_x = -5;
-	pixel_y = 11
-	},
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "fsh" = (
 /obj/structure/chair/stool/rogue,
@@ -28103,10 +28112,14 @@
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/scarymaze)
 "fIQ" = (
-/obj/machinery/light/rogue/lanternpost,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/item/roguekey/vault,
+/obj/structure/closet/crate/roguecloset/lord{
+	lockid = "steward"
+	},
+/obj/item/roguekey/armory,
+/obj/machinery/light/rogue/candle/weak/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/steward)
 "fIR" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider,
 /turf/open/floor/rogue/twig,
@@ -31425,12 +31438,12 @@
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cave/fishmandungeon)
 "grZ" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/mirror{
+	pixel_x = -28;
+	pixel_y = 0
 	},
-/obj/structure/fluff/railing/border/west,
-/turf/open/water/bath,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/dwarfin)
 "gse" = (
 /obj/item/fishingrod,
 /turf/open/floor/rogue/dirt,
@@ -34007,7 +34020,9 @@
 /obj/structure/stairs/stone{
 	dir = 1
 	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/cobblerock{
+	smooth = 0
+	},
 /area/rogue/indoors/town/steward)
 "gUe" = (
 /obj/structure/vine,
@@ -34647,15 +34662,15 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/inq)
 "hau" = (
+/obj/structure/table/wood/poker,
+/obj/structure/bars/passage/shutter/open{
+	redstone_id = "stewardshutter"
+	},
 /obj/structure/bars{
 	icon_state = "barsbent";
 	layer = 2.81
 	},
-/obj/structure/table/wood/poor,
-/obj/structure/bars/passage/shutter/open{
-	redstone_id = "stewardshutter"
-	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "hav" = (
 /obj/effect/decal/cobbleedge{
@@ -34702,10 +34717,10 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "hbh" = (
+/obj/structure/fluff/railing/border/east,
 /obj/structure/roguemachine/atm{
 	location_tag = "Stewardry"
 	},
-/obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "hbk" = (
@@ -35261,9 +35276,22 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "hhl" = (
-/obj/structure/roguemachine/steward_export,
-/turf/open/floor/rogue/blocks/newstone/alt,
-/area/rogue/indoors/town/warehouse)
+/obj/structure/table/wood/fancy/red,
+/obj/item/cooking/platter/silver,
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/obj/item/kitchen/fork/silver{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = -16;
+	pixel_y = 29
+	},
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/steward)
 "hho" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -35339,8 +35367,10 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
 "hhO" = (
-/obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Steward - Office"
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "hhP" = (
 /obj/structure/closet/crate/roguecloset/dark,
@@ -36632,17 +36662,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/druidsgrove)
 "hun" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "steward";
-	name = "To Stewardry"
-	},
-/obj/structure/fluff/walldeco/alarm{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/fluff/railing/border/north,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/steward)
 "huq" = (
 /obj/machinery/light/rogue/candle/off/r,
@@ -36748,8 +36769,12 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/goblinfort)
 "hwb" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 4
+/obj/structure/table/wood/fancy/red,
+/obj/structure/fluff/walldeco/bigpainting/lake{
+	pixel_x = 0
+	},
+/obj/item/roguestatue/gold/loot{
+	pixel_y = 11
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
@@ -37474,12 +37499,12 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "hDH" = (
-/obj/structure/bearpelt{
-	desc = "A hide of a slain bear. It looks rich and expensive.";
-	pixel_y = 20
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "steward";
+	name = "Steward Bedroom"
 	},
-/obj/structure/fluff/railing/corner/south_west,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "hDJ" = (
 /obj/structure/ritualcircle/undivided,
@@ -38227,8 +38252,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "hKH" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/carpet/red,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "hKI" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
@@ -39081,10 +39108,10 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "hTB" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Steward - Office"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "hTC" = (
 /obj/structure/fluff/railing/corner{
@@ -39133,8 +39160,10 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "hTR" = (
-/obj/structure/table/wood/large_table/north_east,
-/turf/open/floor/carpet/red,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "hTW" = (
 /obj/structure/lever/wall{
@@ -39299,25 +39328,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
 "hWh" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/silver,
-/obj/item/reagent_containers/glass/cup/silver/small,
-/obj/item/reagent_containers/glass/cup/silver/small,
-/obj/item/kitchen/spoon/gold,
-/obj/item/kitchen/spoon/iron,
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl/iron,
-/obj/item/cooking/platter/gold,
-/obj/item/cooking/platter,
-/obj/item/reagent_containers/glass/bucket/pot/stone,
-/obj/item/cooking/pan,
-/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "hWl" = (
 /obj/structure/hotspring/border/nine,
@@ -40220,8 +40233,10 @@
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
 "ies" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/carpet/red,
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "iet" = (
 /obj/structure/mineral_door/wood/fancywood{
@@ -40273,11 +40288,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/taricheamanor)
 "ieQ" = (
-/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/roguemachine/headeater,
 /obj/effect/decal/edge{
-	color = "#3f3f3f"
+	color = "#3f3f3f";
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "ieS" = (
 /mob/living/carbon/human/species/orc/npc/footsoldier,
@@ -40896,12 +40912,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "ikR" = (
-/obj/structure/closet/crate/drawer,
-/obj/structure/mirror{
-	pixel_y = 28
+/obj/effect/decal/carpet/kover_darkred{
+	pixel_x = -16
 	},
-/obj/item/hair_dye_cream,
-/turf/open/floor/rogue/tile/bath,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "ikV" = (
 /obj/structure/fluff/railing/border/east,
@@ -42009,10 +42023,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ivK" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/steward)
 "ivQ" = (
 /obj/structure/closet/dirthole/closed/loot,
@@ -42622,11 +42639,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "iCf" = (
-/obj/structure/fluff/railing/corner,
-/obj/structure/roguemachine/noticeboard/wall{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "iCm" = (
 /obj/structure/flora/roguegrass/bush/wall,
@@ -42941,9 +42955,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "iFA" = (
-/obj/structure/closet/crate/drawer,
-/obj/machinery/light/rogue/candle/weak/r,
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/fluff/railing/corner/south_west,
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32;
+	scom_tag = "Stewardry - 2nd Floor"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "iFF" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -44435,13 +44452,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iUW" = (
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_x = 16
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/steward)
 "iUX" = (
 /obj/effect/decal/wood/herringbone{
@@ -45834,8 +45847,18 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/zhurch)
 "jjv" = (
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/rogue/wood,
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/reagent_containers/glass/bucket/pot,
+/obj/item/cooking/pan,
+/obj/item/reagent_containers/glass/bowl/silver,
+/obj/item/reagent_containers/glass/bowl/silver,
+/obj/item/reagent_containers/glass/bowl/silver,
+/obj/item/reagent_containers/glass/bowl/silver,
+/obj/item/kitchen/spoon/silver,
+/obj/item/kitchen/spoon/silver,
+/obj/item/kitchen/spoon/silver,
+/obj/item/kitchen/spoon/silver,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "jjA" = (
 /obj/structure/table/wood/long_table,
@@ -45961,7 +45984,6 @@
 /area/rogue/outdoors/rtfield/eora)
 "jkr" = (
 /obj/structure/roguemachine/steward,
-/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/steward)
 "jks" = (
@@ -48749,11 +48771,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "jMm" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/edge{
-	color = "#3f3f3f"
-	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/roguewindow/openclose/reinforced,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "jMp" = (
 /obj/structure/flora/roguegrass,
@@ -48998,14 +49017,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/goblinfort)
 "jOC" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "warehouse_shutter"
-	},
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/gear_painter,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/steward)
 "jOI" = (
 /obj/effect/decal/remains/wolf,
@@ -49068,12 +49081,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/manor)
 "jPl" = (
-/obj/structure/closet/crate/roguecloset/crafted,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/clothing/under/roguetown/skirt,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/turf/open/floor/carpet/red,
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "jPm" = (
 /obj/structure/mannequin/male{
@@ -49123,13 +49132,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jPF" = (
-/obj/effect/decal/edge{
-	color = "#3f3f3f";
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r,
+/obj/machinery/light/rogue/hearth,
+/obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/steward)
 "jPG" = (
 /obj/structure/flora/roguegrass/bush/westleach,
 /obj/effect/decal/edge_corner{
@@ -49402,12 +49408,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "jRO" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/decal/carpet/kover_darkred{
-	pixel_x = -16
+/obj/structure/mineral_door/wood/donjon{
+	dir = 4;
+	locked = 1;
+	lockid = "steward";
+	name = "Bathroom"
 	},
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "jSe" = (
 /obj/structure/chair/wood/rogue{
@@ -50354,12 +50361,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
 "kbh" = (
-/obj/structure/fluff/walldeco/bigpainting/lake{
-	pixel_x = 0
-	},
-/obj/structure/table/wood/long_table,
-/obj/item/roguestatue/gold/loot{
-	pixel_y = 11
+/obj/structure/stairs{
+	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
@@ -50932,7 +50935,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/church)
 "kgf" = (
-/turf/closed/wall/mineral/rogue/stone,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "kgg" = (
 /obj/structure/flora/roguegrass/bush/wall,
@@ -56789,11 +56795,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lmn" = (
-/obj/structure/fluff/railing/corner{
-	dir = 10
+/obj/structure/chair/wood/rogue/chair5{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/steward)
 "lmo" = (
 /obj/effect/decal/cleanable/sigil/SW,
 /turf/open/floor/rogue/hexstone,
@@ -58379,13 +58385,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
 "lAt" = (
-/obj/item/roguekey/vault,
-/obj/structure/closet/crate/roguecloset/lord{
-	lockid = "steward"
-	},
-/obj/machinery/light/rogue/candle/l,
-/obj/item/roguekey/armory,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy,
+/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "lAw" = (
 /obj/structure/table/church,
@@ -58917,13 +58923,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/underdark/north)
 "lGl" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_x = 32
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/steward)
 "lGn" = (
 /obj/structure/closet/crate/drawer,
@@ -63261,10 +63264,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "mze" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/steward)
 "mzi" = (
 /obj/item/millstone,
@@ -65097,7 +65097,6 @@
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "mUJ" = (
-/obj/machinery/light/rogue/torchholder/c,
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
@@ -65922,7 +65921,7 @@
 /area/rogue/outdoors/town)
 "neg" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
-/area/rogue/indoors/town/warehouse)
+/area/rogue/indoors/town/steward)
 "neh" = (
 /obj/structure/bookcase,
 /turf/open/floor/rogue/church,
@@ -66749,10 +66748,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "nnP" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
+/obj/structure/table/wood/fancy/red,
+/obj/item/cooking/platter/silver,
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_y = 5;
+	pixel_x = 9
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/item/kitchen/fork/silver{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/steward)
 "nnR" = (
 /obj/item/natural/worms/leech,
@@ -66979,10 +66985,7 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
 "npI" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/steward)
 "npL" = (
 /obj/structure/fluff/railing/corner/north_east,
@@ -69969,8 +69972,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault)
 "nUH" = (
-/obj/structure/fluff/railing/border,
-/obj/machinery/light/rogue/candle/floorcandle,
+/obj/structure/fluff/walldeco/church/line,
 /obj/machinery/light/rogue/candle/floorcandle/alt{
 	pixel_y = -14
 	},
@@ -72011,6 +72013,9 @@
 /obj/item/roguemachine/zadcote/steward{
 	pixel_y = 32
 	},
+/obj/structure/roguemachine/noticeboard/wall{
+	pixel_x = 32
+	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/steward)
 "oql" = (
@@ -72194,11 +72199,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/town)
 "osq" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border/east,
-/turf/open/water/bath,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "osr" = (
 /obj/structure/stairs{
@@ -74296,7 +74298,9 @@
 /area/rogue/outdoors/mountains/decap/minotaurfort)
 "oKV" = (
 /obj/structure/roguewindow,
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/cobblerock{
+	smooth = 0
+	},
 /area/rogue/indoors/town/steward)
 "oKZ" = (
 /turf/open/floor/rogue/cobble,
@@ -75017,9 +75021,20 @@
 /turf/open/transparent/openspace,
 /area/rogue/druidsgrove)
 "oRg" = (
-/obj/structure/fluff/railing/corner/south_east,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/steward)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/obj/effect/decal/edge{
+	color = "#3f3f3f";
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/c{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "oRl" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/concrete,
@@ -75506,11 +75521,8 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/beach/forest/south)
 "oWi" = (
-/obj/structure/roguemachine/stockpile{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "oWl" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -77558,14 +77570,13 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
 "prx" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/obj/structure/table/wood,
+/obj/structure/curtain/red,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/steward)
 "prz" = (
 /obj/effect/decal/edge{
@@ -80067,16 +80078,13 @@
 /turf/open/water/ocean,
 /area/rogue/indoors/cave/central)
 "pRr" = (
-/obj/structure/table/wood/poor,
-/obj/item/millstone{
-	pixel_y = 7
+/obj/structure/roguemachine/stockpile,
+/obj/effect/decal/edge{
+	color = "#3f3f3f";
+	dir = 8
 	},
-/obj/item/reagent_containers/peppermill{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "pRu" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/grass,
@@ -80430,10 +80438,6 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "pWf" = (
-/obj/structure/lever/wall{
-	pixel_x = 12;
-	redstone_id = "stewardshutter"
-	},
 /obj/structure/fluff/railing/border/west,
 /obj/item/roguemachine/mastermail,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -81448,9 +81452,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "qgd" = (
-/obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/candle/weak/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/steward)
 "qgf" = (
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/metal{
@@ -81520,10 +81524,6 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"qgG" = (
-/obj/structure/table/wood/large_table/south_east,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/steward)
 "qgH" = (
 /obj/structure/closet/crate/chest/lootbox,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
@@ -81623,7 +81623,7 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
 "qhv" = (
-/obj/machinery/light/rogue/candle,
+/obj/structure/fluff/clock,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "qhw" = (
@@ -82364,13 +82364,17 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qpp" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/obj/effect/decal/edge{
+	color = "#3f3f3f";
+	dir = 4
 	},
 /obj/effect/decal/edge{
-	color = "#3f3f3f"
+	color = "#3f3f3f";
+	dir = 8
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobblerock{
+	smooth = 0
+	},
 /area/rogue/outdoors/town)
 "qpx" = (
 /obj/effect/landmark/start/merchant,
@@ -85798,10 +85802,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
-"qYa" = (
-/obj/structure/closet/crate/chest/old_crate,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/steward)
 "qYe" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -86117,10 +86117,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "rbf" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Streets (East)";
-	pixel_x = -32;
-	pixel_y = 0
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/steward)
@@ -87418,13 +87416,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/zhurch)
 "roi" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 4;
-	locked = 1;
-	lockid = "steward";
-	name = "Bathroom"
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/light/rogue/hearth,
+/obj/machinery/light/rogue/oven/south,
+/obj/machinery/light/rogue/candle/weak/r,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/steward)
 "rol" = (
 /obj/structure/table/wood/large_table/middle_west,
@@ -87898,7 +87893,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "ruz" = (
-/obj/effect/landmark/start/steward,
+/obj/structure/stairs{
+	dir = 8
+	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "ruA" = (
@@ -89708,7 +89705,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault/two)
 "rNq" = (
-/turf/open/floor/rogue/rooftop/green/north,
+/obj/structure/chair/bench/couch,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "rNx" = (
 /turf/closed/wall/mineral/rogue/wooddark/end/west,
@@ -90104,12 +90105,9 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "rRs" = (
-/obj/effect/decal/edge{
-	color = "#3f3f3f"
-	},
-/obj/structure/fluff/walldeco/wantedposter,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/roguemachine/steward_export,
+/turf/open/floor/rogue/blocks/newstone/alt,
+/area/rogue/indoors/town/steward)
 "rRx" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -90892,8 +90890,18 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
 "rZA" = (
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/steward)
+/obj/effect/decal/edge{
+	color = "#3f3f3f";
+	dir = 8
+	},
+/obj/effect/decal/edge{
+	color = "#3f3f3f";
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock{
+	smooth = 0
+	},
+/area/rogue/outdoors/town)
 "rZF" = (
 /obj/effect/decal/cobble/mossy{
 	dir = 4
@@ -91379,7 +91387,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "sfe" = (
-/obj/structure/fluff/railing/border/west,
+/obj/structure/mineral_door/wood/donjon{
+	dir = 8;
+	locked = 1;
+	lockid = "steward";
+	name = "Stewardry Office"
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "sfh" = (
@@ -91968,12 +91981,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/orcdungeon)
 "slW" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/edge{
-	color = "#3f3f3f";
-	dir = 1
-	},
-/turf/open/floor/rogue/concrete,
+/obj/machinery/light/rogue/candle/weak/r,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/steward)
 "sma" = (
 /obj/structure/fluff/walldeco/church/line,
@@ -93024,13 +93033,8 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
 "svr" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 4;
-	locked = 1;
-	lockid = "steward";
-	name = "Steward Bedroom"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "svu" = (
 /obj/structure/mineral_door/wood/fancywood,
@@ -94365,8 +94369,11 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/underdark/north)
 "sJg" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/candle/l,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "sJh" = (
 /obj/structure/bed/rogue/inn/double{
@@ -94527,7 +94534,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "sKx" = (
-/obj/structure/fluff/railing/border,
+/obj/structure/table/wood/fancy/red,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "sKC" = (
@@ -96324,10 +96331,16 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "tcl" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "steward";
+	name = "To Stewardry"
 	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/walldeco/alarm{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "tcz" = (
 /obj/structure/stairs,
@@ -96449,9 +96462,17 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "tea" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/table/wood/fancy/red,
+/obj/item/cooking/platter/silver,
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_y = 16;
+	pixel_x = -7
+	},
+/obj/item/kitchen/fork/silver{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/steward)
 "tec" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
@@ -96720,10 +96741,17 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "tgV" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "steward";
+	name = "To Stewardry"
 	},
-/turf/open/floor/rogue/hexstone,
+/obj/structure/fluff/walldeco/alarm{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "tha" = (
 /obj/structure/flora/roguegrass/bush,
@@ -96826,8 +96854,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/pestra_sanctum)
 "tik" = (
-/obj/structure/fluff/railing/corner/north_east,
-/turf/open/floor/rogue/tile/checkeralt,
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "tiv" = (
 /obj/item/rogueweapon/hammer/wood{
@@ -97861,10 +97889,13 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/magiciantower)
 "tte" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "ttg" = (
 /mob/living/carbon/human/species/orc/npc/warlord,
@@ -98895,18 +98926,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
 "tCR" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/turf/open/floor/rogue/tile/checkeralt,
+/obj/machinery/light/rogue/firebowl/standing,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "tCU" = (
 /obj/structure/fluff/clock,
@@ -98920,10 +98941,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
 "tDn" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/clerk,
-/turf/open/floor/carpet/red,
+/obj/structure/closet/crate/drawer,
+/obj/item/clothing/ring/signet,
+/obj/item/reagent_containers/food/snacks/tallow/black,
+/obj/item/reagent_containers/food/snacks/tallow/black,
+/obj/item/reagent_containers/food/snacks/tallow/black,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "tDo" = (
 /obj/structure/flora/roguegrass/bush/wall,
@@ -99974,18 +99997,6 @@
 /obj/structure/hotspring/border/three,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
-"tOh" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/alch/salvia{
-	pixel_x = -5;
-	pixel_y = 40
-	},
-/obj/item/alch/rosa{
-	pixel_x = 5;
-	pixel_y = 40
-	},
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/steward)
 "tOl" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -101138,14 +101149,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "uam" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/fluff/railing/wood/east,
+/obj/structure/fluff/railing/wood/north{
+	layer = 2.7;
+	pixel_y = 7
 	},
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "uao" = (
 /mob/living/simple_animal/hostile/rogue/deepone,
 /turf/open/floor/rogue/naturalstone,
@@ -101189,39 +101199,21 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/outdoors/woods/southwest)
 "uaE" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/item/bedsheet/rogue/fabric_double{
+	dir = 1
+	},
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/effect/landmark/start/clerk,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "uaF" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "steward"
+/obj/structure/lever/wall{
+	pixel_x = 12;
+	redstone_id = "stewardshutter"
 	},
-/obj/item/roguekey/manor,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/steward,
-/obj/item/roguekey/church,
-/obj/item/roguekey/dungeon,
-/obj/item/roguekey/graveyard,
-/obj/item/roguekey/garrison,
-/obj/item/roguekey/mercenary,
-/obj/item/roguekey/tavern,
-/obj/item/roguekey/physician,
-/obj/item/roguekey/farm,
-/obj/item/roguekey/tailor,
-/obj/item/roguekey/shop,
-/obj/item/roguekey/bathworker,
-/obj/item/roguekey/archive,
-/obj/item/roguekey/apartments/stable1,
-/obj/item/roguekey/apartments/stable2,
-/obj/item/roguekey/tavernkeep,
-/obj/item/roguekey/university,
-/obj/item/roguekey/crafterguild,
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/obj/item/roguekey/crier,
-/turf/open/floor/rogue/tile/tilerg,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "uaJ" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
@@ -101526,6 +101518,7 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
+/obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "uen" = (
@@ -101924,8 +101917,7 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cavewet/bogcaves/north)
 "uiu" = (
-/obj/machinery/light/rogue/candle/r,
-/obj/structure/bookcase/random/archive,
+/obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "uiw" = (
@@ -102177,6 +102169,7 @@
 /obj/effect/decal/edge{
 	color = "#3f3f3f"
 	},
+/obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ukM" = (
@@ -103657,8 +103650,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark/south)
 "uAL" = (
-/obj/structure/roguewindow/harem3,
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/structure/curtain/red,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
 "uAP" = (
 /obj/structure/glowshroom,
@@ -105681,13 +105674,6 @@
 	dir = 1
 	},
 /area/rogue/under/cave/scarymaze)
-"uUH" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32;
-	scom_tag = "Stewardry - 2nd Floor"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/steward)
 "uUL" = (
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/dirt/road,
@@ -107137,10 +107123,11 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/scarymaze)
 "vke" = (
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_y = 32
+/obj/structure/stairs{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "vkf" = (
 /obj/structure/table/wood/poor,
@@ -108916,10 +108903,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "vBJ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/bookcase/random/archive,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "vBO" = (
 /obj/structure/flora/hotspring_rocks,
@@ -109082,8 +109067,17 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
 "vDY" = (
-/obj/structure/table/wood/large_table/south_west,
-/turf/open/floor/carpet/red,
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric_double{
+	dir = 1
+	},
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "vDZ" = (
 /obj/structure/chair/bench/coucha/r,
@@ -114402,10 +114396,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/exposed/town/keep)
 "wGH" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/candle/weak/l,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/steward)
 "wGI" = (
 /obj/machinery/light/rogue/campfire/fireplace{
@@ -116198,14 +116190,15 @@
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/outdoors/rtfield)
 "wZC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
 /obj/effect/decal/edge{
-	color = "#3f3f3f"
+	color = "#3f3f3f";
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble/mossy,
+/obj/machinery/light/rogue/torchholder/c{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "wZM" = (
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
@@ -116483,7 +116476,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods/southwest)
 "xdg" = (
-/obj/structure/fluff/railing/corner/south_west,
+/obj/machinery/light/rogue/candle/floorcandle,
+/obj/machinery/light/rogue/candle/floorcandle/alt{
+	pixel_y = -14
+	},
+/obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "xdh" = (
@@ -116729,8 +116726,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "xfS" = (
-/obj/structure/fluff/railing/border/north,
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/light/rogue/candle,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/steward)
 "xfU" = (
 /obj/structure/table/wood/long_table/right,
@@ -117997,13 +117994,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/scarymaze)
 "xtQ" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 4;
-	locked = 1;
-	lockid = "steward";
-	name = "Stewardry Office"
+/obj/structure/closet/crate/drawer,
+/obj/item/hair_dye_cream,
+/obj/structure/mirror{
+	pixel_x = -28;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/steward)
 "xtZ" = (
 /obj/effect/decal/edge_corner{
@@ -118872,7 +118869,9 @@
 /area/rogue/under/town/basement/keep)
 "xCZ" = (
 /obj/structure/stairs/stone,
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/cobblerock{
+	smooth = 0
+	},
 /area/rogue/indoors/town/steward)
 "xDd" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -119968,9 +119967,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/garrison)
 "xOZ" = (
-/obj/machinery/light/rogue/candle,
-/obj/structure/fluff/railing/corner/north_east,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 1
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "xPe" = (
 /turf/open/floor/rogue/naturalstone,
@@ -120912,8 +120912,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/basement)
 "xXj" = (
-/obj/structure/roguemachine/stockpile,
-/turf/open/floor/rogue/tile/checkeralt,
+/obj/structure/mineral_door/wood/fancywood,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "xXm" = (
 /obj/structure/roguemachine/mossmother/travel,
@@ -121004,8 +121004,9 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/scarymaze)
 "xXW" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/roguewindow,
+/obj/structure/curtain/red,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/steward)
 "xXX" = (
 /obj/structure/fluff/railing/border/west,
@@ -121679,7 +121680,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/underdark/north)
 "yeu" = (
-/turf/open/floor/rogue/tile/checkeralt,
+/obj/structure/table/wood/poor,
+/obj/item/millstone{
+	pixel_y = 7
+	},
+/obj/machinery/light/rogue/candle/weak/r,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "yew" = (
 /turf/open/water/swamp/deep,
@@ -122210,11 +122216,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "yju" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Steward";
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/steward)
 "yjx" = (
 /obj/structure/flora/roguetree/pine,
@@ -277455,12 +277457,12 @@ xqO
 xqO
 xqO
 xqO
-xqO
 vxS
+xqO
 hhy
 eqd
 xqO
-xqO
+vxS
 xqO
 xqO
 exD
@@ -277907,12 +277909,12 @@ xqO
 xqO
 obm
 mBu
-kgf
-oKV
-iyM
 iyM
 oKV
-kgf
+oKV
+oKV
+oKV
+iyM
 fMW
 dTk
 exD
@@ -278359,14 +278361,14 @@ xqO
 xqO
 lJF
 iyM
-kgf
+iyM
 rtc
-oWi
+rbf
 rbf
 fJF
-rKJ
 iyM
-col
+iyM
+lgD
 exD
 xii
 feG
@@ -278809,16 +278811,16 @@ cMz
 xqO
 xqO
 xqO
-lJF
+fVK
 xCZ
-cQN
 lbd
 lbd
 lbd
 lbd
-ePb
+lbd
+lbd
 gUd
-gpM
+fVK
 exD
 fCK
 fUk
@@ -279261,16 +279263,16 @@ cMz
 xqO
 xqO
 xqO
-lJF
+lNh
 xCZ
 slW
 lbd
 lbd
 lbd
 lbd
-jMm
+slW
 gUd
-wZC
+lNh
 exD
 fCK
 feG
@@ -279714,15 +279716,15 @@ xqO
 xqO
 xqO
 lJF
-iyM
-kgf
+mze
+mze
 hau
 hau
 hau
 hau
-kgf
-iyM
-rRs
+mze
+mze
+lgD
 exD
 mfC
 rkI
@@ -280166,14 +280168,14 @@ ghZ
 xqO
 xqO
 lJF
-rKJ
+mze
 rKJ
 hbh
 aqG
 tMh
-tMh
-eGS
-rKJ
+kcF
+mze
+mze
 mUJ
 exD
 uCs
@@ -280618,15 +280620,15 @@ lgD
 xqO
 xqO
 lJF
-rKJ
+mze
 oqh
 oAY
 ued
 tMh
-kcF
-rKJ
-rKJ
-sAU
+tMh
+ruz
+mze
+pRr
 exD
 lJF
 mPk
@@ -281070,15 +281072,15 @@ saN
 uGm
 uGm
 acQ
-rKJ
+mze
 jkr
 oAY
 fAV
 hOa
 tMh
-hun
+tMh
 mze
-sAU
+exD
 exD
 lJF
 dHL
@@ -281522,14 +281524,14 @@ xqO
 xqO
 xqO
 fCK
-rKJ
+mze
 eyl
 oAY
 ued
 tMh
 tMh
-rKJ
-rKJ
+tMh
+mze
 ieQ
 exD
 lJF
@@ -281974,14 +281976,14 @@ xqO
 xqO
 xqO
 fCK
-rKJ
+mze
 rKJ
 pWf
-iCf
+vHt
 tMh
 tMh
 uaF
-rKJ
+mze
 sAU
 exD
 lJF
@@ -282425,15 +282427,15 @@ cMz
 xqO
 xqO
 xqO
-bcv
-rKJ
-rKJ
-iyM
+oRg
+mze
+mze
+brI
 uAL
-dYF
 uAL
-iyM
-rKJ
+brI
+mze
+mze
 ukL
 exD
 lJF
@@ -282877,15 +282879,15 @@ jDG
 tMt
 xqO
 xqO
-lJF
-rKJ
+rZA
+cQN
 tcl
-xfS
-qLE
-qLE
-qLE
+tMh
+tMh
+tMh
+tMh
 tgV
-rKJ
+hTB
 qpp
 exD
 xii
@@ -283329,16 +283331,16 @@ qKs
 eBq
 xqO
 xqO
-lJF
-rKJ
-deO
+wZC
+mze
+mze
 brI
-neg
-neg
-neg
-qLE
-els
-sAU
+uAL
+uAL
+brI
+mze
+mze
+dME
 exD
 cVe
 mPk
@@ -283782,14 +283784,14 @@ lgD
 xqO
 xqO
 acQ
-rKJ
-lrx
+mze
+iCf
 qLE
-neg
-hhl
-neg
 qLE
-els
+qLE
+qLE
+qLE
+mze
 sAU
 exD
 mfC
@@ -284234,13 +284236,13 @@ gpM
 xqO
 xqO
 fCK
-rKJ
+mze
 wtf
 qLE
-neg
-neg
-neg
 qLE
+neg
+neg
+neg
 els
 sAU
 exD
@@ -284686,14 +284688,14 @@ uzI
 xqO
 xqO
 bcv
-rKJ
-aRS
+mze
+tPw
 qLE
 qLE
-qLE
-qLE
-jOC
-rKJ
+neg
+rRs
+neg
+els
 nFZ
 exD
 lJF
@@ -285138,15 +285140,15 @@ xqO
 xqO
 xqO
 lJF
-rKJ
-rKJ
-rKJ
-tPw
-fWD
-qYa
-rKJ
-rKJ
-dME
+mze
+lrx
+qLE
+qLE
+neg
+neg
+neg
+els
+xqO
 exD
 deS
 exD
@@ -285590,15 +285592,15 @@ xhO
 xqO
 xqO
 lJF
-sns
+mze
+fWD
 qgd
-rKJ
-eAi
-rKJ
-rKJ
-rKJ
-fIQ
-pPw
+qLE
+qLE
+qgd
+deO
+mze
+xqO
 exD
 exD
 exD
@@ -286042,15 +286044,15 @@ xqO
 xqO
 xqO
 lJF
-sns
-sns
-rKJ
-tcl
-rKJ
-jiQ
-aZo
-jiQ
-pdm
+mze
+mze
+mze
+mze
+mze
+mze
+mze
+mze
+xqO
 exD
 exD
 exD
@@ -286493,16 +286495,16 @@ eVp
 eEA
 xqO
 xqO
-jPF
+lJF
 sns
-sns
-vAX
-exD
-lmn
-cZO
-cZO
-cZO
-xeQ
+xqO
+xqO
+xqO
+xqO
+xqO
+xqO
+xqO
+xqO
 exD
 exD
 exD
@@ -286946,12 +286948,12 @@ qnN
 loJ
 loJ
 qnN
+fOH
+fOH
+fOH
+fOH
 nqN
 sns
-sns
-sns
-sns
-nqN
 qok
 njB
 aFv
@@ -287402,7 +287404,7 @@ bge
 bge
 bge
 bge
-fOH
+uam
 fOH
 fOH
 pdZ
@@ -393167,14 +393169,14 @@ bGf
 bGf
 bGf
 kSK
-kSK
 rKJ
 rKJ
 rKJ
 rKJ
 rKJ
+ies
 rKJ
-kSK
+rKJ
 kSK
 bGf
 kSK
@@ -393620,12 +393622,12 @@ bGf
 bGf
 kSK
 rKJ
-rKJ
+iCf
 hWh
-tMh
-tMh
-uaE
 rKJ
+svr
+uaE
+sJg
 rKJ
 kSK
 bGf
@@ -394072,12 +394074,12 @@ bGf
 bGf
 kSK
 rKJ
-rKJ
-rKJ
+dWp
+qLE
 xOZ
-rZA
-dKZ
-bYk
+dxv
+dxv
+dxv
 rKJ
 kSK
 bGf
@@ -394524,13 +394526,13 @@ bGf
 bGf
 kSK
 rKJ
-tte
-tte
-ebo
-ies
+rKJ
+rKJ
+rKJ
+rKJ
 exE
-vDY
-dLK
+rKJ
+rKJ
 kSK
 bGf
 kSK
@@ -394978,11 +394980,11 @@ kSK
 rKJ
 qhv
 dxv
-vHt
-ies
+aVm
+dxv
 hTR
-qgG
-dLK
+dxv
+rKJ
 kSK
 bGf
 kSK
@@ -395427,14 +395429,14 @@ bGf
 bGf
 bGf
 kSK
-rUb
+oZZ
 dxv
 dxv
-tMh
-rZA
-cmD
-uam
-rKJ
+dxv
+dxv
+osq
+tgi
+dLK
 kSK
 bGf
 kSK
@@ -395881,11 +395883,11 @@ bGf
 kSK
 rKJ
 kbh
+yaI
 dxv
-ivK
-iyM
-uAL
-iyM
+dxv
+osq
+jJC
 rKJ
 kSK
 bGf
@@ -396332,13 +396334,13 @@ bGf
 bGf
 kSK
 rKJ
-euZ
-dxv
-uUH
+rKJ
+vHt
+tMh
+tMh
+iFA
 rKJ
 rKJ
-rKJ
-rNq
 kSK
 bGf
 kSK
@@ -396783,13 +396785,13 @@ bGf
 bGf
 bGf
 kSK
-rUb
-dxv
-dxv
+rKJ
+lAt
+tMh
 ivK
-iyM
-uAL
-iyM
+dKZ
+tMh
+jjv
 rKJ
 kSK
 bGf
@@ -397236,13 +397238,13 @@ bGf
 bGf
 kSK
 rKJ
-qhv
-dxv
+hwb
 tMh
 tea
-pRr
+tea
+tMh
 eYj
-rKJ
+dLK
 kSK
 bGf
 kSK
@@ -397688,11 +397690,11 @@ bGf
 bGf
 kSK
 rKJ
-tgi
-rKJ
+sKx
 tMh
+nnP
+hhl
 tMh
-yeu
 bOa
 dLK
 kSK
@@ -398137,14 +398139,14 @@ oCF
 kSK
 bGf
 bGf
-kSK
+bGf
 kSK
 rKJ
-jJC
-rKJ
+tCR
 tMh
+cmD
+cmD
 tMh
-yeu
 tCR
 rKJ
 kSK
@@ -398589,15 +398591,15 @@ kSK
 kSK
 bGf
 bGf
+bGf
 kSK
 rKJ
-rKJ
-rKJ
-rKJ
-xtQ
-rKJ
-tOh
-yeu
+bYk
+tMh
+tMh
+tMh
+tMh
+tMh
 rKJ
 kSK
 bGf
@@ -399041,16 +399043,16 @@ kSK
 bGf
 bGf
 bGf
+bGf
 kSK
 rKJ
-lAt
 xXW
 prx
-tMh
+prx
 rKJ
 xXj
-yeu
-dLK
+rKJ
+rKJ
 kSK
 bGf
 bGf
@@ -399493,14 +399495,14 @@ bGf
 bGf
 bGf
 bGf
+bGf
 kSK
-oZZ
-ruz
-tMh
-tMh
-yju
 rKJ
-ald
+jPF
+hun
+yju
+dxv
+dxv
 tik
 rKJ
 kSK
@@ -399945,15 +399947,15 @@ bGf
 bGf
 bGf
 bGf
+bGf
 kSK
 rKJ
-tMh
-rjK
-rjK
-rjK
-rKJ
+roi
+ckG
+yju
+jPl
 fed
-rKJ
+yeu
 rKJ
 kSK
 bGf
@@ -400397,16 +400399,16 @@ bGf
 bGf
 bGf
 bGf
+bGf
 kSK
 rKJ
-dSe
-jdB
-ocm
-umt
 rKJ
 rKJ
 rKJ
-kSK
+rKJ
+rKJ
+rKJ
+rKJ
 kSK
 bGf
 bGf
@@ -400849,13 +400851,13 @@ bGf
 jyZ
 bGf
 bGf
+bGf
 kSK
-rKJ
-hhO
-hTB
-lGl
-bqs
-rKJ
+kSK
+kSK
+kSK
+kSK
+kSK
 kSK
 kSK
 kSK
@@ -401301,13 +401303,13 @@ bGf
 bGf
 bGf
 bGf
+bGf
 kSK
-rKJ
-rKJ
-rKJ
-rKJ
-rKJ
-rKJ
+kSK
+kSK
+kSK
+kSK
+kSK
 kSK
 kSK
 kSK
@@ -401753,17 +401755,17 @@ bGf
 bGf
 bGf
 bGf
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -507072,13 +507074,13 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+tqj
+fYu
+fYu
+fYu
+fYu
+fYu
+iGn
 bGf
 bGf
 bGf
@@ -507524,13 +507526,13 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+gPs
+iUW
+aRS
+bow
+lmn
+iUW
+bsh
 bGf
 bGf
 bGf
@@ -507974,18 +507976,18 @@ bGf
 bGf
 bGf
 bGf
+kSK
+kSK
+mCk
+lGl
+npI
+npI
+npI
+lGl
+yaT
+kSK
+kSK
 bGf
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
 kSK
 kSK
 kSK
@@ -508426,18 +508428,18 @@ qfC
 bGf
 bGf
 bGf
+kSK
+rKJ
+rKJ
+rKJ
+bdw
+dSe
+bdw
+rKJ
+rKJ
+rKJ
+rKJ
 bGf
-kSK
-rKJ
-rKJ
-rKJ
-rKJ
-rKJ
-hwb
-rKJ
-hwb
-rKJ
-kSK
 kSK
 eUH
 rRl
@@ -508878,18 +508880,18 @@ cbr
 iGn
 bGf
 bGf
-bGf
 kSK
-rUb
+rKJ
+tte
 aVm
 dxv
-aVm
-rKJ
+dxv
+dxv
 wGH
-rZA
-jPl
+rjK
+rjK
 rKJ
-kSK
+bGf
 kSK
 ycO
 mPk
@@ -509330,18 +509332,18 @@ quq
 bsh
 bGf
 bGf
+kSK
+rKJ
+rNq
+dxv
+cZO
+ebo
+dxv
+jdB
+ocm
+umt
+rKJ
 bGf
-kSK
-rKJ
-tgi
-tgi
-yaI
-bdw
-tMh
-rZA
-npI
-rKJ
-kSK
 kSK
 ycO
 eZd
@@ -509782,18 +509784,18 @@ aOA
 bsh
 bGf
 bGf
-bGf
 kSK
 rKJ
-jJC
-jJC
-yaI
-rKJ
-sJg
+bqs
+hhO
+dxv
+dxv
+dxv
+fsb
 hKH
 tDn
 rKJ
-kSK
+bGf
 kSK
 ycO
 eZd
@@ -510234,18 +510236,18 @@ quq
 bsh
 bGf
 bGf
+kSK
+rKJ
+rKJ
+rKJ
+sfe
+rKJ
+dYF
+ePb
+fIQ
+rKJ
+rKJ
 bGf
-kSK
-rUb
-sfe
-sfe
-jjv
-rKJ
-rKJ
-rKJ
-rKJ
-rKJ
-kSK
 kSK
 ycO
 eZd
@@ -510686,18 +510688,18 @@ quq
 bsh
 bGf
 bGf
-bGf
 kSK
-rKJ
+kSK
+jMm
 uiu
-dxv
-bow
+euZ
 rKJ
 rKJ
+rKJ
+rKJ
+rKJ
 kSK
-kSK
-kSK
-kSK
+bGf
 kSK
 ycO
 mPk
@@ -511130,7 +511132,7 @@ lvw
 aZh
 puP
 mlQ
-mlQ
+grZ
 mlQ
 nsN
 ahe
@@ -511141,12 +511143,12 @@ bGf
 bGf
 kSK
 rKJ
+xfS
+yaI
 rKJ
-svr
-rKJ
-rKJ
-rKJ
-rKJ
+eAi
+vDY
+eAi
 rKJ
 kSK
 bGf
@@ -511594,12 +511596,12 @@ bGf
 kSK
 rKJ
 vke
-tMh
-sKx
-fsb
-xVm
-iSk
+yaI
 rKJ
+fsb
+ikR
+fsb
+rGx
 kSK
 bGf
 kSK
@@ -512044,9 +512046,9 @@ bGf
 bGf
 bGf
 kSK
-rKJ
-iUW
-tMh
+jMm
+dxv
+dxv
 hDH
 qXw
 qXw
@@ -512498,12 +512500,12 @@ bGf
 kSK
 rKJ
 vBJ
-tMh
-oRg
+oWi
+rKJ
+iSk
 qXw
-qXw
-qXw
-rGx
+xVm
+rKJ
 kSK
 bGf
 kSK
@@ -512943,18 +512945,18 @@ dtV
 dtV
 jXq
 bMm
-bGf
+eGS
 bGf
 bGf
 bGf
 kSK
 rKJ
-nnP
-tMh
-sKx
-iFA
+rKJ
+rKJ
+rKJ
+rKJ
 jRO
-iFA
+rKJ
 rKJ
 kSK
 bGf
@@ -513400,13 +513402,13 @@ bGf
 bGf
 bGf
 kSK
+kSK
+kSK
 rKJ
-rKJ
-roi
-rKJ
-rKJ
-rKJ
-rKJ
+xtQ
+jOC
+qLE
+dTu
 rKJ
 kSK
 bGf
@@ -513851,14 +513853,14 @@ bGf
 bGf
 bGf
 bGf
+bGf
+kSK
 kSK
 rKJ
-dTu
 qLE
-nUH
-sXL
-sXL
-noJ
+kgf
+kgf
+kgf
 rKJ
 kSK
 bGf
@@ -514303,15 +514305,15 @@ bGf
 bGf
 bGf
 bGf
+bGf
+kSK
 kSK
 rKJ
-ikR
-qLE
 xdg
-grZ
 sXL
 sXL
-xjI
+noJ
+rKJ
 kSK
 bGf
 kSK
@@ -514755,12 +514757,12 @@ bGf
 bGf
 bGf
 bGf
+bGf
 kSK
-rKJ
-dTu
-qLE
-ckG
-osq
+kSK
+rUb
+nUH
+sXL
 sXL
 sXL
 xjI
@@ -515207,15 +515209,15 @@ bGf
 bGf
 bGf
 bGf
+bGf
 kSK
-rKJ
-rKJ
-dWp
+kSK
+rUb
 nUH
 sXL
 sXL
-noJ
-rKJ
+sXL
+xjI
 kSK
 bGf
 kSK
@@ -515659,14 +515661,14 @@ bGf
 bGf
 bGf
 bGf
+bGf
 kSK
 kSK
 rKJ
-rKJ
-rKJ
-rKJ
-rKJ
-rKJ
+xdg
+sXL
+sXL
+noJ
 rKJ
 kSK
 bGf
@@ -516111,15 +516113,15 @@ bGf
 bGf
 bGf
 bGf
+bGf
 kSK
 kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
+rKJ
+rKJ
+rKJ
+rKJ
+rKJ
+rKJ
 kSK
 bGf
 bGf
@@ -516563,16 +516565,16 @@ bGf
 bGf
 bGf
 bGf
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
 bGf
 bGf
-bGf
-bGf
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf


### PR DESCRIPTION
## About The Pull Request

Updated the stewardry so it fits better with the surrounding buildings. Also gives them a pet because, why not?

Now it looks like this:

<details>

<img width="672" height="352" alt="image" src="https://github.com/user-attachments/assets/fd036d16-6370-4367-b2c0-79bdd2de2ac7" />
<img width="704" height="384" alt="image" src="https://github.com/user-attachments/assets/189a887e-cd0b-44b9-bd79-758183c0f2ac" />
<img width="736" height="416" alt="image" src="https://github.com/user-attachments/assets/9eba25d9-cda2-4040-a4f5-e17914aff6df" />

</details>

## Testing Evidence

<details>

<img width="676" height="719" alt="dreamseeker_rjCwLIFd0C" src="https://github.com/user-attachments/assets/ce957936-fc04-420b-9d54-33b5e3646bf5" />
<img width="598" height="746" alt="dreamseeker_iOn9zXdtyv" src="https://github.com/user-attachments/assets/c15dfe0a-aa3d-4243-b177-f811fba290de" />
<img width="644" height="505" alt="dreamseeker_60EmA9AHLp" src="https://github.com/user-attachments/assets/d096d140-8113-4678-8195-f7670a22b78a" />
<img width="393" height="690" alt="dreamseeker_YLNbLqPFEW" src="https://github.com/user-attachments/assets/a1e88696-598a-4961-a08f-3ccae698997d" />
<img width="890" height="589" alt="dreamseeker_cY6ZqkP7Om" src="https://github.com/user-attachments/assets/cb148144-acb9-4f91-a537-971ad895c7f8" />
<img width="1920" height="1080" alt="dreamseeker_GP5NoaLqgk" src="https://github.com/user-attachments/assets/f36c3c40-d9a2-44e0-8b77-7f7205afa281" />
<img width="613" height="649" alt="dreamseeker_uz46OxHb6S" src="https://github.com/user-attachments/assets/4168695f-aae2-47d8-af98-c762c4f2fc4e" />
<img width="521" height="582" alt="dreamseeker_10tyXwR9K5" src="https://github.com/user-attachments/assets/3e486b72-160d-472b-b9eb-f768c4319ec6" />

(images are missing cuttlery)

</details>

## Why It's Good For The Game

Should feel better to play in vs the old one.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
map: Updated stewardry building.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
