### PR TITLE
[BugFix] Fixes Sneak allowing characters to phase through closed serving hatches

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -69,6 +69,10 @@
 		for(var/obj/structure/bars/B in T)
 			to_chat(user, span_warning("I can't fit down there with the bars in the way!"))
 			return
+		for(var/obj/structure/mineral_door/wood/deadbolt/shutter/b in T)
+			if(!b.door_opened)
+				to_chat(user, span_warning("I can't fit down there with the shutter in the way!"))
+				return
 		hideinside(user)
 		return
 	if(Adjacent(user) && user.pulling)


### PR DESCRIPTION
## About The Pull Request

Currently you can sneak under closed serving hatches by sneaking into the table beneath them, then climbing out of the other side. This prevents characters from being able to sneak underneath shutters by checking the turf for closed hatches when trying to climb under tables.

## Testing Evidence

<img width="417" height="32" alt="Screenshot 2026-06-17 165319" src="https://github.com/user-attachments/assets/78d0ec84-07a9-4f16-990b-1b38b370a79f" />

Closed shutters prevent characters from sneaking into the table on the same turf.

## Why It's Good For The Game

A minor bug fix. People probably shouldn't be phasing through shutters by sneaking.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Serving Hatches can no longer be bypassed by sneaking.
/:cl:
