### PR TITLE
[TM FIRST] Economy / Commissioner / Parchment Theme Optimizations

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -593,7 +593,7 @@
 		var/list/nearby = block(get_step(user, SOUTHWEST), get_step(user, NORTHEAST))
 		for(var/turf/T as anything in nearby)
 			if(T.Adjacent(user))
-				quick_hash += T.contents.len
+				quick_hash += "[T.contents.len]"
 
 	if(quick_hash == last_surroundings_hash && cached_craftability)
 		data["craftability"] = cached_craftability

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -577,14 +577,30 @@
 	data["busy"] = busy
 	data["showonlycraftable"] = showonlycraftable
 
-	var/list/surroundings = get_surroundings(user)
-	var/new_hash = list2params(surroundings["other"])
+	// Cheap structural pre-check: loc + held items (by ref) + pocket slots + adjacent tile counts.
+	// Skips get_surroundings() entirely on cache hit. False negatives (same count, swapped items)
+	// extend staleness by one tick — acceptable given ui_data already runs on a 2s cycle.
+	var/quick_hash = REF(user.loc)
+	for(var/obj/item/I in user.held_items)
+		quick_hash += REF(I)
+	var/lstore = user.get_item_by_slot(SLOT_L_STORE)
+	var/rstore = user.get_item_by_slot(SLOT_R_STORE)
+	if(lstore)
+		quick_hash += REF(lstore)
+	if(rstore)
+		quick_hash += REF(rstore)
+	if(isturf(user.loc))
+		var/list/nearby = block(get_step(user, SOUTHWEST), get_step(user, NORTHEAST))
+		for(var/turf/T as anything in nearby)
+			if(T.Adjacent(user))
+				quick_hash += T.contents.len
 
-	if(new_hash == last_surroundings_hash && cached_craftability)
+	if(quick_hash == last_surroundings_hash && cached_craftability)
 		data["craftability"] = cached_craftability
 		return data
 
-	last_surroundings_hash = new_hash
+	last_surroundings_hash = quick_hash
+	var/list/surroundings = get_surroundings(user)
 	var/list/craftability = list()
 	for(var/rec in GLOB.crafting_recipes)
 		var/datum/crafting_recipe/R = rec
@@ -593,7 +609,6 @@
 			continue
 		if(R.required_tech_node && !R.tech_unlocked)
 			continue
-
 		craftability[R.name] = check_contents(R, surroundings)
 
 	cached_craftability = craftability

--- a/code/modules/client/preferences_tgui.dm
+++ b/code/modules/client/preferences_tgui.dm
@@ -17,6 +17,7 @@
 		"vellum" = "Vellum",
 		"parchment" = "Parchment",
 		"leatherbound" = "Leatherbound",
+		"disabled" = "Disabled (Compatibility)",
 	)
 	return skins
 

--- a/code/modules/roguetown/roguemachine/escrow.dm
+++ b/code/modules/roguetown/roguemachine/escrow.dm
@@ -13,6 +13,11 @@
 	var/list/cached_required_counts
 	var/list/cached_lines
 	var/list/cached_materials
+	// Pre-baked fulfillment template: list of list("path", "name", "want") — static after posting.
+	// Built alongside cached_lines in build_order_cache(). Lets ui_data() skip initial(A.name)
+	// and required_result_counts() every tick; only the live delivered_counts lookup remains.
+	var/list/cached_fulfillment_template
+	var/cached_needed_count = 0
 
 /datum/escrow_order/proc/label()
 	var/list/parts = list()
@@ -158,6 +163,7 @@
 		ITEM_CAT_ENG_MISC,
 	)
 	var/list/group_order = list("Armor", "Weapons", "Tools", "Valuables", "Decoration", "Engineering", "Other")
+	var/last_prune_day = -1
 
 /obj/structure/roguemachine/escrow/Initialize()
 	. = ..()
@@ -553,6 +559,9 @@
 	update_icon()
 
 /obj/structure/roguemachine/escrow/proc/prune_expired_orders()
+	if(last_prune_day == GLOB.dayspassed)
+		return
+	last_prune_day = GLOB.dayspassed
 	var/turf/T = get_turf(src)
 	for(var/datum/escrow_order/O in orders.Copy())
 		if(O.status == "open" && GLOB.dayspassed - O.day_posted >= ESCROW_OPEN_EXPIRY_DAYS)
@@ -618,6 +627,19 @@
 	O.cached_lines = order_lines
 	O.cached_materials = order_materials
 
+	// Pre-bake the static parts of the fulfillment display (item name + want count).
+	// ui_data() only needs to fill in the live delivered_counts value per tick.
+	var/list/needed = O.required_result_counts()
+	var/list/tmpl = list()
+	var/total_needed = 0
+	for(var/path in needed)
+		var/want = needed[path]
+		var/atom/A = path
+		tmpl += list(list("path" = path, "name" = initial(A.name), "want" = want))
+		total_needed += want
+	O.cached_fulfillment_template = tmpl
+	O.cached_needed_count = total_needed
+
 /obj/structure/roguemachine/escrow/ui_data(mob/user)
 	prune_expired_orders()
 	var/list/data = list()
@@ -653,20 +675,16 @@
 	for(var/datum/escrow_order/O in orders)
 		if(isnull(O.cached_lines))
 			build_order_cache(O)
-		var/list/needed = O.required_result_counts()
 		var/list/fulfillment = list()
 		var/done_count = 0
-		var/needed_count = 0
-		for(var/path in needed)
-			var/want = needed[path]
-			var/have = O.delivered_counts[path] || 0
-			done_count += min(have, want)
-			needed_count += want
-			var/atom/A = path
+		var/needed_count = O.cached_needed_count
+		for(var/list/tmpl in O.cached_fulfillment_template)
+			var/have = O.delivered_counts[tmpl["path"]] || 0
+			done_count += min(have, tmpl["want"])
 			fulfillment += list(list(
-				"name" = initial(A.name),
+				"name" = tmpl["name"],
 				"have" = have,
-				"want" = want,
+				"want" = tmpl["want"],
 			))
 		var/days_left = 0
 		var/expiry_label = ""

--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -40,6 +40,7 @@
 	var/list/cached_petition_eligibility = null
 	var/petition_eligibility_dirty = TRUE
 	var/last_petition_day = -1
+	var/last_pledge_balance = -1
 
 /obj/structure/roguemachine/steward/Initialize()
 	. = ..()

--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -33,6 +33,13 @@
 	// the per-tick Market Scroll payload.
 	var/list/ledger_view = list()
 	COOLDOWN_DECLARE(fulfill_retry_cooldown)
+	// Cached petition eligibility map (category_id → region_id → blocker string).
+	// Rebuilt only when dirty; avoids rerunning the categories×regions×templates triple-loop
+	// every ui_data tick. Invalidated by fulfill_order, petition_for_order, market rebuilds
+	// (which catch blockade flips), and day rollover.
+	var/list/cached_petition_eligibility = null
+	var/petition_eligibility_dirty = TRUE
+	var/last_petition_day = -1
 
 /obj/structure/roguemachine/steward/Initialize()
 	. = ..()

--- a/code/modules/roguetown/roguemachine/steward/steward_trade_tgui.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward_trade_tgui.dm
@@ -273,11 +273,12 @@
 
 	var/list/petition_state = list()
 	var/petitions_remaining = SSeconomy.petitions_remaining_today()
-	petition_state["pledge_balance"] = SStreasury.burgher_pledge_fund?.balance || 0
+	var/current_pledge_balance = SStreasury.burgher_pledge_fund?.balance || 0
+	petition_state["pledge_balance"] = current_pledge_balance
 	petition_state["petitions_remaining"] = petitions_remaining
 	petition_state["is_steward_role"] = (user.job in GLOB.crown_authority_roles) ? TRUE : FALSE
 	petition_state["is_alderman_acting"] = SScity_assembly?.is_alderman(user) ? TRUE : FALSE
-	if(last_petition_day != GLOB.dayspassed)
+	if(last_petition_day != GLOB.dayspassed || current_pledge_balance != last_pledge_balance)
 		petition_eligibility_dirty = TRUE
 	if(petition_eligibility_dirty || isnull(cached_petition_eligibility))
 		rebuild_petition_eligibility()
@@ -450,6 +451,7 @@
 	cached_petition_eligibility = eligibility
 	petition_eligibility_dirty = FALSE
 	last_petition_day = GLOB.dayspassed
+	last_pledge_balance = SStreasury.burgher_pledge_fund?.balance || 0
 
 /obj/structure/roguemachine/steward/proc/build_market_import_regions(good_id)
 	var/list/out = list()

--- a/code/modules/roguetown/roguemachine/steward/steward_trade_tgui.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward_trade_tgui.dm
@@ -403,7 +403,13 @@
 	var/pledge_balance = SStreasury.burgher_pledge_fund?.balance || 0
 	var/pledge_missing = !SStreasury.burgher_pledge_fund
 	var/list/orders_by_region = list()
+	var/list/seen_pair_keys = list()
 	for(var/datum/standing_order/O as anything in GLOB.standing_order_pool)
+		if(O.pair_id)
+			var/pair_key = "[O.region_id]|[O.pair_id]"
+			if(seen_pair_keys[pair_key])
+				continue
+			seen_pair_keys[pair_key] = TRUE
 		orders_by_region[O.region_id] = (orders_by_region[O.region_id] || 0) + 1
 	var/list/eligibility = list()
 	for(var/cat_id in GLOB.petition_categories)

--- a/code/modules/roguetown/roguemachine/steward/steward_trade_tgui.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward_trade_tgui.dm
@@ -277,49 +277,11 @@
 	petition_state["petitions_remaining"] = petitions_remaining
 	petition_state["is_steward_role"] = (user.job in GLOB.crown_authority_roles) ? TRUE : FALSE
 	petition_state["is_alderman_acting"] = SScity_assembly?.is_alderman(user) ? TRUE : FALSE
-	var/list/eligibility = list()
-	var/pool_full = (GLOB.standing_order_pool.len >= STANDING_ORDERS_POOL_CAP)
-	var/pledge_balance = SStreasury.burgher_pledge_fund?.balance || 0
-	var/pledge_missing = !SStreasury.burgher_pledge_fund
-	var/list/orders_by_region = list()
-	for(var/datum/standing_order/O as anything in GLOB.standing_order_pool)
-		orders_by_region[O.region_id] = (orders_by_region[O.region_id] || 0) + 1
-	for(var/cat_id in GLOB.petition_categories)
-		var/list/cat = GLOB.petition_categories[cat_id]
-		var/cost = cat["cost"]
-		var/list/templates = cat["templates"]
-		var/list/per_region = list()
-		eligibility[cat_id] = per_region
-		for(var/region_id in GLOB.economic_regions)
-			var/datum/economic_region/region = GLOB.economic_regions[region_id]
-			var/blocker = ""
-			if(petitions_remaining <= 0)
-				blocker = "the trade hall has already heard a petition today"
-			else if(!region)
-				blocker = "unknown region"
-			else if(region.is_region_blockaded)
-				blocker = "[region.name] is blockaded - the road is closed to envoys"
-			else if(region.day_last_cleared >= 0 && (GLOB.dayspassed - region.day_last_cleared) < PETITION_BLOCKADE_RECOVERY_DAYS)
-				var/wait_days = PETITION_BLOCKADE_RECOVERY_DAYS - (GLOB.dayspassed - region.day_last_cleared)
-				blocker = "[region.name]'s contacts are still scattered - wait [wait_days]d more"
-			else if(pool_full)
-				blocker = "the warehouse manifest is full - fulfill orders first"
-			else if((orders_by_region[region_id] || 0) >= STANDING_ORDERS_MAX_PER_REGION)
-				blocker = "[region.name] already has [orders_by_region[region_id]] active orders"
-			else if(pledge_missing)
-				blocker = "the Burgher Pledge is not yet established"
-			else if(pledge_balance < cost)
-				blocker = "the Burgher Pledge cannot cover [cost]m"
-			else
-				var/has_template = FALSE
-				for(var/template_path in templates)
-					if(template_path in region.possible_standing_order_types)
-						has_template = TRUE
-						break
-				if(!has_template)
-					blocker = "[region.name]'s trade hall does not deal in [cat["label"]]"
-			per_region[region_id] = blocker
-	petition_state["eligibility"] = eligibility
+	if(last_petition_day != GLOB.dayspassed)
+		petition_eligibility_dirty = TRUE
+	if(petition_eligibility_dirty || isnull(cached_petition_eligibility))
+		rebuild_petition_eligibility()
+	petition_state["eligibility"] = cached_petition_eligibility
 	data["petition"] = petition_state
 
 	data["sequestration"] = list(
@@ -431,6 +393,57 @@
 	SStreasury.cached_region_rows = region_rows
 	SStreasury.cached_total_arbitrage_potential = total_arbitrage_potential
 	SStreasury.market_view_dirty = FALSE
+	// Blockade flips, economic events, and day resets all reach us through dirty_market_view().
+	// Any of those can change eligibility blockers, so invalidate the petition cache here.
+	petition_eligibility_dirty = TRUE
+
+/obj/structure/roguemachine/steward/proc/rebuild_petition_eligibility()
+	var/petitions_remaining = SSeconomy.petitions_remaining_today()
+	var/pool_full = (GLOB.standing_order_pool.len >= STANDING_ORDERS_POOL_CAP)
+	var/pledge_balance = SStreasury.burgher_pledge_fund?.balance || 0
+	var/pledge_missing = !SStreasury.burgher_pledge_fund
+	var/list/orders_by_region = list()
+	for(var/datum/standing_order/O as anything in GLOB.standing_order_pool)
+		orders_by_region[O.region_id] = (orders_by_region[O.region_id] || 0) + 1
+	var/list/eligibility = list()
+	for(var/cat_id in GLOB.petition_categories)
+		var/list/cat = GLOB.petition_categories[cat_id]
+		var/cost = cat["cost"]
+		var/list/templates = cat["templates"]
+		var/list/per_region = list()
+		eligibility[cat_id] = per_region
+		for(var/region_id in GLOB.economic_regions)
+			var/datum/economic_region/region = GLOB.economic_regions[region_id]
+			var/blocker = ""
+			if(petitions_remaining <= 0)
+				blocker = "the trade hall has already heard a petition today"
+			else if(!region)
+				blocker = "unknown region"
+			else if(region.is_region_blockaded)
+				blocker = "[region.name] is blockaded - the road is closed to envoys"
+			else if(region.day_last_cleared >= 0 && (GLOB.dayspassed - region.day_last_cleared) < PETITION_BLOCKADE_RECOVERY_DAYS)
+				var/wait_days = PETITION_BLOCKADE_RECOVERY_DAYS - (GLOB.dayspassed - region.day_last_cleared)
+				blocker = "[region.name]'s contacts are still scattered - wait [wait_days]d more"
+			else if(pool_full)
+				blocker = "the warehouse manifest is full - fulfill orders first"
+			else if((orders_by_region[region_id] || 0) >= STANDING_ORDERS_MAX_PER_REGION)
+				blocker = "[region.name] already has [orders_by_region[region_id]] active orders"
+			else if(pledge_missing)
+				blocker = "the Burgher Pledge is not yet established"
+			else if(pledge_balance < cost)
+				blocker = "the Burgher Pledge cannot cover [cost]m"
+			else
+				var/has_template = FALSE
+				for(var/template_path in templates)
+					if(template_path in region.possible_standing_order_types)
+						has_template = TRUE
+						break
+				if(!has_template)
+					blocker = "[region.name]'s trade hall does not deal in [cat["label"]]"
+			per_region[region_id] = blocker
+	cached_petition_eligibility = eligibility
+	petition_eligibility_dirty = FALSE
+	last_petition_day = GLOB.dayspassed
 
 /obj/structure/roguemachine/steward/proc/build_market_import_regions(good_id)
 	var/list/out = list()
@@ -977,6 +990,7 @@ GLOBAL_LIST_INIT(steward_trade_sequestration_locked_actions, list(
 				var/datum/economic_region/region = GLOB.economic_regions[region_id]
 				playsound(src, 'sound/items/inqslip_sealed.ogg', 70, FALSE, -1)
 				visible_message(span_notice("[src] stamps a freshly sealed writ. The wax bears the mark of the [region?.name] trade hall."))
+			petition_eligibility_dirty = TRUE
 			SStgui.update_uis(src)
 			return TRUE
 		if("take_atc_loan")

--- a/tgui/packages/tgui/interfaces/MiaCraft.tsx
+++ b/tgui/packages/tgui/interfaces/MiaCraft.tsx
@@ -266,7 +266,7 @@ const CraftingCategory = (props: {
 
 export const MiaCraft = () => {
   const { act, data } = useBackend<Data>();
-  const craftability: Craftability = Object.entries(data.craftability);
+  const craftability: Craftability = Object.entries(data.craftability ?? {});
   const onlyCraftable = !!data.showonlycraftable;
   const [searchText, setSearchText] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);

--- a/tgui/packages/tgui/interfaces/common/parchment.tsx
+++ b/tgui/packages/tgui/interfaces/common/parchment.tsx
@@ -41,6 +41,7 @@ export const titleStyle: CSSProperties = {
   fontFamily: TITLE_FONT,
   color: TITLE,
   margin: '0 0 4px 0',
+  fontSynthesis: 'none',
 };
 
 export const subtitleStyle: CSSProperties = {
@@ -75,17 +76,32 @@ export const tabBarStyle: CSSProperties = {
   margin: '10px 0 6px 0',
 };
 
-export const tabStyle = (active: boolean): CSSProperties => ({
+const _tabBase: CSSProperties = {
   fontFamily: SERIF,
   fontSize: FONT_BODY,
   padding: '4px 18px',
-  color: active ? INK : INK_FAINT,
-  background: active ? 'var(--p-tab-active-bg)' : 'transparent',
-  border: `1px solid ${active ? INK_SOFT : 'transparent'}`,
   borderRadius: '2px',
   cursor: 'pointer',
-  fontWeight: active ? 'bold' : 'normal',
-});
+};
+
+const tabStyleActive: CSSProperties = {
+  ..._tabBase,
+  color: INK,
+  background: 'var(--p-tab-active-bg)',
+  border: `1px solid ${INK_SOFT}`,
+  fontWeight: 'bold',
+};
+
+const tabStyleInactive: CSSProperties = {
+  ..._tabBase,
+  color: INK_FAINT,
+  background: 'transparent',
+  border: '1px solid transparent',
+  fontWeight: 'normal',
+};
+
+export const tabStyle = (active: boolean): CSSProperties =>
+  active ? tabStyleActive : tabStyleInactive;
 
 export const subTabBarStyle: CSSProperties = {
   display: 'flex',
@@ -95,39 +111,68 @@ export const subTabBarStyle: CSSProperties = {
   margin: '6px 0',
 };
 
-export const subTabStyle = (active: boolean): CSSProperties => ({
+const _subTabBase: CSSProperties = {
   fontFamily: SERIF,
   fontSize: FONT_BODY,
   padding: '3px 10px',
-  color: active ? INK : INK_FAINT,
-  background: active ? 'var(--p-tab-active-bg)' : 'transparent',
-  border: `1px solid ${active ? INK_SOFT : INK_FAINT}`,
   borderRadius: '2px',
   cursor: 'pointer',
-  fontWeight: active ? 'bold' : 'normal',
   whiteSpace: 'nowrap',
-});
+};
 
-/// Wiki-style table-of-contents link. Renders as plain text with a dashed separator
-/// between rows, a subtle background tint when selected, and a hover underline.
-/// Apply via `style={tocLinkStyle(active)} className="toc-link"` on a button or anchor.
-/// Hover style lives in parchment.scss (and variants) keyed off the .toc-link class.
-export const tocLinkStyle = (active: boolean): CSSProperties => ({
+const subTabStyleActive: CSSProperties = {
+  ..._subTabBase,
+  color: INK,
+  background: 'var(--p-tab-active-bg)',
+  border: `1px solid ${INK_SOFT}`,
+  fontWeight: 'bold',
+};
+
+const subTabStyleInactive: CSSProperties = {
+  ..._subTabBase,
+  color: INK_FAINT,
+  background: 'transparent',
+  border: `1px solid ${INK_FAINT}`,
+  fontWeight: 'normal',
+};
+
+export const subTabStyle = (active: boolean): CSSProperties =>
+  active ? subTabStyleActive : subTabStyleInactive;
+
+const _tocLinkBase: CSSProperties = {
   display: 'block',
   width: '100%',
   textAlign: 'left',
-  background: active ? 'var(--p-tab-active-bg)' : 'transparent',
   border: 'none',
   borderBottom: `1px dashed ${INK_FAINT}`,
   padding: '4px 8px',
   fontFamily: SERIF,
   fontSize: FONT_TITLE,
-  color: active ? INK : INK_SOFT,
-  fontWeight: active ? 'bold' : 'normal',
   cursor: 'pointer',
   whiteSpace: 'normal',
   lineHeight: 1.3,
-});
+};
+
+const tocLinkStyleActive: CSSProperties = {
+  ..._tocLinkBase,
+  background: 'var(--p-tab-active-bg)',
+  color: INK,
+  fontWeight: 'bold',
+};
+
+const tocLinkStyleInactive: CSSProperties = {
+  ..._tocLinkBase,
+  background: 'transparent',
+  color: INK_SOFT,
+  fontWeight: 'normal',
+};
+
+/// Wiki-style table-of-contents link. Renders as plain text with a dashed separator
+/// between rows, a subtle background tint when selected, and a hover underline.
+/// Apply via `style={tocLinkStyle(active)} className="toc-link"` on a button or anchor.
+/// Hover style lives in parchment.scss (and variants) keyed off the .toc-link class.
+export const tocLinkStyle = (active: boolean): CSSProperties =>
+  active ? tocLinkStyleActive : tocLinkStyleInactive;
 
 export const cardStyle: CSSProperties = {
   background: 'var(--p-card-bg)',
@@ -166,10 +211,25 @@ export const badgeStyle = (color: string): CSSProperties => ({
   verticalAlign: 'middle',
 });
 
+const inkButtonStyleDefault: CSSProperties = {
+  fontFamily: SERIF,
+  fontSize: FONT_BODY,
+  fontWeight: 'bold',
+  padding: '2px 10px',
+  color: INK,
+  background: BUTTON_BG,
+  border: `1px solid ${INK}`,
+  borderRadius: '2px',
+  cursor: 'pointer',
+  opacity: 1,
+  transition: 'background-color 80ms linear',
+};
+
 export const inkButtonStyle = (opts: {
   color?: string;
   disabled?: boolean;
 } = {}): CSSProperties => {
+  if (!opts.color && !opts.disabled) return inkButtonStyleDefault;
   const col = opts.color || INK;
   return {
     fontFamily: SERIF,
@@ -249,14 +309,23 @@ export const ellipsisCellStyle: CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
+const compactButtonStyleDefault: CSSProperties = {
+  ...inkButtonStyleDefault,
+  padding: '1px 7px',
+  fontSize: FONT_LEAD,
+};
+
 export const compactButtonStyle = (opts: {
   color?: string;
   disabled?: boolean;
-} = {}): CSSProperties => ({
-  ...inkButtonStyle(opts),
-  padding: '1px 7px',
-  fontSize: FONT_LEAD,
-});
+} = {}): CSSProperties => {
+  if (!opts.color && !opts.disabled) return compactButtonStyleDefault;
+  return {
+    ...inkButtonStyle(opts),
+    padding: '1px 7px',
+    fontSize: FONT_LEAD,
+  };
+};
 
 export const PriceTag = (props: {
   price: number;

--- a/tgui/packages/tgui/layouts/Layout.tsx
+++ b/tgui/packages/tgui/layouts/Layout.tsx
@@ -22,6 +22,7 @@ type Props = Partial<{
 const PARCHMENT_VARIANTS: Record<string, (cfg: any) => string> = {
   parchment: (cfg) => {
     const skin = cfg?.window?.parchment_skin;
+    if (skin === 'disabled') return cfg?.window?.theme ?? 'azure_default';
     if (skin === 'leatherbound') return 'parchment-leatherbound';
     if (skin === 'vellum') return 'parchment-vellum';
     return 'parchment';

--- a/tgui/packages/tgui/styles/themes/_azure_base.scss
+++ b/tgui/packages/tgui/styles/themes/_azure_base.scss
@@ -31,6 +31,7 @@
 @font-face {
   font-family: 'Pterra';
   src: url('~roguefont/pterra.ttf');
+  font-display: swap;
 }
 
 @font-face {
@@ -38,6 +39,7 @@
   src: url('~roguefont/lora-regular.ttf');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -45,6 +47,7 @@
   src: url('~roguefont/lora-italic.ttf');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -52,6 +55,7 @@
   src: url('~roguefont/lora-medium.ttf');
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -59,11 +63,15 @@
   src: url('~roguefont/lora-bold.ttf');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
   font-family: 'MedievalSharp';
   src: url('~roguefont/medievalsharp.ttf');
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
 }
 
 @mixin azure-theme($colors, $topbar-svg) {

--- a/tgui/packages/tgui/styles/themes/_azure_base.scss
+++ b/tgui/packages/tgui/styles/themes/_azure_base.scss
@@ -106,6 +106,38 @@
   --button-border-radius: 3px;
   --button-background: #{map.get($colors, 'border')};
   --button-background-default: #{map.get($colors, 'border')};
+
+  // ── Parchment fallbacks (used when parchment-themed interfaces render under a standard theme) ──
+  --p-font-tiny:   10px;
+  --p-font-small:  11px;
+  --p-font-body:   13px;
+  --p-font-lead:   13px;
+  --p-font-title:  14px;
+  --p-font-head:   15px;
+
+  --p-ink:         var(--color-text);
+  --p-ink-soft:    var(--color-label);
+  --p-ink-faint:   var(--color-label);
+  --p-bg:          var(--color-base);
+  --p-bg-deep:     var(--color-base-end);
+  --p-bg-shadow:   var(--color-border);
+  --p-title:       var(--section-title-color);
+  --p-title-font:  var(--font-family);
+
+  --p-button-bg:      var(--button-background);
+  --p-tab-active-bg:  var(--button-background-selected);
+  --p-card-bg:        var(--color-section);
+  --p-card-shadow:    rgba(0, 0, 0, 0.20);
+  --p-badge-text:     var(--color-text);
+
+  --p-banner-bg:      rgba(139, 32, 32, 0.18);
+  --p-banner-bg-soft: rgba(139, 32, 32, 0.10);
+
+  --p-seal-red:       #b32929;
+  --p-seal-red-soft:  #a8433a;
+  --p-seal-green:     #3a7c31;
+  --p-seal-blue:      #205dbe;
+  --p-seal-amber:     #b88d44;
   --button-background-selected: #{map.get($colors, 'btn-selected')};
 
   // ── Layout ──────────────────────────────────────────────────────

--- a/tgui/packages/tgui/styles/themes/parchment.scss
+++ b/tgui/packages/tgui/styles/themes/parchment.scss
@@ -55,8 +55,7 @@
 
   &, .Window, .Layout, .Layout__content, .Window__rest, .Window__content,
   .Window__contentPadding {
-    background: #c2ad7c !important;
-    background-image: none !important;
+    background: var(--p-bg) !important;
   }
   .Window__contentPadding {
     margin: 0;
@@ -89,7 +88,6 @@
   .Section {
     background: rgba(230, 210, 165, 0.3);
     border: 1px solid rgba(122, 86, 22, 0.35);
-    box-shadow: inset 0 0 24px rgba(181, 148, 64, 0.09);
   }
 
   .Section__title {

--- a/tgui/packages/tgui/styles/themes/parchment_leatherbound.scss
+++ b/tgui/packages/tgui/styles/themes/parchment_leatherbound.scss
@@ -55,8 +55,7 @@
 
   &, .Window, .Layout, .Layout__content, .Window__rest, .Window__content,
   .Window__contentPadding {
-    background: #2a2118 !important;
-    background-image: none !important;
+    background: var(--p-bg) !important;
   }
 
   .Window__contentPadding {

--- a/tgui/packages/tgui/styles/themes/parchment_vellum.scss
+++ b/tgui/packages/tgui/styles/themes/parchment_vellum.scss
@@ -55,8 +55,7 @@
 
   &, .Window, .Layout, .Layout__content, .Window__rest, .Window__content,
   .Window__contentPadding {
-    background: #f4e7c6 !important;
-    background-image: none !important;
+    background: var(--p-bg) !important;
   }
 
   .Window__contentPadding {
@@ -89,7 +88,6 @@
   .Section {
     background: rgba(255, 248, 220, 0.5);
     border: 1px solid rgba(122, 86, 22, 0.35);
-    box-shadow: inset 0 0 24px rgba(181, 148, 64, 0.09);
   }
 
   .Section__title {


### PR DESCRIPTION
## About The Pull Request

**UPDATE**: Now includes more aggressive optimizations on the Stewardry / Commissioner machines that are causing issues for people after they still are suffering crashing and performance issues. Since the two machines are so data-heavy some optimizations were made in a bid to make them more performant. Frontend is still unchanged and most functionality remains intact - will need further TMing to see if anything breaks.

Patches a few backend holes in the parchment TGUI theme family in a bid to address some performance issues and crashing. No guarantees if they'll work or not considering I don't have such problems on my computer. Might be worth a TM.

Additionally adds a fallback "Disabled (Compatibility)" theme to the Parchment theme selector in Preferences. This will disable the parchment theme entirely in favor of the default TGUI theme you've selected. It won't be as pretty, this is more of a compatibility layer for people having trouble with the parchment theming if the hotfixes I made don't work.

If you do find the Compatibility theme more to your liking in general, that's fine! Just note that it's not specially tuned for *every* single Parchment window and some things might be missing or miscolored. It's listed as Compatibility for a reason.

The Compatibility mode does not work with the Trey Liam TGUI theme. While it will render, things will be difficult to read and it's not worth it to fix for a meme thing.

## Technical Details
Backend changes mostly include performance optimizations and font adjustments. Here are the details:

### Stewardry
* Petition eligibility checks ran unconditionally every tick. Moved into a cache that invalidates only when something meaningful changes.
* Fixed a bug where the UI could incorrectly block petitions in a region that still had capacity, due to paired standing orders being double-counted toward the regional cap.
* Fixed a staleness issue where the Burgher Pledge balance shown in blocker text could disagree with the live balance displayed in the header.

### Commissioner
* `prune_expired_orders()` now runs at most once per game day instead of every tick
* Pre-baked static fulfillment data (item names, required counts) into the order cache. `ui_data()` now only reads live delivery progress per tick.

### Parchment Theme
* `@font-face` declarations now use `font-display: swap` to minimize flickering or blank windows while TTF files might be downloaded for the first time.
* "MedievalSharp" font has no native bold weight. Attempting to render it as bold (as the theme tries to do) will have the renderer attempt to synthesize a bold version from scratch, which can cause crashes on older GPU drivers. This has been patched out, though title themes will look a bit skinnier than before. 
* Several elements in `parchment.tsx` (tabStyle, subTabStyle, tocLinkStyle, inkButtonStyle, and compactButtonStyle) were returning new object literals on every call, causing unnecessary overhead. This has been patched.
* Background variables including `background-image` and `--p-bg` had redundant copies that have been removed.
* `box-shadow` might be causing unnecessary performance overhead for little visual effect on Parchment and Vellum themes and has been removed. Leatherbound retains the box shadow.
* Compatibility theme was added as a fallback in case players still run into performance issues with the parchment theme. This contains `--p-*` fallback variables via `azure_base.scss` to handle special parchment-native styles like borders and seal colors for readability.

# TM Details
Some backend stuff was changed in ways that might behave unpredictably. 

## Testing Evidence
Parchment theme stuff itself doesn't have any front-facing changes.

### Compatibility Theme
(Screenshots use Noccite, though other themes will adjust accordingly too.)

<img width="797" height="511" alt="image" src="https://github.com/user-attachments/assets/03568217-6b1a-4014-9409-4b88d7f0eb95" />

<img width="860" height="820" alt="image" src="https://github.com/user-attachments/assets/28e335cb-f023-4f45-af92-53c4e0937305" />

<img width="620" height="620" alt="image" src="https://github.com/user-attachments/assets/d85e141a-89d5-418c-a293-b69b3bdb81df" />

<img width="880" height="800" alt="image" src="https://github.com/user-attachments/assets/7220ae78-d652-4c16-b23f-f7db96421747" />

<img width="780" height="720" alt="image" src="https://github.com/user-attachments/assets/02a85847-5af6-42c0-b6c1-2ee7185da9ad" />

## Why It's Good For The Game

Some players can't seem to be able to use the Meister or Stewardry/vendor stuff properly without performance problems. This aims to fix that, and barring that provides a different layer to access them.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Refactored parchment TGUI theming to optimize performance.
refactor: Refactored code for Nerve Master and Commissioner due to performance concerns.
add: Added a compatibility theme for Parchment windows (e.g. Meister, Nervemaster, Silverface) for people having performance issues or crashes with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
