### PR TITLE
[Keeper] allows keepers to be revenants

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/keeper.dm
+++ b/code/modules/jobs/job_types/roguetown/church/keeper.dm
@@ -6,7 +6,6 @@
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
-	forbidden_races = list(RACES_DESPISED)
 	allowed_ages = ALL_AGES_LIST
 	allowed_patrons = list(/datum/patron/divine/pestra)
 


### PR DESCRIPTION
## About The Pull Request
- Allows keepers to be revenants

## Testing Evidence
One line change

## Why It's Good For The Game
When dullahans were added they were sort of blanket banned from most roles. Keepers are monastic outcasts, if anywhere there would be shunned freeks, it's in the sanctum.

## Changelog

:cl:
add: Keepers can now be revenants
/:cl:
