### PR TITLE
Mage Balance Pack

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -272,6 +272,7 @@
 #define TRAIT_HARDSHELL "Hardshell"
 #define TRAIT_WOODWALKER "Woodwalker"
 #define TRAIT_ARCYNE "Arcyne Training"
+#define TRAIT_LEYLINE_ATTUNEMENT "Leyline Attunement"
 #define TRAIT_BITERHELM "Helmetbiter" // just use this to get helmets which are bitey.
 #define TRAIT_STRENGTH_UNCAPPED "Strength Unbound"	//ignores the STR softcap.
 #define TRAIT_MANORKEEPER "Manorkeeper" // Flavortext-related for the Absolver.
@@ -516,6 +517,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_MATTHIOS_EYES = span_notice("I have a sense for what the most valuable item someone has is. I can also tell if someone is hoarding mammons, and with blessed gilded spectacles, I can even see how much they have in their bank."),
 	TRAIT_WOODWALKER = span_notice("I can climb trees quicker, and gain climbing experience twice as quickly. I can step on thorns and branches safely in the woods. I can stand on leaves in trees safely."),
 	TRAIT_ARCYNE = span_notice("I am trained in the Arcyne arts, allowing me to wield magyck."),
+	TRAIT_LEYLINE_ATTUNEMENT = span_notice("I am attuned to the leylines, allowing me to imbue enchantments into objects."),
 	TRAIT_INFINITE_ENERGY = span_notice ("I don't need rest; I won't ever feel fatigue."),
 	TRAIT_PERMAMUTE = span_notice("I am a mute. I cannot speak."),
 	TRAIT_STRENGTH_UNCAPPED = span_warning("MY STRENGTH IS UNBOUND!"),

--- a/code/datums/magic_items/superior_items/superior.dm
+++ b/code/datums/magic_items/superior_items/superior.dm
@@ -23,16 +23,6 @@
 		active_item = FALSE
 		to_chat(user, span_notice("I feel mundane once more"))
 
-/datum/magic_item/superior/unbreaking
-	name = "unbreaking"
-	description = "It feels as strong as blacksteel"
-	glow_color = "#808080"
-
-/datum/magic_item/superior/unbreaking/on_apply(var/obj/item/i)
-	.=..()
-	i.max_integrity += 100
-	i.obj_integrity += 100
-
 /datum/magic_item/superior/featherstep
 	name = "feather step"
 	description = "It feels as light as a feather"
@@ -57,29 +47,6 @@
 		active_item = FALSE
 		REMOVE_TRAIT(user, TRAIT_LIGHT_STEP, "[type]")
 		user.change_stat(STATKEY_SPD, 0, "featherstep_enchant")
-		to_chat(user, span_notice("I feel mundane once more"))
-
-/datum/magic_item/superior/fireresist
-	name = "fire resistance"
-	description = "It seems to be absorbing heat!"
-	glow_color = "#FF4500"
-	var/active_item = FALSE
-
-/datum/magic_item/superior/fireresist/on_equip(var/obj/item/i, var/mob/living/user, slot)
-	. = ..()
-	if(slot == ITEM_SLOT_HANDS)
-		return
-	if(active_item)
-		return
-	else
-		active_item = TRUE
-		ADD_TRAIT(user, TRAIT_FIRE_RESIST, "[type]")
-		to_chat(user, span_notice("I feel fire-resistant!"))
-
-/datum/magic_item/superior/fireresist/on_drop(var/obj/item/i, var/mob/living/user)
-	if(active_item)
-		active_item = FALSE
-		REMOVE_TRAIT(user, TRAIT_FIRE_RESIST, "[type]")
 		to_chat(user, span_notice("I feel mundane once more"))
 
 /datum/magic_item/superior/climbing

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -409,8 +409,6 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 		aspect.apply_variant(src, variant)
 	else if(has_mastery)
 		aspect.apply_variant(src, "mastery")
-	if((max_majors > 0 || max_minors > 0) && current)
-		ADD_TRAIT(current, TRAIT_LEYLINE_ATTUNEMENT, TRAIT_GENERIC)
 	ensure_mage_basics()
 	return TRUE
 
@@ -950,8 +948,10 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	if(current)
 		to_chat(current, span_nicegreen("Tip: You can Ctrl-Click your hotkey bar to unlock it, then drag to rearrange your spells. Re-arranging them change which hotkeys they are bound to in order from left to right (Alt 1 to Alt 9 default). You can shift click your spells to learn more about them."))
 
-/datum/mind/proc/setup_mage_aspects(list/config)
+/datum/mind/proc/setup_mage_aspects(list/config, grant_attunement = TRUE)
 	mage_aspect_config = config
+	if(grant_attunement && current)
+		ADD_TRAIT(current, TRAIT_LEYLINE_ATTUNEMENT, TRAIT_GENERIC)
 	ensure_mage_basics()
 	check_learnspell()
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -409,6 +409,8 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 		aspect.apply_variant(src, variant)
 	else if(has_mastery)
 		aspect.apply_variant(src, "mastery")
+	if(max_majors > 0 || max_minors > 0 && current)
+		ADD_TRAIT(current, TRAIT_LEYLINE_ATTUNEMENT, TRAIT_GENERIC)
 	ensure_mage_basics()
 	return TRUE
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -409,7 +409,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 		aspect.apply_variant(src, variant)
 	else if(has_mastery)
 		aspect.apply_variant(src, "mastery")
-	if(max_majors > 0 || max_minors > 0 && current)
+	if((max_majors > 0 || max_minors > 0) && current)
 		ADD_TRAIT(current, TRAIT_LEYLINE_ATTUNEMENT, TRAIT_GENERIC)
 	ensure_mage_basics()
 	return TRUE

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -666,7 +666,7 @@
 	if(HAS_TRAIT(owner, TRAIT_IRONMAN))
 		return
 	owner.adjust_bodytemperature(8)
-	if(!owner.resting)
+	if(owner.has_status_effect(/datum/status_effect/combat_tag))
 		return
 	owner.energy_add(healing_on_tick * 2)
 
@@ -681,7 +681,7 @@
 	duration = 6 SECONDS
 
 /datum/status_effect/buff/campfire/tick()
-	if(owner.cmode)
+	if(owner.has_status_effect(/datum/status_effect/combat_tag))
 		return
 	if(HAS_TRAIT(owner, TRAIT_IRONMAN))
 		return

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -665,11 +665,10 @@
 /datum/status_effect/buff/campfire_stamina/tick()
 	if(HAS_TRAIT(owner, TRAIT_IRONMAN))
 		return
-	var/stamheal = healing_on_tick
-	if(!owner.cmode)
-		stamheal *= 2
-	owner.energy_add(stamheal)
 	owner.adjust_bodytemperature(8)
+	if(!owner.resting)
+		return
+	owner.energy_add(healing_on_tick * 2)
 
 /datum/status_effect/buff/campfire_stamina/on_remove()
 	owner.remove_filter(CAMPFIRE_BASE_FILTER)

--- a/code/datums/status_effects/rogue/roguestatus.dm
+++ b/code/datums/status_effects/rogue/roguestatus.dm
@@ -121,3 +121,15 @@
 	desc = "I'm revealed. It will take me a while to regain my sense of surroundings."
 	icon_state = "revealed"
 	icon = 'icons/mob/screen_alert_combat.dmi'
+
+// Merge this into stealth status once FREE approves.
+/datum/status_effect/combat_tag
+	id = "combat_tag"
+	alert_type = /atom/movable/screen/alert/status_effect/combat_tag
+	duration = 10 SECONDS
+	status_type = STATUS_EFFECT_REFRESH
+
+/atom/movable/screen/alert/status_effect/combat_tag
+	name = "In Combat"
+	desc = "I was recently in active combat. I won't get a proper rest until I catch my breath."
+	icon_state = "clash"

--- a/code/game/objects/items/rogueitems/magic/mageitems.dm
+++ b/code/game/objects/items/rogueitems/magic/mageitems.dm
@@ -57,7 +57,7 @@
 	var/chosen_keyword
 
 /obj/item/chalk/attack_self(mob/living/carbon/human/user)
-	if(!isarcyne(user))
+	if(!HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT))
 		to_chat(user, span_cult("Nothing comes in mind to draw with the chalk."))
 		return
 
@@ -69,9 +69,6 @@
 	pickrune = GLOB.rune_types[runenameinput]
 	rune_to_scribe = pickrune
 	if(rune_to_scribe == null)
-		return
-	if(ispath(rune_to_scribe, /obj/effect/decal/cleanable/roguerune/arcyne/enchantment) && !HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT))
-		to_chat(user, span_warning("I lack the attunement to inscribe an imbuement array."))
 		return
 	var/turf/Turf = get_turf(user)
 	if(locate(/obj/effect/decal/cleanable/roguerune) in Turf)
@@ -131,7 +128,7 @@
 	filter(type="drop_shadow", x=0, y=0, size=2, offset=1, color=rgb(128, 0, 128, 1))
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/arcyne/attack_self(mob/living/carbon/human/user)
-	if(!isarcyne(user))
+	if(!HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT))
 		return
 	if(!is_bled)
 		playsound(loc, get_sfx("genslash"), 100, TRUE)
@@ -148,9 +145,6 @@
 	pickrune = GLOB.rune_types[runenameinput]
 	rune_to_scribe = pickrune
 	if(rune_to_scribe == null)
-		return
-	if(ispath(rune_to_scribe, /obj/effect/decal/cleanable/roguerune/arcyne/enchantment) && !HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT))
-		to_chat(user, span_warning("I lack the leyline attunement to inscribe an imbuement array."))
 		return
 	var/turf/Turf = get_turf(user)
 	if(locate(/obj/effect/decal/cleanable/roguerune) in Turf)

--- a/code/game/objects/items/rogueitems/magic/mageitems.dm
+++ b/code/game/objects/items/rogueitems/magic/mageitems.dm
@@ -70,6 +70,9 @@
 	rune_to_scribe = pickrune
 	if(rune_to_scribe == null)
 		return
+	if(ispath(rune_to_scribe, /obj/effect/decal/cleanable/roguerune/arcyne/enchantment) && !HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT))
+		to_chat(user, span_warning("I lack the attunement to inscribe an imbuement array."))
+		return
 	var/turf/Turf = get_turf(user)
 	if(locate(/obj/effect/decal/cleanable/roguerune) in Turf)
 		to_chat(user, span_cult("There is already a rune here."))
@@ -145,6 +148,9 @@
 	pickrune = GLOB.rune_types[runenameinput]
 	rune_to_scribe = pickrune
 	if(rune_to_scribe == null)
+		return
+	if(ispath(rune_to_scribe, /obj/effect/decal/cleanable/roguerune/arcyne/enchantment) && !HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT))
+		to_chat(user, span_warning("I lack the leyline attunement to inscribe an imbuement array."))
 		return
 	var/turf/Turf = get_turf(user)
 	if(locate(/obj/effect/decal/cleanable/roguerune) in Turf)

--- a/code/game/objects/items/spell_implements/wand.dm
+++ b/code/game/objects/items/spell_implements/wand.dm
@@ -16,7 +16,7 @@
 	wdefense = 1
 	max_integrity = 80
 	resistance_flags = FIRE_PROOF
-	associated_skill = /datum/skill/magic/arcane
+	associated_skill = /datum/skill/combat/staves
 	possible_item_intents = list(SPEAR_BASH)
 	sellprice = 34
 	implement_tier = IMPLEMENT_TIER_LESSER

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -278,7 +278,7 @@
 	action_icon = 'icons/mob/actions/gnollmiracles.dmi'
 	overlay_state = "stalk"
 	action_icon_state = "stalk"
-	ignore_stealth_reveal = TRUE
+	ignore_combat_tag = TRUE
 
 /obj/effect/proc_holder/spell/invoked/invisibility/gnoll/cast(list/targets, mob/living/user)
 	var/mob/living/target = user

--- a/code/modules/clothing/rogueclothes/npc/goblin.dm
+++ b/code/modules/clothing/rogueclothes/npc/goblin.dm
@@ -27,10 +27,6 @@
 	armor = null
 	sellprice = 0
 
-/obj/item/clothing/suit/roguetown/armor/leather/hide/goblin/Initialize()
-	. = ..()
-	AddComponent(/datum/component/magic_item, new /datum/magic_item/superior/fireresist)
-
 /obj/item/clothing/head/roguetown/helmet/leather/goblin
 	name = "goblin helmet"
 	icon_state = "leather_helm_item"

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -235,6 +235,7 @@
 	if(has_status_effect(/datum/status_effect/debuff/exposed))
 		return FALSE
 
+	apply_status_effect(/datum/status_effect/combat_tag)
 	if(get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(src, TRAIT_LIGHT_STEP))
 		apply_status_effect(/datum/status_effect/stealth_revealed)
 

--- a/code/modules/mob/living/combat/checkdefense.dm
+++ b/code/modules/mob/living/combat/checkdefense.dm
@@ -11,6 +11,8 @@
 	if(mid_climb)
 		interrupt_climb()
 
+	apply_status_effect(/datum/status_effect/combat_tag)
+	user.apply_status_effect(/datum/status_effect/combat_tag)
 	if(!has_status_effect(/datum/status_effect/stealth_revealed) || !user.has_status_effect(/datum/status_effect/stealth_revealed))
 		if(get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(src, TRAIT_LIGHT_STEP))
 			apply_status_effect(/datum/status_effect/stealth_revealed)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -206,26 +206,28 @@
 		if(!apply_damage(actual_damage, P.damage_type, def_zone, armor))
 			nodmg = TRUE
 			next_attack_msg += VISMSG_ARMOR_BLOCKED
-		apply_effects(stun = P.stun, knockdown = P.knockdown, unconscious = P.unconscious, slur = P.slur, stutter = P.stutter, eyeblur = P.eyeblur, drowsy = P.drowsy, blocked = armor, stamina = P.stamina, jitter = P.jitter, paralyze = P.paralyze, immobilize = P.immobilize)
+		if(!P.out_of_effective_range())
+			apply_effects(stun = P.stun, knockdown = P.knockdown, unconscious = P.unconscious, slur = P.slur, stutter = P.stutter, eyeblur = P.eyeblur, drowsy = P.drowsy, blocked = armor, stamina = P.stamina, jitter = P.jitter, paralyze = P.paralyze, immobilize = P.immobilize)
 		if(!nodmg)
-			if(P.dismemberment)
-				check_projectile_dismemberment(P, def_zone,armor)
-			if(P.woundclass)
-				check_projectile_wounding(P, def_zone, armor)
+			if(!P.out_of_effective_range())
+				if(P.dismemberment)
+					check_projectile_dismemberment(P, def_zone,armor)
+				if(P.woundclass)
+					check_projectile_wounding(P, def_zone, armor)
 
-			if(P.poisontype)// New proc for poisoning that respects if armor stopped damage from the projectile, by blocking or through reduction. Only called if poison type is defined.
-				if(!P.poisonamount)
-					CRASH("Projectile attempted to add poison with undefined amount.")
-				if(iscarbon(src))
-					var/mob/living/carbon/M = src
-					M.reagents.add_reagent(P.poisontype, P.poisonamount)
-					if(P.poisonfeel)
-						M.show_message(span_danger("You feel an intense [P.poisonfeel] sensation spreading swiftly from the area!"))
+				if(P.poisontype)// New proc for poisoning that respects if armor stopped damage from the projectile, by blocking or through reduction. Only called if poison type is defined.
+					if(!P.poisonamount)
+						CRASH("Projectile attempted to add poison with undefined amount.")
+					if(iscarbon(src))
+						var/mob/living/carbon/M = src
+						M.reagents.add_reagent(P.poisontype, P.poisonamount)
+						if(P.poisonfeel)
+							M.show_message(span_danger("You feel an intense [P.poisonfeel] sensation spreading swiftly from the area!"))
 
-			if(P.embedchance && !check_projectile_embed(P, def_zone, armor))
-				P.handle_drop()
+				if(P.embedchance && !check_projectile_embed(P, def_zone, armor))
+					P.handle_drop()
 
-			P.do_special_projectile_effect(P.firer, get_bodypart(check_zone(def_zone)), src, def_zone)
+				P.do_special_projectile_effect(P.firer, get_bodypart(check_zone(def_zone)), src, def_zone)
 
 		else
 			P.handle_drop()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -206,6 +206,8 @@
 		if(!apply_damage(actual_damage, P.damage_type, def_zone, armor))
 			nodmg = TRUE
 			next_attack_msg += VISMSG_ARMOR_BLOCKED
+		if(!nodmg)
+			apply_status_effect(/datum/status_effect/combat_tag)
 		if(!P.out_of_effective_range())
 			apply_effects(stun = P.stun, knockdown = P.knockdown, unconscious = P.unconscious, slur = P.slur, stutter = P.stutter, eyeblur = P.eyeblur, drowsy = P.drowsy, blocked = armor, stamina = P.stamina, jitter = P.jitter, paralyze = P.paralyze, immobilize = P.immobilize)
 		if(!nodmg)
@@ -280,6 +282,7 @@
 				nodmg = TRUE
 				next_attack_msg += VISMSG_ARMOR_BLOCKED
 			if(!nodmg)
+				apply_status_effect(/datum/status_effect/combat_tag)
 				if(iscarbon(src))
 					var/obj/item/bodypart/affecting = get_bodypart(zone)
 					if(affecting)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -206,8 +206,7 @@
 		if(!apply_damage(actual_damage, P.damage_type, def_zone, armor))
 			nodmg = TRUE
 			next_attack_msg += VISMSG_ARMOR_BLOCKED
-		if(!nodmg)
-			apply_status_effect(/datum/status_effect/combat_tag)
+		apply_status_effect(/datum/status_effect/combat_tag)
 		if(!P.out_of_effective_range())
 			apply_effects(stun = P.stun, knockdown = P.knockdown, unconscious = P.unconscious, slur = P.slur, stutter = P.stutter, eyeblur = P.eyeblur, drowsy = P.drowsy, blocked = armor, stamina = P.stamina, jitter = P.jitter, paralyze = P.paralyze, immobilize = P.immobilize)
 		if(!nodmg)

--- a/code/modules/mob/living/simple_animal/hostile/bosses/baroness.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/baroness.dm
@@ -101,6 +101,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.Immobilize(1, src)
 			playsound(get_turf(src), pick('sound/misc/elec (1).ogg', 'sound/misc/elec (2).ogg', 'sound/misc/elec (3).ogg'), 100, FALSE)
 	qdel(src)
@@ -130,6 +132,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.Immobilize(1, src)
 			playsound(get_turf(src), pick('sound/misc/elec (1).ogg', 'sound/misc/elec (2).ogg', 'sound/misc/elec (3).ogg'), 100, FALSE)
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/bosses/lich_boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/lich_boss.dm
@@ -199,6 +199,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.Immobilize(1, src)
 			playsound(get_turf(src), pick('sound/misc/elec (1).ogg', 'sound/misc/elec (2).ogg', 'sound/misc/elec (3).ogg'), 100, FALSE)
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/zard_guard_mage.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zard_guard_mage.dm
@@ -57,6 +57,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.Immobilize(1, src)
 			playsound(get_turf(src), pick('sound/misc/elec (1).ogg', 'sound/misc/elec (2).ogg', 'sound/misc/elec (3).ogg'), 100, FALSE)
 	qdel(src)
@@ -86,6 +88,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.Immobilize(1, src)
 			playsound(get_turf(src), pick('sound/misc/elec (1).ogg', 'sound/misc/elec (2).ogg', 'sound/misc/elec (3).ogg'), 100, FALSE)
 	qdel(src)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -139,6 +139,7 @@
 		if(user.rogue_sneaking)
 			user.mob_timers[MT_FOUNDSNEAK] = world.time
 			user.update_sneak_invis(reset = TRUE)
+		user.apply_status_effect(/datum/status_effect/combat_tag)
 		if(user.get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(user, TRAIT_LIGHT_STEP))
 			user.apply_status_effect(/datum/status_effect/stealth_revealed)
 		sprd = round((rand() - 0.5) * DUALWIELD_PENALTY_EXTRA_MULTIPLIER * (randomized_gun_spread + randomized_bonus_spread))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -161,9 +161,14 @@
 	var/max_range = 0
 	/// Falloff factor for damage. Multiplicative.
 	var/dam_falloff_factor = 1
+	var/suppress_effects_past_range = FALSE
 
 /obj/projectile/proc/handle_drop()
 	return
+
+
+/obj/projectile/proc/out_of_effective_range()
+	return suppress_effects_past_range && max_range && check_range(get_turf(src))
 
 /obj/projectile/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -9,12 +9,21 @@
 	flag = "fire"
 	reflectable = REFLECT_NORMAL
 	guard_deflectable = TRUE
+	dam_falloff_factor = 0.5
+	suppress_effects_past_range = TRUE
+	max_range = 7
 	var/explode_sound = list('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg')
 	var/mob/living/carbon/human/sender
 	/// Impact visual intensity. SPELL_IMPACT_NONE / SPELL_IMPACT_LOW / SPELL_IMPACT_MEDIUM / SPELL_IMPACT_HIGH
 	var/spell_impact_intensity = SPELL_IMPACT_LOW
 	/// Override color for the impact effect. If null, uses light_color.
 	var/spell_impact_color
+
+/// Energy projectiles (divine and arcane bolts) are a separate base from /magic but share the same off-screen falloff.
+/obj/projectile/energy
+	dam_falloff_factor = 0.5
+	suppress_effects_past_range = TRUE
+	max_range = 7
 
 /obj/projectile/magic/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -301,6 +310,8 @@
 
 /obj/projectile/magic/sickness/on_hit(atom/target, blocked = FALSE)
 	. = ..()
+	if(out_of_effective_range())
+		return
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.reagents.add_reagent(/datum/reagent/toxin, 3)
@@ -375,8 +386,12 @@
 		if(M.anti_magic_check())
 			visible_message(span_warning("[src] vanishes into smoke on contact with [target]!"))
 			return BULLET_ACT_BLOCK
+		if(out_of_effective_range())
+			return
 		if(exp_fire)
 			M.adjust_fire_stacks(exp_fire*3)
+	else if(out_of_effective_range())
+		return
 	var/turf/T
 	if(isturf(target))
 		T = target
@@ -401,6 +416,8 @@
 		var/mob/living/M = target
 		if(M.anti_magic_check())
 			return BULLET_ACT_BLOCK
+	if(out_of_effective_range())
+		return
 	var/turf/T = get_turf(target)
 	for(var/i=0, i<50, i+=10)
 		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), T, -1, exp_heavy, exp_light, exp_flash, FALSE, FALSE, exp_fire), i)

--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -153,23 +153,6 @@ T1 Enchantments below here*/
 	else
 		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
 
-/obj/item/enchantmentscroll/superior/unbreaking
-	name = "enchanting scroll of unbreaking"
-	desc = "A scroll imbued with an enchantment of unbreakingt. Causes an enchanted item to be able to take more punishment.."
-	component = /datum/magic_item/superior/unbreaking
-
-/obj/item/enchantmentscroll/superior/unbreaking/attack_obj(obj/item/O, mob/living/user)
-	if(!..())
-		return
-	if(istype(O,/obj/item/clothing)|| istype(O,/obj/item/rogueweapon))
-		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
-		var/magiceffect= new component
-		O.AddComponent(/datum/component/magic_item, magiceffect)
-		O.name += " of unbreaking"
-		qdel(src)
-	else
-		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
-
 /obj/item/enchantmentscroll/superior/featherstep
 	name = "enchanting scroll of featherstep"
 	desc = "A scroll imbued with an enchantment of featherstep. Makes you speedier, and makes your footfalls silent."
@@ -183,23 +166,6 @@ T1 Enchantments below here*/
 		var/magiceffect= new component
 		O.AddComponent(/datum/component/magic_item, magiceffect)
 		O.name += " of featherstep"
-		qdel(src)
-	else
-		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
-
-/obj/item/enchantmentscroll/superior/fireresist
-	name = "enchanting scroll of fire resistance"
-	desc = "A scroll imbued with an enchantment of fire resistance. Prevents you from catching fire."
-	component = /datum/magic_item/superior/fireresist
-
-/obj/item/enchantmentscroll/superior/fireresist/attack_obj(obj/item/O, mob/living/user)
-	if(!..())
-		return
-	if(istype(O,/obj/item/clothing))
-		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
-		var/magiceffect= new component
-		O.AddComponent(/datum/component/magic_item, magiceffect)
-		O.name += " of fire resistance"
 		qdel(src)
 	else
 		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))

--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -335,10 +335,13 @@ GLOBAL_LIST(teleport_runes)
 	can_be_scribed = FALSE
 
 /obj/effect/decal/cleanable/roguerune/arcyne/attack_hand(mob/living/user)
-	if(!isarcyne(user))
+	if(!can_use_arcyne_rune(user))
 		to_chat(user, span_warning("You aren't able to understand the words of [src]."))
 		return
 	. = ..()
+
+/obj/effect/decal/cleanable/roguerune/arcyne/proc/can_use_arcyne_rune(mob/living/user)
+	return HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT)
 
 
 
@@ -358,6 +361,9 @@ GLOBAL_LIST(teleport_runes)
 /obj/effect/decal/cleanable/roguerune/arcyne/enchantment/New()
 	. = ..()
 	rituals += GLOB.t3enchantmentrunerituallist
+
+/obj/effect/decal/cleanable/roguerune/arcyne/enchantment/can_use_arcyne_rune(mob/living/user)
+	return HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT)
 
 /obj/effect/decal/cleanable/roguerune/arcyne/enchantment/invoke(list/invokers, datum/runeritual/runeritual)
 	if(!..())	//VERY important. Calls parent and checks if it fails. parent/invoke has all the checks for ingredients

--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -835,7 +835,7 @@ GLOBAL_LIST(teleport_runes)
 	LAZYADD(GLOB.teleport_runes, src)
 
 /obj/effect/decal/cleanable/roguerune/arcyne/teleport/attack_hand(mob/living/user)
-	if(!isarcyne(user))
+	if(!can_use_arcyne_rune(user))
 		to_chat(user, span_warning("You aren't able to understand the words of [src]."))
 		return
 	if(rune_in_use)

--- a/code/modules/roguetown/roguejobs/mages/rituals/enchanting.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/enchanting.dm
@@ -87,14 +87,6 @@
 	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/fae/iridescentscale = 2)
 	result_atoms = list(/obj/item/enchantmentscroll/superior/nightvision)
 
-/datum/runeritual/enchanting/unbreaking
-	name = "Unbreaking"
-	desc = "Provides extra integrity!"
-	blacklisted = FALSE
-	tier = 2
-	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/elemental/shard = 2)
-	result_atoms = list(/obj/item/enchantmentscroll/superior/unbreaking)
-
 /datum/runeritual/enchanting/featherstep
 	name = "Feather Step"
 	desc = "Makes your step lighter and speedier!"
@@ -102,14 +94,6 @@
 	tier = 2
 	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/fae/iridescentscale = 2)
 	result_atoms = list(/obj/item/enchantmentscroll/superior/featherstep)
-
-/datum/runeritual/enchanting/fireresist
-	name = "Fire Resistance"
-	desc = "Provides resistance from fire!"
-	blacklisted = FALSE
-	tier = 2
-	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/infernal/fang = 2)
-	result_atoms = list(/obj/item/enchantmentscroll/superior/fireresist)
 
 /datum/runeritual/enchanting/climbing
 	name = "Spider movements"

--- a/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -375,6 +375,8 @@
 	. = ..()
 	if(!istype(M))
 		return
+	if(out_of_effective_range())
+		return
 	if(target)
 		to_chat(target, span_warning("Gah! Something.. got in my - eyes.."))
 		M.blur_eyes(2)

--- a/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -198,6 +198,8 @@
 	. = ..()
 	if(!iscarbon(target))
 		return
+	if(out_of_effective_range())
+		return
 	if(target)
 		ensnare(target)
 

--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -188,6 +188,8 @@
 		qdel(src)
 		return BULLET_ACT_BLOCK
 
+	if(out_of_effective_range())
+		return
 	try_embed_target(L)
 	qdel(src)
 

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -240,6 +240,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
 			if(HAS_TRAIT(L, TRAIT_SILVER_WEAK))
 				L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/sunder)

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -216,7 +216,7 @@
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
-	ignore_stealth_reveal = TRUE
+	ignore_combat_tag = TRUE
 
 /datum/action/cooldown/spell/noc/invisibility/cast(atom/cast_on)
 	. = ..()
@@ -261,7 +261,7 @@
 	antimagic_allowed = TRUE
 	hide_charge_effect = TRUE
 	cost = 3 // Very useful
-	ignore_stealth_reveal = TRUE
+	ignore_combat_tag = TRUE
 
 /obj/effect/proc_holder/spell/invoked/invisibility/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -40,7 +40,7 @@
 	recharge_time = 30 SECONDS
 	var/firstcast = TRUE
 	var/icon/clone_icon
-	ignore_stealth_reveal = TRUE
+	ignore_combat_tag = TRUE
 
 /obj/effect/proc_holder/spell/invoked/mastersillusion/cast(list/targets, mob/living/carbon/human/user = usr)
 	if(firstcast)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -211,7 +211,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/miracle = FALSE
 	var/devotion_cost = 0
 	var/ignore_cockblock = FALSE //whether or not to ignore TRAIT_SPELLCOCKBLOCK
-	var/ignore_stealth_reveal = FALSE
+	var/ignore_combat_tag = FALSE
 	action_icon_state = "spell0"
 	action_icon = 'icons/mob/actions/roguespells.dmi'
 	action_background_icon_state = ""
@@ -605,7 +605,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			if(L.has_status_effect(/datum/status_effect/buff/clash))
 				var/mob/living/carbon/human/H = user
 				H.bad_guard(span_warning("I can't focus while casting spells!"), cheesy = TRUE)
-			if(!ignore_stealth_reveal)
+			if(!ignore_combat_tag)
+				L.apply_status_effect(/datum/status_effect/combat_tag)
 				if(L.get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(L, TRAIT_LIGHT_STEP))
 					L.apply_status_effect(/datum/status_effect/stealth_revealed)
 		if(action)

--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -50,7 +50,7 @@
 	active_background_icon_state = "spell1"
 	button_icon = 'icons/mob/actions/roguespells.dmi'
 	button_icon_state = "shieldsparkles"
-	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_PHASED
+	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_PHASED|AB_CHECK_IMMOBILE
 	panel = "Spells"
 	click_to_activate = TRUE
 	unset_after_click = FALSE

--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -176,8 +176,8 @@
 	var/weapon_penalty_active = FALSE
 	/// If TRUE, this spell ignores armor cooldown penalties (for armored casters like Tithebound).
 	var/ignore_armor_penalty = FALSE
-	/// If TRUE, will -not- trigger stealth reveal mechanics after cast.
-	var/ignore_stealth_reveal = FALSE
+	/// If TRUE, casting will -not- apply the combat tag (skips stealth reveal and rest interruption).
+	var/ignore_combat_tag = FALSE
 	/// If TRUE, spell charges on button press, then waits for a separate middle-click to cast.
 	/// If FALSE (default), spell uses hold-and-release: hold middle-click to charge, release to cast.
 	var/charge_then_click = FALSE
@@ -891,7 +891,8 @@
 		if(H.has_status_effect(/datum/status_effect/buff/clash))
 			H.bad_guard(span_warning("I can't focus while casting spells!"), cheesy = TRUE)
 
-		if(!ignore_stealth_reveal)
+		if(!ignore_combat_tag)
+			H.apply_status_effect(/datum/status_effect/combat_tag)
 			if(H.get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(H, TRAIT_LIGHT_STEP))
 				H.apply_status_effect(/datum/status_effect/stealth_revealed)
 

--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -146,7 +146,7 @@
 	 * Total drain is: ([charge_time] / [process_time]) * charge_drain
 	 * process_time is currently 4 from SSfastprocess.
 	 */
-	var/charge_drain = 0
+	var/charge_drain = 1
 	/// Time to charge.
 	var/charge_time = 0
 	/// Slowdown while charging.

--- a/code/modules/spells/spell_touch.dm
+++ b/code/modules/spells/spell_touch.dm
@@ -21,7 +21,7 @@
 // AP Note: Right click secondary cast is NOT PROPERLY IMPLEMENTED. It is just stubbed out
 
 /datum/action/cooldown/spell/touch
-	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
+	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE
 	charge_required = FALSE
 	has_visual_effects = FALSE
 	click_to_activate = FALSE

--- a/code/modules/spells/spell_types/bardic/vicious_mockery.dm
+++ b/code/modules/spells/spell_types/bardic/vicious_mockery.dm
@@ -77,6 +77,8 @@ GLOBAL_LIST_INIT(mockery_insults, list(
 			visible_message(span_warning("The insult falls on deaf ears!"))
 			qdel(src)
 			return BULLET_ACT_BLOCK
+		if(out_of_effective_range())
+			return
 		// Stack the debuff
 		var/datum/status_effect/debuff/mockery_stack/existing = M.has_status_effect(/datum/status_effect/debuff/mockery_stack)
 		if(existing)

--- a/code/modules/spells/spell_types/classunique/spellblade/azurean_pilum.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/azurean_pilum.dm
@@ -92,6 +92,8 @@
 			visible_message(span_warning("[src] disperses on contact with [L]!"))
 			playsound(get_turf(L), 'sound/magic/magic_nulled.ogg', 100)
 			return BULLET_ACT_BLOCK
+		if(out_of_effective_range())
+			return
 		apply_frost_stack(L, frost_stacks)
 		to_chat(L, span_danger("An icy pilum strikes true - the cold seeps into my bones!"))
 		if(firer)

--- a/code/modules/spells/spell_types/classunique/spellblade/blade_storm.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/blade_storm.dm
@@ -236,6 +236,9 @@
 		playsound(get_turf(victim), 'sound/magic/magic_nulled.ogg', 100)
 		return BULLET_ACT_BLOCK
 
+	if(out_of_effective_range())
+		return
+
 	INVOKE_ASYNC(parent_spell, TYPE_PROC_REF(/datum/action/cooldown/spell/projectile/blade_storm, execute_storm), caster, victim, aoe_cuts, aoe_dmg, p_cuts, p_dmg, def_zone)
 	return BULLET_ACT_BLOCK
 

--- a/code/modules/spells/spell_types/classunique/spellblade/tremor.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/tremor.dm
@@ -10,9 +10,6 @@
 	spell_color = GLOW_COLOR_ARCANE
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 
-	click_to_activate = FALSE
-	self_cast_possible = TRUE
-
 	primary_resource_type = SPELL_COST_STAMINA
 	primary_resource_cost = SPELLCOST_SB_POKE
 
@@ -49,6 +46,8 @@
 		return FALSE
 
 	var/turf/center = get_turf(H)
+	if(!center)
+		return FALSE
 
 	var/empowered = FALSE
 	var/datum/status_effect/buff/arcyne_momentum/M = H.has_status_effect(/datum/status_effect/buff/arcyne_momentum)

--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -57,6 +57,8 @@
 			playsound(get_turf(H), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
+		if(out_of_effective_range())
+			return
 		if(H.mob_biotypes & MOB_UNDEAD)
 			damage += 20
 	if(ishuman(target))

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -52,6 +52,8 @@
 /obj/projectile/energy/unholyblast/on_hit(target)
 	if(isliving(target))
 		var/mob/living/H = target
+		if(out_of_effective_range())
+			return
 		if(H.mob_biotypes & MOB_UNDEAD)
 			damage += 20
 	if(ishuman(target))

--- a/code/modules/spells/spell_types/skills/projectile/flashpowder.dm
+++ b/code/modules/spells/spell_types/skills/projectile/flashpowder.dm
@@ -33,6 +33,8 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
+		if(out_of_effective_range())
+			return
 		M.apply_status_effect(/datum/status_effect/debuff/flashpowder)
 		M.apply_status_effect(/datum/status_effect/debuff/clickcd, 3 SECONDS)
 		if(iscarbon(target))

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_arcyne_ward.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_arcyne_ward.dm
@@ -197,7 +197,7 @@
 
 	charge_required = TRUE
 	charge_time = 10 SECONDS
-	charge_drain = 5
+	charge_drain = 1
 	charge_slowdown = 3
 	charge_sound = 'sound/magic/charging.ogg'
 	cooldown_time = 2 MINUTES

--- a/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
@@ -65,6 +65,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			if(L.on_fire)
 				L.adjust_fire_stacks(-1)
 				L.visible_message(span_warning("The frost dampens the flames on [L]!"))

--- a/code/modules/spells/spell_types/wizard/cryomancy/ice_burst.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/ice_burst.dm
@@ -71,6 +71,9 @@
 		qdel(src)
 		return BULLET_ACT_BLOCK
 
+	if(out_of_effective_range())
+		return
+
 	var/aoe_damage = round(damage * aoe_damage_ratio)
 	var/turf/epicenter = get_turf(target)
 

--- a/code/modules/spells/spell_types/wizard/ferramancy/iron_tempest.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/iron_tempest.dm
@@ -69,6 +69,8 @@
 
 /obj/projectile/magic/iron_tempest_seed/on_hit(atom/target)
 	. = ..()
+	if(out_of_effective_range())
+		return
 	var/turf/impact = get_turf(target)
 	if(impact)
 		new /obj/effect/iron_tempest(impact, firer, spell_ref)

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/arc_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/arc_bolt.dm
@@ -68,6 +68,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
 	else if(isatom(target))
 		var/atom/A = target

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/lightning_bolt.dm
@@ -66,6 +66,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
 			// Lightning Adaptation: all CC effects gated behind the adaptation timer
 			if(!L.mob_timers[MT_LIGHTNING_ADAPTATION] || world.time > L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN)

--- a/code/modules/spells/spell_types/wizard/geomancy/boulder_strike.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/boulder_strike.dm
@@ -60,6 +60,8 @@
 
 /obj/projectile/magic/boulder/on_hit(target)
 	. = ..()
+	if(out_of_effective_range())
+		return
 	var/turf/impact = get_turf(src)
 	if(!impact)
 		return

--- a/code/modules/spells/spell_types/wizard/legacy_spells_unused/acid_splash.dm
+++ b/code/modules/spells/spell_types/wizard/legacy_spells_unused/acid_splash.dm
@@ -47,6 +47,8 @@
 
 /obj/projectile/magic/acidsplash/on_hit(atom/target, blocked = FALSE)
 	. = ..()
+	if(out_of_effective_range())
+		return
 	var/turf/T = get_turf(src)
 	playsound(src, 'sound/misc/drink_blood.ogg', 100)
 

--- a/code/modules/spells/spell_types/wizard/projectiles_single/blood_lightning.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/blood_lightning.dm
@@ -57,6 +57,8 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			if(out_of_effective_range())
+				return
 			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
 			if(!L.mob_timers[MT_LIGHTNING_ADAPTATION] || world.time > L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN)
 				L.Immobilize(0.5 SECONDS)

--- a/code/modules/spells/spell_types/wizard/projectiles_single/blood_steal.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/blood_steal.dm
@@ -51,6 +51,8 @@
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
+		if(out_of_effective_range())
+			return
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
 			H.blood_volume = max(H.blood_volume-45, 0)

--- a/code/modules/spells/spell_types/wizard/pyromancy/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/fireball.dm
@@ -74,6 +74,9 @@
 		qdel(src)
 		return BULLET_ACT_BLOCK
 
+	if(out_of_effective_range())
+		return
+
 	if(M)
 		M.adjust_fire_stacks(1)
 		M.ignite_mob()

--- a/code/modules/spells/spell_types/wizard/pyromancy/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/fireball.dm
@@ -24,7 +24,6 @@
 	charge_required = TRUE
 	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_MAJOR
-	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_MEDIUM
 	charge_sound = 'sound/magic/charging_fire.ogg'
 	cooldown_time = 16 SECONDS

--- a/code/modules/spells/spell_types/wizard/pyromancy/fireball_artillery.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/fireball_artillery.dm
@@ -51,6 +51,8 @@
 	var/turf/fallzone = get_turf(target)
 	if(!fallzone)
 		return
+	if(out_of_effective_range())
+		return
 	for(var/turf/open/visual in view(cached_radius, fallzone))
 		var/obj/effect/temp_visual/lavastaff/Lava = new /obj/effect/temp_visual/lavastaff(visual)
 		animate(Lava, alpha = 255, time = 5)

--- a/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
@@ -67,6 +67,8 @@
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
+		if(out_of_effective_range())
+			return
 		if(has_frost_stacks(M))
 			remove_frost_stack(M)
 			visible_message(span_warning("The fire thaws the frost on [target]!"))

--- a/code/modules/spells/spell_types/wizard/telomancy/seeker_volley.dm
+++ b/code/modules/spells/spell_types/wizard/telomancy/seeker_volley.dm
@@ -88,6 +88,8 @@
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
+		if(out_of_effective_range())
+			return
 		M.apply_status_effect(/datum/status_effect/debuff/seeker_marked)
 	. = ..()
 

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -18,7 +18,7 @@
 	if(!recipient.mind)
 		return
 	if(!LAZYLEN(recipient.mind.mage_aspect_config))
-		recipient.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 0))
+		recipient.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 0), grant_attunement = FALSE)
 	recipient.mind.mage_aspect_config["utilities"] += amount
 	recipient.mind.check_learnspell()
 	

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -1,14 +1,14 @@
 /datum/virtue/combat/magical_potential
 	name = "Arcyne Potential"
 	desc = "I am talented in the Arcyne arts, expanding my capacity for magic. I have become more intelligent from its studies. Other effects depends on what training I chose to focus on at a later age."
-	custom_text = "Classes that has a combat trait (Medium / Heavy Armor Training, Dodge Expert or Critical Resistance) get only prestidigitation. Everyone else get +3 utility points and Arcyne Training if they don't have any Arcyne."
+	custom_text = "Classes that has a combat trait (Medium / Heavy Armor Training, Dodge Expert, Critical Resistance, Thick Blooded, Painless or Enduring) get only prestidigitation. Everyone else get +3 utility points and Arcyne Training if they don't have any Arcyne."
 	added_skills = list(list(/datum/skill/magic/arcane, 1, 6), list(/datum/skill/misc/reading, 1, 6))
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
 	if (!recipient.get_skill_level(/datum/skill/magic/arcane))
 		if (!recipient.mind?.has_spell(/datum/action/cooldown/spell/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /datum/action/cooldown/spell/touch/prestidigitation)
-		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE))
+		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE) && !HAS_TRAIT(recipient, TRAIT_BLOOD_RESISTANCE) && !HAS_TRAIT(recipient, TRAIT_NOPAIN) && !HAS_TRAIT(recipient, TRAIT_NOPAINSTUN))
 			ADD_TRAIT(recipient, TRAIT_ARCYNE, TRAIT_GENERIC)
 			add_arcyne_potential_utilities(recipient, 3)
 	else

--- a/code/modules/virtues/crafter.dm
+++ b/code/modules/virtues/crafter.dm
@@ -103,7 +103,7 @@
 				added_skills.Add(list(list(/datum/skill/craft/engineering, 2, 2)))
 				added_skills.Add(list(list(/datum/skill/craft/smelting, 2, 2)))
 				added_skills.Add(list(list(/datum/skill/magic/arcane, 2, 2)))
-				added_traits.Add(TRAIT_ENCHANTING_EXPERT, TRAIT_ALCHEMY_EXPERT, TRAIT_ARCYNE)
+				added_traits.Add(TRAIT_ENCHANTING_EXPERT, TRAIT_ALCHEMY_EXPERT, TRAIT_ARCYNE, TRAIT_LEYLINE_ATTUNEMENT)
 				recipient.mind?.special_items["Pestle"] = /obj/item/pestle
 				recipient.mind?.special_items["Mortar"] = /obj/item/reagent_containers/glass/mortar
 				recipient.mind?.special_items["Chalk"] = /obj/item/chalk


### PR DESCRIPTION
## About The Pull Request
local man shoots his own main class: 
- Campfire's stamina buff / healing is now gated if you perform, or had any combat action (I.e. being shot, shooting a spell, using a bow, parry) a combat action in the last 10 seconds.
- Removed the Fire Resistance & Unbreaking enchantment entirely. I was skeptical of the unbreaking enchantment when it was added and now it seems to have become another mandatory toolkit in the arms race caused by us adding more and more vendor gears to enhance your fragging potential. Let this be the first step to dial it back.
- Implemented effective range for spells. Default is 7 - beyond that, damage are halved, and on hit rider effects don't hit. They are still a hazard and still do damage, but long range sniping is no longer ultra deadly, which should makes mage a bit less frustrating as they have to be on screen at least. Consider this intermediary until proper implementation of Mage 3 whenever that come.
- All spells that don't have an explicitly set charge drain now have a default charge drain of 1, reducing mage's ability to zone people out indefinitely with a spell while regenerating stamina
- Separated arcyne skills from access to enchantment. Now it is granted by the LEYLINE ATTUNEMENT TRAIT, granted to anyone with a Minor or Major Aspect of magic OR taking the Enchanter's Apprentice
- Tweak: Tremor is now a charging spell you can hold and release, like I originally intended
- Wand now use the Staves skills to end exploit using Skills + Parry
- Incorporated Ryan's PR to block Thick Blooded, Enduring and Painless from gaining Arcyne Potential
- Spells can no longer be used while stunned, paralyzed, or asleep.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="238" height="325" alt="dreamseeker_WUYO3cAh57" src="https://github.com/user-attachments/assets/df80883b-ffc4-4523-8e67-7e49ff6b4a1b" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Create Campfire is considered rather OP and apparently there's a bunch of people using it by conjuring it and standing next to it in the backline in a hyperwar. So now I am requiring you must lie down to take advantage of it which reduces your mobility and render you vulnerable. 
- The two enchantments either invalidate an entire playstyle (or most of it) and Unbreaking is frankly, a very very bad ideas and I'd like to not see any of those permanent enchantment ever show up again 
- Fighting a kiting mage is frustrating, but it is currently part of their toolkit. This reduce their effectiveness beyond visual range, which is double frustrating to deal with and symmetrical with how ranged attacks has been treated.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Campfire's stamina buff / healing is now gated if you perform, or had any combat action (I.e. being shot, shooting a spell, using a bow, parry) a combat action in the last 10 seconds.
del: Removed the Fire Resistance & Unbreaking enchantment entirely. I was skeptical of the unbreaking enchantment when it was added and now it seems to have become another mandatory toolkit in the arms race caused by us adding more and more vendor gears to enhance your fragging potential. Let this be the first step to dial it back.
add: Implemented effective range for spells. Default is 7 - beyond that, damage are halved, and on hit rider effects don't hit. They are still a hazard and still do damage, but long range sniping is no longer ultra deadly, which should makes mage a bit less frustrating as they have to be on screen at least. Consider this intermediary until proper implementation of Mage 3 whenever that come.
add: All spells that don't have an explicitly set charge drain now have a default charge drain of 1, reducing mage's ability to zone people out indefinitely with a spell while regenerating stamina
tweak: Tremor is now a charging spell you can hold and release, like I originally intended
add: Wand now use the Staves skills to end exploit using Arcane Skills + Parry
add: Incorporated Ryan's PR to block Thick Blooded, Enduring and Painless from gaining Arcyne Potential
add: Spells can no longer be used while stunned, paralyzed, or asleep.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
