### PR TITLE
that's not a drakkyn

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/voiddragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/voiddragon.dm
@@ -60,7 +60,7 @@ It will also call down lightning strikes from the sky, and fling people with it'
 	..()
 
 /mob/living/simple_animal/hostile/retaliate/rogue/voiddragon
-	name = "void dragon"
+	name = "void drake"
 	desc = "An ancient creature from a bygone age. Now would be a good time to run."
 	health = 5000
 	maxHealth = 5000

--- a/code/modules/roguetown/roguejobs/mages/rituals/summons.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/summons.dm
@@ -344,7 +344,7 @@
 // Only powerful leylines (Bog) have max_tier = 5, so it can only be performed there.
 
 /datum/runeritual/summoning/leyline_encounter/void_dragon
-	name = "Supreme Ritual of Void Dragon Calling"
+	name = "Supreme Ritual of Void Drake Calling"
 	desc = "Tear open the deepest layer of the veil, reaching beyond all planes. There is only one thing that dwells there. Requires a confluence of power from all three realms."
 	blacklisted = FALSE
 	tier = 5
@@ -360,7 +360,7 @@
 
 /datum/runeritual/summoning/leyline_encounter/void_dragon/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	if(GLOB.dayspassed < 4)
-		to_chat(user, span_warning("The veil is not yet thin enough for such a ritual. The void dragon can only be called later in the week."))
+		to_chat(user, span_warning("The veil is not yet thin enough for such a ritual. The void drake can only be called later in the week."))
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
renames the void drake, because we should not have anything called a drakkyn/dragon that isn't immediately clarified to not be one like drakkyn aspirants are in their desc

## Testing Evidence
text change

## Why It's Good For The Game
people keep getting confused by this
