### PR TITLE
Allows Constructs to take the 'Underdweller' origin.

### DIFF
--- a/code/modules/virtues/origin.dm
+++ b/code/modules/virtues/origin.dm
@@ -207,6 +207,7 @@
 				/datum/species/anthromorphsmall,
 				/datum/species/dullahan,
 				/datum/species/ooze,
+				/datum/species/construct/metal,
 )
 	origin_desc = "Underdwellers are those who are descendants of their lengthy lineage that settled, lived and toiled in the darkest and deepest \
 	of depths of the vast, deadly Underdark a millennia ago. When one speaks of a 'Underdweller',a dark elf first comes to mynd, though despite them\


### PR DESCRIPTION
## About The Pull Request

Constructs are currently able to be Underdweller-based classes, so I'd imagine they're also supposed to be able to take the Underdweller origin. Simple one-line change.

Nobody seemed to know the answer when I asked on the Discord, so I'm just making the PR assuming it is meant to be like this.

## Testing Evidence

<img width="170" height="107" alt="BXFKYTRSUO" src="https://github.com/user-attachments/assets/3093c38a-3f12-45af-9aae-787ba0806ecb" />
<br>
<img width="400" height="327" alt="0psvbl1TzN" src="https://github.com/user-attachments/assets/6f72fce0-d05f-4975-ade2-5694e3454ee0" />

## Why It's Good For The Game

Consistency is good! If Constructs can be an origin-locked class, surely they should also be able to take the origin itself.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added Construct to the list of races that can take the 'Underdweller' origin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
