### PR TITLE
change sword+axe default on nocblade

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar/templar_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar/templar_spellblade.dm
@@ -135,7 +135,7 @@
 					H.put_in_hands(new /obj/item/rogueweapon/sword/long/kriegmesser/noc(H))
 					H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword(H), SLOT_BELT_R, TRUE)
 				if("Longsword")
-					H.put_in_hands(new /obj/item/rogueweapon/sword/long(H))
+					H.put_in_hands(new /obj/item/rogueweapon/sword/long/church(H))
 					H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword(H), SLOT_BELT_R, TRUE)
 				if("Rapier")
 					H.put_in_hands(new /obj/item/rogueweapon/sword/rapier(H))
@@ -189,7 +189,7 @@
 					H.put_in_hands(new /obj/item/rogueweapon/mace/goden/steel(H))
 					H.put_in_hands(new /obj/item/rogueweapon/scabbard/gwstrap(H))
 				if("Battle Axe")
-					H.put_in_hands(new /obj/item/rogueweapon/stoneaxe/battle(H))
+					H.put_in_hands(new /obj/item/rogueweapon/stoneaxe/battle/holyseeaxe(H))
 					picked_axe = TRUE
 				if("Steel Greataxe")
 					H.put_in_hands(new /obj/item/rogueweapon/greataxe/steel(H))


### PR DESCRIPTION
## About The Pull Request

nocblade longsword option gives the holy see sword. nocblade battleaxe option gives the holysee axe

## Testing Evidence

should be fine

## Why It's Good For The Game

they are meant to

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: give nocblade holysee weapon options
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
