### PR TITLE
[Fix] Fixes noc T4 spell to adjust dream points and cooldown per spell

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -318,45 +318,53 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	desc = "Teaches you how to cast Fireball."
 	spell = /datum/action/cooldown/spell/projectile/fireball
 	spellname = "Fireball"
+	dreamcost = 10
 
 /obj/item/book/granter/spell/noc/lbolt
 	name = "Scroll of Lighting Bolt"
 	desc = "Teaches you how to cast Lighting Bolt."
 	spell = /datum/action/cooldown/spell/projectile/lightning_bolt
 	spellname = "Lightning Bolt"
+	dreamcost = 6
 
 /obj/item/book/granter/spell/noc/boulderstrike
 	name = "Scroll of Boulder Strike"
 	desc = "Teaches you how to cast Boulder Strike."
 	spell = /datum/action/cooldown/spell/projectile/boulder_strike
 	spellname = "Boulder Strike"
+	dreamcost = 9
 
 /obj/item/book/granter/spell/noc/message
 	name = "Scroll of Message"
 	desc = "Teaches you how to cast Message."
 	spell = /datum/action/cooldown/spell/message
 	spellname = "Message"
+	dreamcost = 3
 
 /obj/item/book/granter/spell/noc/mindlink
 	name = "Scroll of Mindlink"
 	desc = "Teaches you how to cast Mindlink."
 	spell = /datum/action/cooldown/spell/mindlink
 	spellname = "Mindlink"
+	dreamcost = 4
 
 /obj/item/book/granter/spell/noc/mending
 	name = "Scroll of Mending"
 	desc = "Teaches you how to cast Mending."
 	spell = /datum/action/cooldown/spell/mending
 	spellname = "Mending"
+	dreamcost = 5
 
 /obj/item/book/granter/spell/noc/blink
 	name = "Scroll of Blink"
 	desc = "Teaches you how to cast Blink."
 	spell = /datum/action/cooldown/spell/blink
 	spellname = "Blink"
+	dreamcost = 8
 
 /obj/item/book/granter/spell/noc/repulse
 	name = "Scroll of Repulse"
 	desc = "Teaches you how to cast Repulse."
 	spell = /datum/action/cooldown/spell/repulse
 	spellname = "Repulse"
+	dreamcost = 6

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -554,12 +554,13 @@
 	invocations = list("Deepest dreaming, scribe!")
 
 	charge_required = FALSE
-	cooldown_time = 45 MINUTES
+	cooldown_time = 1 MINUTES
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
 	var/points_need = 10
 	var/alreadychoosing = FALSE
+	var/last_dreamcost = 0
 
 /datum/action/cooldown/spell/noc/grimoire/cast(mob/living/carbon/human/user)
 	if(alreadychoosing)
@@ -569,13 +570,11 @@
 	alreadychoosing = TRUE
 
 	. = ..()
-	// commentened out until someone fixes the cooldown code. 
-	/*
+
 	if(GLOB.tod == "day" || GLOB.tod == "dawn")
 		to_chat(user, span_warning("ASTRATA IS RISEN! MY SPELL FIZZLES!"))
-		revert_cast()
 		alreadychoosing = FALSE
-		return FALSE*/
+		return FALSE
 
 	var/feather_check = FALSE
 
@@ -646,17 +645,23 @@
 		for(var/obj/item/burn in books_burnt)
 			new /obj/effect/temp_visual/moon/spell(get_turf(burn))
 			qdel(burn)
-		user.mind.sleep_adv.sleep_adv_points -= item.dreamcost
-/*		if(item.dreamcost == 3) // this doesnt fucking work. our code doesnt allow for custom recharges to be done 
-			cooldown_time = 5 MINUTES // in any convenient way. if you want to fix this later try using a status_effect
-		if(item.dreamcost == 6) // secondary charge system instead of this shit. 
-			cooldown_time = 15 MINUTES // kept in so the intent is understood.
-		if(item.dreamcost >= 9)
-			cooldown_time = 30 MINUTES*/
+		last_dreamcost = item.dreamcost
+		user.mind.sleep_adv.sleep_adv_points -= last_dreamcost
 		var/obj/item/I = new item (get_turf(user))
 		user.put_in_hands(I)
 		alreadychoosing = FALSE
 		return TRUE
+
+/datum/action/cooldown/spell/noc/grimoire/get_adjusted_cooldown()
+	switch(last_dreamcost)
+		if(-INFINITY to 2)
+			return 1 MINUTES
+		if(3 to 5)
+			return 5 MINUTES
+		if(6 to 8)
+			return 15 MINUTES
+		if(9 to INFINITY)
+			return 30 MINUTES
 
 /obj/effect/temp_visual/moon/spell
 	icon_state = "spellwarning"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Restores the functionality the T4 noc spell had, making the scrolls that only those with holy and reading expert can use, adjusting their (totally arbitrary) dream cost and giving it a cooldown different per spell used.

It also restores their intended functionality of not being able to cast this during the day and dawn.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="437" height="297" alt="image" src="https://github.com/user-attachments/assets/d2e8f5cb-8d18-4e20-b6ad-330eb6df66cd" />

<img width="544" height="345" alt="image" src="https://github.com/user-attachments/assets/b43c8fc0-12e8-432a-9c15-195d4a1fe649" />

<img width="527" height="327" alt="image" src="https://github.com/user-attachments/assets/55b9e8a3-526d-4b66-915d-c0468c237abf" />

<img width="551" height="679" alt="image" src="https://github.com/user-attachments/assets/b7077075-b965-401a-8ed7-aa07036ea4c0" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Restores T4 Noc's spell scroll crafting functionality. It has a variable dream point and cooldown now, cannot be used during day, but can create more than it used to (probably requires buff/nerf but this was a restore of functionality.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
