### PR TITLE
revs can be witches + witch pre_equip runtime fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/barbersurgeon.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/barbersurgeon.dm
@@ -2,6 +2,7 @@
 	name = "Barber Surgeon"
 	tutorial = "Wielding crude tools and accumulated knowledge, you are something of a 'freelance physician' even if the local apothecary declined your application, and over the yils have probably cut into more people than the average knight."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/doctor
 	category_tags = list(CTAG_PILGRIM, CTAG_TOWNER)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
@@ -3,6 +3,7 @@
 	tutorial = "A skilled blacksmith, able to forge capable weapons for warriors in the bog, \
 	only after building a forge for themselves of course"
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/blacksmith
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/cheesemaker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/cheesemaker.dm
@@ -4,6 +4,7 @@
 	As very skilled cook you come with some ingredients to make food and feed the masses. \
 	cook up some cuisine with food gathered from the local flora and fauna"
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/cheesemaker
 	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/drunkard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/drunkard.dm
@@ -2,6 +2,7 @@
 	name = "Gambler"
 	tutorial = "You are a gambler. Everyone in your life has given up on you, and the stress of losing it all over and over has taken its toll on your body. All you have left to your name are some cards, dice and whatever is in this bottle. At least you're still in Baotha's good graces, whether you reciprocate such feelings or not..."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/drunkard
 	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
@@ -2,6 +2,7 @@
 	name = "Fisher"
 	tutorial = "You are a fisherman, with your bag of bait and your fishing rod, you are one of few who can reliably get a stable source of meat around here"
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/fisher
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
@@ -2,6 +2,7 @@
 	name = "Homesteader"
 	tutorial = "Azure population's tendency to take up arms and become unwashed beastslayers had forced you to take up jobs, small and large of most professions.\n A jack of all trades, what will you be known as this week?"
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/homesteader
 	traits_applied = list(TRAIT_JACKOFALLTRADES,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
@@ -2,6 +2,7 @@
 	name = "Bow-Hunter"
 	tutorial = "You are a hunter. With your bow you hunt the fauna of the glade, skinning what you kill and cooking any meat left over. The job is dangerous but important in the circulation of clothing and light armor."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/hunter
 	traits_applied = list(TRAIT_OUTDOORSMAN, TRAIT_SURVIVAL_EXPERT, TRAIT_MASTERFUL_HUNTER)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
@@ -2,6 +2,7 @@
 	name = "Levy"
 	tutorial = "When the bailiff came to your household it was the worst dae of your lyfe, dragging you away into service to the Crown with nothing more but whatever household object you managed to piece together into a weapon. Safeguard your home from the terrors beyond the walls and those lurking in the bog."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/levy
 	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -3,6 +3,7 @@
 	tutorial = "Swing the pick. Heave. Swing. Heave. Deep underground where the days lose their meaning, the work is grueling, the tunnels cramped, and the stale air full of coal dust, yet tales abound of the lucky few who persevered, and found enough precious gems to set them for life."
 
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/miner
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/minstrel.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/minstrel.dm
@@ -2,6 +2,7 @@
 	name = "Minstrel"
 	tutorial = "Unlike those so-called 'bards' who traipse around in fancy cloth and swordfight in the woods, you follow the calling of a true musician. You've simply... yet to find a receptive audience."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/minstrel
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/peasant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/peasant.dm
@@ -3,6 +3,7 @@
 	tutorial = "As a Peasant, you are a skilled farmer, able to grow a variety of crops \
 	Join the local Soilsmen at their farm, or make your own little orchard."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/peasant
 	cmode_music = 'sound/music/cmode/towner/combat_towner2.ogg'

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/potter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/potter.dm
@@ -3,6 +3,7 @@
 	tutorial = "You are a skilled artisan in the manipulation of ceramics, \
 	and their fashioning into a multitude of different objects and valuables, including glass."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/potter
 	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lchef.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lchef.dm
@@ -6,6 +6,7 @@
 	With noble origins, you were taught by cooking masters in the secretive League of Fine Dining in exotic meals from all around the world \
 	Now you wander, free to experiment, cook exotic dishes and gourmet meals, worthy for a king"
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/masterchef
 	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lfish.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lfish.dm
@@ -4,6 +4,7 @@
 	name = "Master Fisher"
 	tutorial = "You are a Master Fisher, you cast your rod with might, and are able to pull fish larger than Eoras Bosom."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/fishermaster
 	traits_applied = list(TRAIT_CAUTIOUS_FISHER, TRAIT_HOMESTEAD_EXPERT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
@@ -4,6 +4,7 @@
 	name = "Master Miner"
 	tutorial = "A master miner, you are capable of cutting stone like butter, and forging rocks into anything you can think of"
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/minermaster
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lpeasant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lpeasant.dm
@@ -4,6 +4,7 @@
 	You, a simple peasent, through sheer determination have conquered nature \
 	and made it bow before your green thumb."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/farmermaster
 	traits_applied = list(TRAIT_HOMESTEAD_EXPERT, TRAIT_SEEDKNOW)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lsmith.dm
@@ -5,6 +5,7 @@
 	tutorial = "A master blacksmith, able to forge steel like dough, and gold like clay. \
 	create masterful weapons and armor, be a legend among those who interest in your mighty forge"
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/masterblacksmith
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/seamstress.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/seamstress.dm
@@ -2,6 +2,7 @@
 	name = "Seamster"
 	tutorial = "You know your trade by the passage of a needle through cloth and leather alike. Mend and sew garments for the townsfolk - Coats, pants, hats, hoods, and so much more. So what if you overcharge? You're the reason everyone looks good in the first place."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/seamstress
 	traits_applied = list(TRAIT_SEWING_EXPERT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -40,10 +40,10 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 
 	var/classes = list("Old Magick", "Godsblood", "Mystagogue")
-	var/classchoice = input("How do your powers manifest?", "THE OLD WAYS") as anything in classes
+	var/classchoice = input(H, "How do your powers manifest?", "THE OLD WAYS") as anything in classes
 
 	var/shapeshifts = list("Zad", "Cat", "Cat (Black)", "Bat", "Lesser Volf", "Cabbit", "Small Rous", "Lesser Venard")
-	var/shapeshiftchoice = input("What form does your second skin take?", "THE OLD WAYS") as anything in shapeshifts
+	var/shapeshiftchoice = input(H, "What form does your second skin take?", "THE OLD WAYS") as anything in shapeshifts
 
 	switch (classchoice)
 		if("Old Magick")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodworker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodworker.dm
@@ -3,6 +3,7 @@
 	tutorial = "You are a strong Woodworker, armed with an axe, you can gather wood \
 	either for yourself, or for others. You are an expert carpenter too, so you can bend wood into items you need."
 	allowed_sexes = list(MALE, FEMALE)
+	forbidden_races = list(RACES_DESPISED)
 	
 	outfit = /datum/outfit/job/roguetown/adventurer/woodworker
 	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 75
 	spawn_positions = 75
-	forbidden_races = list(RACES_DESPISED)
+	// forbidden_races = list(RACES_DESPISED)
 	tutorial = "You've lived in this shithole for effectively all your life. You are not an explorer, nor exactly a warrior in many cases. You're just some average poor bastard who thinks they'll be something someday. Respect the nobles and yeomen alike for they are your superiors - should you find yourself in trouble your Elder is your best hope."
 	advclass_cat_rolls = list(CTAG_TOWNER = 20)
 	outfit = null


### PR DESCRIPTION
## About The Pull Request
Allows revenants to be witch towners specifically. They still can't be any other type of towner, but the number of roles they can play has gone from 'town crier (almost certainly an oversight), vagabond and lunatic, adv/cagent/trader/merc, and antag roles' to 'that and also witch'. Not exactly swimming in choices here.

Also fixes a runtime with witch pre_equip implicitly calling input on src (may not have a client) instead of H (which does), if this gets denied it'll atomize the runtime fix into another PR

## Testing Evidence
<img width="359" height="96" alt="2026-06-17_00-04" src="https://github.com/user-attachments/assets/c44fc6cb-24e0-4d70-b687-68f5a96fa525" />

## Why It's Good For The Game
the runtime fix is a no-brainer. the controversial thing here is the rev role expansion

The logic is as follows.
- Witch is the dedicated 'town outcast' role. You are, explicitly, supposed to be ostracised and treated with suspicion, possibly accused of heresy, etc. So it fits revs' role as eternal outcasts perfectly
- The idea that a rev could not hide their nature enough to live on the outskirts like that is laughable when they pass silver tests (they don't have silverweak!), meanwhile you can take rotcured, pallid, hollow, etc as Literal Royalty and be mechanically far more undead (rotcured gets WAY more undead perks than revs do) and fail a silver test (silverweak). Unless you take off your head in front of people, there's... not really a way to tell you apart from people with one of those virtues?
- If you don't want to play a Psydonite or a wretch, your options for playing a revenant are basically nonexistent. It's adv or merc, p much. And that sucks if you want to engage in any long-term roleplay as a rev character, because you just kind of don't get to... stick around in town and build relationships if the expectation is that you're going to wander. Advs and mercs _can_ roleplay and have story arcs, but it's a lot harder because they're so isolated from everything but PvE in terms of their mechanics.
- If it is easier for me to play my revived-through-unholy-means character as rotcured and get more mechanical benefits and be able to play burgher and noble roles than to play a rev living on the outskirts then I. Don't know what we're doing here anymore. Am I crazy? I don't think that's a crazy take.
- Just to pre-empt it, this should not be a 'slippery slope'. This is not allowing revs to be towners unequivocally (though they already could with pilgrim, apparently. And town crier), this is allowing the dedicated outcast race to fit in the dedicated outcast role. If people don't treat the latter with the weight it deserves, that's a player issue, and not a reason to lock people out of the combination in code. 

## Changelog

:cl:
add: Allows revenants to be witches (and only witches, no other towners)
/:cl:
