### PR TITLE
Marks the center tile of the admin event area (non multiz one) for quick and easy maploading

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -811,15 +811,9 @@
 /obj/structure/fluff/pillow/green,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/shelter/bog_hag)
-"es" = (
-/turf/open/floor/rogue/shroud/hag,
-/area/rogue/indoors/eventarea)
 "ex" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/lich_start)
-"eB" = (
-/turf/open/floor/rogue/underworld/space/dense,
-/area/rogue/indoors/eventarea)
 "eD" = (
 /obj/machinery/light/rogue/candle/blue/l,
 /obj/structure/stairs{
@@ -845,9 +839,6 @@
 /obj/item/ash,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start/lich_lair)
-"fu" = (
-/turf/open/floor/rogue/blocks/bluestone,
-/area/rogue/indoors/eventarea)
 "fy" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/churchbrick,
@@ -866,9 +857,6 @@
 /obj/structure/flora/tinymushrooms,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/lich_start/lich_lair)
-"fQ" = (
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/eventarea)
 "fY" = (
 /obj/effect/landmark/deaths_door/entry/br,
 /turf/open/floor/rogue/underworld/road,
@@ -889,9 +877,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start/lich_lair)
-"gm" = (
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/indoors/eventarea)
 "gw" = (
 /obj/structure/bars/pipe{
 	dir = 9;
@@ -956,16 +941,10 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start)
-"hX" = (
-/turf/open/floor/rogue/sand,
-/area/rogue/indoors/eventarea)
 "ij" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors)
-"im" = (
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/eventarea)
 "iw" = (
 /obj/effect/decal/remains/crow,
 /turf/open/floor/rogue/dirt/road,
@@ -1037,22 +1016,10 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/lich_start/lich_lair)
-"jc" = (
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/eventarea)
 "jk" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/bog_hag)
-"jn" = (
-/turf/open/floor/rogue/rooftop/north,
-/area/rogue/indoors/eventarea)
-"jr" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/eventarea)
-"jz" = (
-/turf/open/floor/rogue/carpet/lord/left,
-/area/rogue/indoors/eventarea)
 "jB" = (
 /obj/structure/fluff/statue/femalestatue/zizo{
 	pixel_x = -28
@@ -1069,9 +1036,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/lich_start/lich_lair)
-"jG" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors/eventarea)
 "jH" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -1128,15 +1092,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/lich_start)
-"ki" = (
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/eventarea)
-"kk" = (
-/turf/open/floor/rogue/blocks/paving/vert,
-/area/rogue/indoors/eventarea)
-"kp" = (
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/eventarea)
 "ks" = (
 /obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
@@ -1147,9 +1102,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/lich_start/lich_lair)
-"kE" = (
-/turf/open/floor/rogue/snowrough,
-/area/rogue/indoors/eventarea)
 "kF" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -1180,9 +1132,6 @@
 /obj/structure/fluff/ravox/challenged,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/ravoxarena)
-"ls" = (
-/turf/open/floor/rogue/greenstone/glyph5,
-/area/rogue/indoors/eventarea)
 "lw" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue)
@@ -1204,9 +1153,6 @@
 /obj/item/leechtick,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/bog_hag)
-"lJ" = (
-/turf/open/floor/rogue/volcanic,
-/area/rogue/indoors/eventarea)
 "lR" = (
 /obj/item/hag_catalyst/varnish_base,
 /turf/open/floor/rogue/shroud/hag,
@@ -1215,9 +1161,6 @@
 /obj/structure/roguemachine/mazeroot,
 /turf/open/floor/rogue/shroud/hag,
 /area/rogue/indoors/shelter/bog_hag/root_maze)
-"mg" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/eventarea)
 "mj" = (
 /obj/structure/ritualcircle/zizo,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -1230,9 +1173,6 @@
 /obj/structure/deaths_door_shrine,
 /turf/open/floor/rogue/underworld/road,
 /area/rogue/indoors/deathsedge)
-"mt" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/eventarea)
 "mw" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/eventarea)
@@ -1263,9 +1203,6 @@
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/bog_hag)
-"mN" = (
-/turf/open/floor/rogue/snowpatchy,
-/area/rogue/indoors/eventarea)
 "mY" = (
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/food/snacks/butterslice,
@@ -1327,10 +1264,6 @@
 /obj/item/rogueweapon/sword/cutlass,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
-"ob" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/eventarea)
 "oe" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1339,15 +1272,9 @@
 /obj/effect/spawner/lootdrop/hag/raw_botanicals,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/bog_hag)
-"oo" = (
-/turf/open/floor/rogue/blocks/flipped,
-/area/rogue/indoors/eventarea)
 "op" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/underworld/dream)
-"ou" = (
-/turf/open/floor/rogue/rooftop/green/corner1/direight,
-/area/rogue/indoors/eventarea)
 "ox" = (
 /obj/effect/decal/cleanable/dreamfiend_ichor/huge{
 	pixel_x = -17;
@@ -1361,9 +1288,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/underworld/dream)
-"oy" = (
-/turf/open/floor/rogue/rooftop/east,
-/area/rogue/indoors/eventarea)
 "oA" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 4
@@ -1372,9 +1296,6 @@
 /obj/item/ash,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start)
-"oC" = (
-/turf/open/floor/rogue/tile/masonic/single,
-/area/rogue/indoors/eventarea)
 "oE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -1397,18 +1318,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/bog_hag)
-"oO" = (
-/turf/open/floor/rogue/rooftop/green/corner1/dirten,
-/area/rogue/indoors/eventarea)
 "oY" = (
 /obj/structure/stairs/fancy/c{
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/lich_start/lich_lair)
-"pe" = (
-/turf/open/floor/rogue/greenstone/runed,
-/area/rogue/indoors/eventarea)
 "pl" = (
 /turf/open/floor/rogue/shroud/hag,
 /area/rogue/indoors/shelter/bog_hag)
@@ -1447,9 +1362,6 @@
 "pJ" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/lich_start/lich_lair)
-"pN" = (
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/eventarea)
 "pO" = (
 /obj/structure/flora/roguetree/stump/burnt,
 /turf/open/floor/rogue/dirt,
@@ -1467,22 +1379,10 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter/bog_hag)
-"qi" = (
-/turf/open/floor/rogue/concrete/bronze,
-/area/rogue/indoors/eventarea)
 "ql" = (
 /obj/structure/table/wood/long_table/mid/alt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/bog_hag)
-"qx" = (
-/turf/open/floor/rogue/underworld/road,
-/area/rogue/indoors/eventarea)
-"qC" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/eventarea)
-"qD" = (
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/eventarea)
 "qG" = (
 /obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
@@ -1526,9 +1426,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/shroud/hag,
 /area/rogue/indoors/shelter/bog_hag)
-"rw" = (
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/eventarea)
 "rz" = (
 /obj/structure/fluff/ravox/challenger,
 /turf/open/floor/rogue/blocks,
@@ -1546,9 +1443,6 @@
 /obj/structure/fluff/statue/knight,
 /turf/open/water/pond,
 /area/rogue/indoors/ravoxarena)
-"rK" = (
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/eventarea)
 "rL" = (
 /obj/structure/fluff/railing/border/east,
 /obj/structure/fluff/railing/border,
@@ -1557,9 +1451,6 @@
 "rQ" = (
 /turf/closed,
 /area/rogue)
-"rR" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/eventarea)
 "rV" = (
 /obj/structure/roguemachine/mossmother/travel,
 /turf/open/floor/rogue/grass,
@@ -1574,9 +1465,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/bog_hag)
-"rX" = (
-/turf/open/floor/rogue/greenstone/glyph6,
-/area/rogue/indoors/eventarea)
 "rZ" = (
 /turf/open/floor/rogue/dark_ice,
 /area/rogue/underworld/dream)
@@ -1587,9 +1475,6 @@
 /obj/effect/landmark/underworldstrands,
 /turf/open/floor/rogue/underworld/road,
 /area/rogue/indoors/deathsedge)
-"sp" = (
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/eventarea)
 "st" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start/lich_lair)
@@ -1618,9 +1503,6 @@
 /obj/item/rogueweapon/halberd/glaive,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
-"sU" = (
-/turf/open/floor/rogue/rooftop/green/east,
-/area/rogue/indoors/eventarea)
 "sZ" = (
 /obj/structure/table/wood/long_table/right,
 /obj/item/cooking/platter,
@@ -1643,9 +1525,6 @@
 /obj/structure/flora/mushroomcluster,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/lich_start/lich_lair)
-"th" = (
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/eventarea)
 "ts" = (
 /obj/effect/landmark/deaths_door/entry/tr,
 /turf/open/floor/rogue/underworld/road,
@@ -1699,9 +1578,6 @@
 	},
 /turf/open/floor/rogue/shroud/hag,
 /area/rogue/indoors/shelter/bog_hag)
-"tV" = (
-/turf/open/floor/rogue/rooftop/green/north,
-/area/rogue/indoors/eventarea)
 "ue" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -1709,9 +1585,6 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start/lich_lair)
-"uj" = (
-/turf/open/floor/rogue/greenstone/glyph1,
-/area/rogue/indoors/eventarea)
 "ur" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/bog_hag)
@@ -1782,9 +1655,6 @@
 /obj/item/rogueweapon/halberd,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
-"vo" = (
-/turf/open/floor/rogue/ruinedwood/chevron,
-/area/rogue/indoors/eventarea)
 "vq" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -1858,9 +1728,6 @@
 "wO" = (
 /turf/closed,
 /area/rogue/outdoors)
-"wZ" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/eventarea)
 "xe" = (
 /obj/structure/fluff/psycross/zizocross/golden,
 /obj/effect/decal/cleanable/dirt/cobweb{
@@ -1875,9 +1742,6 @@
 /obj/item/roguecoin/aalloy/pile,
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/lich_start/lich_lair)
-"xg" = (
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/indoors/eventarea)
 "xi" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue)
@@ -1945,9 +1809,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/lich_start/lich_lair)
-"yd" = (
-/turf/open/floor/rogue/rooftop/green/corner1/dirnine,
-/area/rogue/indoors/eventarea)
 "yh" = (
 /obj/structure/underworld/carriageman,
 /turf/open/floor/rogue/underworld/road,
@@ -1975,12 +1836,6 @@
 "yv" = (
 /turf/closed/wall/shroud/hag,
 /area/rogue/indoors/shelter/bog_hag/root_maze)
-"yA" = (
-/turf/open/floor/rogue/underworld/space/quiet/dense,
-/area/rogue/indoors/eventarea)
-"yB" = (
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/eventarea)
 "yI" = (
 /obj/structure/mannequin/male/decorative/training_dummy_style,
 /obj/item/clothing/suit/roguetown/armor/plate/cuirass/aalloy,
@@ -2059,9 +1914,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/bog_hag)
-"zL" = (
-/turf/open/floor/rogue/rooftop/green/corner1/dirsix,
-/area/rogue/indoors/eventarea)
 "zP" = (
 /obj/structure/fluff/walldeco/psybanner/zizo,
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
@@ -2071,9 +1923,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/lich_start/lich_lair)
-"zV" = (
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/eventarea)
 "zY" = (
 /obj/effect/decal/cleanable/dreamfiend_ichor/large{
 	pixel_x = 1;
@@ -2081,6 +1930,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/underworld/dream)
+"zZ" = (
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/indoors/eventarea)
 "Aa" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -2142,25 +1996,16 @@
 "AU" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors)
-"AV" = (
-/turf/open/floor/rogue/rooftop,
-/area/rogue/indoors/eventarea)
 "Bg" = (
 /obj/structure/flagpole,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/lich_start/lich_lair)
-"By" = (
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/indoors/eventarea)
 "BC" = (
 /obj/item/natural/bundle/fibers/full{
 	pixel_x = 13
 	},
 /turf/open/floor/rogue/shroud/hag,
 /area/rogue/indoors/shelter/bog_hag)
-"BG" = (
-/turf/open/floor/rogue/greenstone/glyph3,
-/area/rogue/indoors/eventarea)
 "BH" = (
 /turf/closed/wall/mineral/rogue/stone/red_moss,
 /area/rogue/indoors/lich_start/lich_lair)
@@ -2207,9 +2052,6 @@
 "CL" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/lich_start/lich_lair)
-"CQ" = (
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/eventarea)
 "CX" = (
 /obj/effect/hag_teleport_marker,
 /turf/open/floor/rogue/shroud/hag,
@@ -2279,9 +2121,6 @@
 /obj/effect/landmark/deaths_door/entry/bl,
 /turf/open/floor/rogue/underworld/road,
 /area/rogue/indoors/deathsedge)
-"DL" = (
-/turf/open/floor/rogue/snow,
-/area/rogue/indoors/eventarea)
 "DY" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/dirt,
@@ -2370,15 +2209,6 @@
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start/lich_lair)
-"EX" = (
-/turf/open/floor/rogue/carpet/lord/center,
-/area/rogue/indoors/eventarea)
-"Fb" = (
-/turf/open/floor/rogue/greenstone,
-/area/rogue/indoors/eventarea)
-"Fd" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/eventarea)
 "Ff" = (
 /obj/structure/bars/pipe{
 	dir = 4
@@ -2437,9 +2267,6 @@
 /obj/effect/spawner/lootdrop/hag/raw_botanicals,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/bog_hag)
-"Gl" = (
-/turf/open/floor/rogue/metal/barograte/open,
-/area/rogue/indoors/eventarea)
 "Gp" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/naturalstone,
@@ -2469,9 +2296,6 @@
 /obj/structure/bars/tough,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/lich_start/lich_lair)
-"GP" = (
-/turf/open/floor/rogue/blocks/newstone/alt,
-/area/rogue/indoors/eventarea)
 "GT" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/landmark/start/lich,
@@ -2481,9 +2305,6 @@
 /obj/effect/landmark/start/hag,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/bog_hag)
-"He" = (
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/eventarea)
 "Hf" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/lich_start/lich_lair)
@@ -2503,9 +2324,6 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start/lich_lair)
-"Hy" = (
-/turf/open/floor/rogue/tile/masonic/spiral,
-/area/rogue/indoors/eventarea)
 "HA" = (
 /obj/structure/stairs/stone,
 /obj/structure/fluff/railing/border/west,
@@ -2522,18 +2340,6 @@
 /obj/effect/landmark/underworldstrands,
 /turf/open/floor/rogue/underworld/road,
 /area/rogue/indoors/deathsedge)
-"HL" = (
-/turf/open/floor/rogue/underworld/space/sparkle_quiet/dense,
-/area/rogue/indoors/eventarea)
-"HN" = (
-/turf/open/floor/rogue/rooftop/green/corner1,
-/area/rogue/indoors/eventarea)
-"HP" = (
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/indoors/eventarea)
-"HT" = (
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/eventarea)
 "HV" = (
 /obj/item/kitchen/spoon/aalloy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2583,9 +2389,6 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start)
-"IE" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/eventarea)
 "IL" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/lich_start/lich_lair)
@@ -2674,9 +2477,6 @@
 	},
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/lich_start/lich_lair)
-"Jx" = (
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/indoors/eventarea)
 "JA" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2704,9 +2504,6 @@
 "JM" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/underworld/dream)
-"JQ" = (
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/eventarea)
 "Kc" = (
 /obj/structure/table/vtable/v2,
 /obj/machinery/light/rogue/candle/floorcandle/alt,
@@ -2737,9 +2534,6 @@
 /obj/structure/fluff/railing/corner/south_east,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/lich_start/lich_lair)
-"KD" = (
-/turf/open/floor/rogue/rooftop/green/corner1/dirfour,
-/area/rogue/indoors/eventarea)
 "KG" = (
 /obj/structure/fluff/walldeco/psybanner/zizo{
 	pixel_x = 2
@@ -2810,15 +2604,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/lich_start/lich_lair)
-"Mm" = (
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/eventarea)
-"Mo" = (
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/eventarea)
-"Mt" = (
-/turf/open/floor/rogue/carpet/lord/right,
-/area/rogue/indoors/eventarea)
 "MB" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/churchbrick,
@@ -2851,9 +2636,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/lich_start/lich_lair)
-"Nh" = (
-/turf/open/floor/rogue/hay,
-/area/rogue/indoors/eventarea)
 "Ni" = (
 /obj/structure/vine,
 /turf/open/floor/rogue/dirt,
@@ -2975,9 +2757,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/bog_hag)
-"OM" = (
-/turf/open/floor/rogue/rooftop/green/west,
-/area/rogue/indoors/eventarea)
 "OO" = (
 /obj/structure/chair/wood/rogue{
 	can_buckle = 0;
@@ -3011,9 +2790,6 @@
 "Ph" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
-"Ps" = (
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/eventarea)
 "Pu" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/glass/cup/aalloygob{
@@ -3030,9 +2806,6 @@
 /obj/effect/spawner/lootdrop/hag/wyrd_artifacts,
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/bog_hag)
-"PP" = (
-/turf/open/floor/rogue/greenstone/glyph2,
-/area/rogue/indoors/eventarea)
 "PQ" = (
 /obj/item/kitchen/fork/aalloy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -3041,9 +2814,6 @@
 /obj/item/ash,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/lich_start/lich_lair)
-"Qb" = (
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/eventarea)
 "Qc" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start)
@@ -3067,20 +2837,11 @@
 /obj/structure/roguerock,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/lich_start/lich_lair)
-"Qy" = (
-/obj/structure/fluff/customsign{
-	name = "EXAMPLE TILES"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/eventarea)
 "Qz" = (
 /obj/effect/decal/remains/bear,
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/underworld/dream)
-"QE" = (
-/turf/open/floor/rogue/rooftop/green/corner1/dirone,
-/area/rogue/indoors/eventarea)
 "QF" = (
 /obj/structure/chair/wood/rogue{
 	can_buckle = 0;
@@ -3112,18 +2873,12 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/underworld/dream)
-"Rb" = (
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/eventarea)
 "Rd" = (
 /obj/structure/ritualcircle/zizo{
 	icon_state = "zizo_active"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/lich_start/lich_lair)
-"Ro" = (
-/turf/open/floor/rogue/rooftop/west,
-/area/rogue/indoors/eventarea)
 "Ry" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/grasscold,
@@ -3146,10 +2901,6 @@
 /obj/item/cooking/platter/aalloy,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start)
-"RV" = (
-/obj/structure/fluff/traveltile/eventarea,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/eventarea)
 "RX" = (
 /turf/closed/indestructible/riveted,
 /area/start)
@@ -3178,12 +2929,6 @@
 /obj/structure/fluff/walldeco/rpainting/crown,
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/lich_start/lich_lair)
-"Sv" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/eventarea)
-"Sz" = (
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/eventarea)
 "SB" = (
 /obj/item/kitchen/spoon/aalloy{
 	pixel_x = 8;
@@ -3264,9 +3009,6 @@
 /obj/machinery/light/rogue/candle,
 /turf/closed,
 /area/rogue)
-"TU" = (
-/turf/open/floor/rogue/grassyel,
-/area/rogue/indoors/eventarea)
 "TZ" = (
 /obj/machinery/light/rogue/candle/blue,
 /obj/structure/bars/pipe{
@@ -3301,12 +3043,6 @@
 "Uf" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/underworld/dream)
-"Ui" = (
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/eventarea)
-"Up" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/eventarea)
 "Ut" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -3319,9 +3055,6 @@
 /obj/structure/bed/rogue/inn/wool,
 /turf/open/floor/rogue/concrete,
 /area/rogue/underworld/dream)
-"UK" = (
-/turf/open/floor/rogue/grasscold,
-/area/rogue/indoors/eventarea)
 "US" = (
 /obj/item/reagent_containers/glass/bottle/rogue{
 	pixel_x = 12;
@@ -3394,9 +3127,6 @@
 /obj/machinery/light/rogue/candle/floorcandle,
 /turf/open/floor/rogue/concrete,
 /area/rogue/underworld/dream)
-"VN" = (
-/turf/open/floor/rogue/blocks/paving,
-/area/rogue/indoors/eventarea)
 "VS" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors)
@@ -3414,9 +3144,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/bog_hag)
-"Wm" = (
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/eventarea)
 "Wo" = (
 /obj/structure/fluff/railing/border/north,
 /obj/effect/decal/edge{
@@ -3425,9 +3152,6 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/lich_start)
-"Wr" = (
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/eventarea)
 "Xd" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/churchbrick,
@@ -3512,9 +3236,6 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/lich_start/lich_lair)
-"Yn" = (
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/indoors/eventarea)
 "Yr" = (
 /obj/machinery/light/rogue/candle/blue/r,
 /obj/structure/stairs{
@@ -3557,9 +3278,6 @@
 /obj/item/cooking/platter,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/bog_hag)
-"Zn" = (
-/turf/open/floor/rogue/blocks/newstone,
-/area/rogue/indoors/eventarea)
 "Zr" = (
 /obj/structure/table/wood/long_table/mid/alt,
 /obj/item/reagent_containers/powder/flour,
@@ -3582,9 +3300,6 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/lich_start/lich_lair)
-"ZK" = (
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/eventarea)
 "ZL" = (
 /obj/structure/flora/tinymushrooms,
 /turf/open/floor/rogue/dirt,
@@ -3612,9 +3327,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/bog_hag)
-"ZZ" = (
-/turf/open/floor/rogue/greenstone/glyph4,
-/area/rogue/indoors/eventarea)
 
 (1,1,1) = {"
 rQ
@@ -6125,94 +5837,94 @@ MY
 MY
 MY
 FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+mw
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -6255,7 +5967,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -6299,6 +6010,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -6331,18 +6043,18 @@ Gx
 Gx
 Gx
 Gx
-rX
-ls
-ZZ
-BG
-PP
-uj
-Fb
-He
-Fd
-qD
-rK
-kp
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -6385,7 +6097,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -6429,6 +6140,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -6463,16 +6175,16 @@ Gx
 Gx
 Gx
 Gx
-AV
-jn
-sU
-rR
-pe
-Ui
-Ps
-jz
-jc
-Sz
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -6515,7 +6227,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -6559,6 +6270,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -6593,16 +6305,16 @@ Gx
 Gx
 Gx
 Gx
-oy
-Ro
-tV
-vo
-Nh
-qi
-Up
-EX
-Qb
-zV
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -6645,7 +6357,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -6720,19 +6431,20 @@ Gx
 Gx
 Gx
 Gx
-ob
 Gx
 Gx
-lJ
-zL
-OM
-pN
-jr
-Sv
-fQ
-Mt
-Mo
-ZK
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -6775,7 +6487,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -6852,17 +6563,18 @@ Gx
 Gx
 Gx
 Gx
-DL
-jG
-oO
-xg
-gm
 Gx
-mg
-Jx
-qC
-By
-JQ
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -6905,7 +6617,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -6980,19 +6691,20 @@ Gx
 Gx
 Gx
 Gx
-Qy
 Gx
-mN
-th
-eB
-HN
-mt
-mw
-UK
-rw
-CQ
-Wr
-oC
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -7035,7 +6747,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -7112,17 +6823,18 @@ Gx
 Gx
 Gx
 Gx
-kE
-wZ
-yA
-ou
-Mm
-Sn
-Wm
-kk
-oo
-IE
-Hy
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -7165,7 +6877,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -7240,19 +6951,20 @@ Gx
 Gx
 Gx
 Gx
-ob
 Gx
-HT
-ki
-HL
-jG
-hX
-Gl
-TU
-VN
-Yn
-fu
-FY
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -7295,7 +7007,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -7372,17 +7083,18 @@ Gx
 Gx
 Gx
 Gx
-im
-im
-qx
-KD
-es
-Rb
-yB
-GP
-Zn
-FY
-FY
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -7425,7 +7137,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -7505,14 +7216,15 @@ Gx
 Gx
 Gx
 Gx
-yd
-DL
-eB
-HP
-sp
-FY
-FY
-FY
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -7555,7 +7267,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -7635,14 +7346,15 @@ Gx
 Gx
 Gx
 Gx
-QE
-mN
-yA
-qx
-FY
-FY
-FY
-FY
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -7685,7 +7397,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -7772,7 +7483,8 @@ Gx
 Gx
 Gx
 Gx
-RV
+Gx
+Gx
 FY
 rQ
 "}
@@ -7815,7 +7527,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -7902,7 +7613,8 @@ Gx
 Gx
 Gx
 Gx
-RV
+Gx
+Gx
 FY
 rQ
 "}
@@ -7945,7 +7657,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -8032,7 +7743,8 @@ Gx
 Gx
 Gx
 Gx
-RV
+Gx
+Gx
 FY
 rQ
 "}
@@ -8075,7 +7787,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -8162,7 +7873,8 @@ Gx
 Gx
 Gx
 Gx
-RV
+Gx
+Gx
 FY
 rQ
 "}
@@ -8205,7 +7917,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -8292,7 +8003,8 @@ Gx
 Gx
 Gx
 Gx
-RV
+Gx
+Gx
 FY
 rQ
 "}
@@ -8335,7 +8047,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -8422,7 +8133,8 @@ Gx
 Gx
 Gx
 Gx
-RV
+Gx
+Gx
 FY
 rQ
 "}
@@ -8465,7 +8177,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -8549,10 +8260,11 @@ Gx
 Gx
 Gx
 Gx
-FY
-FY
-FY
-FY
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -8595,7 +8307,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -8680,9 +8391,10 @@ Gx
 Gx
 Gx
 Gx
-FY
-FY
-FY
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -8725,7 +8437,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -8811,8 +8522,9 @@ Gx
 Gx
 Gx
 Gx
-FY
-FY
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -8855,7 +8567,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -8942,7 +8653,8 @@ Gx
 Gx
 Gx
 Gx
-FY
+Gx
+Gx
 FY
 rQ
 "}
@@ -8985,7 +8697,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -9030,6 +8741,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -9115,7 +8827,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -9160,6 +8871,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -9245,7 +8957,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -9290,6 +9001,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -9375,7 +9087,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -9420,6 +9131,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -9505,7 +9217,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -9550,6 +9261,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -9635,7 +9347,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -9680,6 +9391,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -9765,7 +9477,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -9810,6 +9521,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -9895,7 +9607,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -9940,6 +9651,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -10025,7 +9737,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -10070,6 +9781,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -10155,7 +9867,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -10200,6 +9911,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -10285,7 +9997,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -10330,6 +10041,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -10415,7 +10127,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -10460,6 +10171,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -10545,7 +10257,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -10590,6 +10301,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -10675,7 +10387,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -10720,6 +10431,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -10805,7 +10517,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -10850,6 +10561,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -10935,7 +10647,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -10980,6 +10691,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -11065,7 +10777,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -11110,6 +10821,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -11195,7 +10907,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -11240,6 +10951,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -11325,7 +11037,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -11370,6 +11081,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -11455,7 +11167,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -11500,6 +11211,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -11585,7 +11297,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -11630,6 +11341,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -11715,7 +11427,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -11760,6 +11471,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -11845,7 +11557,6 @@ MY
 MY
 MY
 FY
-FY
 Gx
 Gx
 Gx
@@ -11890,6 +11601,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -11975,7 +11687,6 @@ AU
 AU
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -12020,6 +11731,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -12105,7 +11817,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -12150,6 +11861,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -12235,7 +11947,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -12280,6 +11991,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -12365,7 +12077,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -12410,6 +12121,7 @@ Gx
 Gx
 Gx
 mw
+Gx
 Gx
 Gx
 Gx
@@ -12495,94 +12207,94 @@ VS
 VS
 AU
 FY
-FY
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-mw
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
-Gx
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+Sn
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
+zZ
 FY
 rQ
 "}
@@ -12625,51 +12337,51 @@ VS
 VS
 AU
 FY
-FY
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-mw
-Sn
+Gx
 Gx
 Gx
 Gx
@@ -12755,7 +12467,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -12799,6 +12510,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -12885,7 +12597,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -12929,6 +12640,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -13015,7 +12727,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -13059,6 +12770,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -13145,7 +12857,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -13189,6 +12900,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -13275,7 +12987,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -13319,6 +13030,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -13405,7 +13117,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -13449,6 +13160,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -13535,7 +13247,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -13579,6 +13290,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -13665,7 +13377,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -13709,6 +13420,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -13795,7 +13507,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -13839,6 +13550,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -13925,7 +13637,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -13969,6 +13680,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -14055,7 +13767,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -14099,6 +13810,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -14185,7 +13897,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -14229,6 +13940,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -14315,7 +14027,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -14359,6 +14070,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -14445,7 +14157,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -14489,6 +14200,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -14575,7 +14287,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -14619,6 +14330,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -14705,7 +14417,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -14749,6 +14460,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -14835,7 +14547,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -14879,6 +14590,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -14965,7 +14677,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -15009,6 +14720,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -15095,7 +14807,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -15139,6 +14850,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -15225,7 +14937,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -15269,6 +14980,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -15355,7 +15067,6 @@ VS
 VS
 AU
 FY
-FY
 Gx
 Gx
 Gx
@@ -15399,6 +15110,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -15484,7 +15196,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -15529,6 +15240,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -15614,7 +15326,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -15659,6 +15370,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -15744,7 +15456,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -15789,6 +15500,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -15874,7 +15586,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -15919,6 +15630,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -16004,7 +15716,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -16049,6 +15760,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -16134,7 +15846,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -16179,6 +15890,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -16264,7 +15976,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -16309,6 +16020,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -16394,7 +16106,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -16439,6 +16150,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -16524,7 +16236,6 @@ VS
 VS
 VS
 AU
-bX
 FY
 Gx
 Gx
@@ -16569,6 +16280,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -16654,7 +16366,6 @@ AU
 AU
 AU
 AU
-bX
 FY
 Gx
 Gx
@@ -16699,6 +16410,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -16784,7 +16496,6 @@ MY
 MY
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -16829,6 +16540,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -16914,7 +16626,6 @@ MY
 MY
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -16959,6 +16670,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -17044,7 +16756,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -17089,6 +16800,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -17174,7 +16886,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -17219,6 +16930,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -17304,7 +17016,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -17349,6 +17060,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -17434,7 +17146,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -17479,6 +17190,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -17564,7 +17276,6 @@ ca
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -17609,6 +17320,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -17694,7 +17406,6 @@ ca
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -17739,6 +17450,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -17824,7 +17536,6 @@ op
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -17869,6 +17580,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -17954,7 +17666,6 @@ Ko
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -17999,6 +17710,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -18084,7 +17796,6 @@ Ry
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -18129,6 +17840,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -18214,7 +17926,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -18259,6 +17970,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -18344,7 +18056,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -18389,6 +18100,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -18474,7 +18186,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -18519,6 +18230,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -18604,7 +18316,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -18649,6 +18360,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -18734,7 +18446,6 @@ bX
 bX
 MY
 MY
-bX
 FY
 Gx
 Gx
@@ -18779,6 +18490,7 @@ Gx
 Gx
 Gx
 Gx
+mw
 Gx
 Gx
 Gx
@@ -18864,95 +18576,95 @@ QQ
 bX
 MY
 MY
-bX
 FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
-FY
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+mw
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
+Gx
 FY
 rQ
 "}
@@ -18994,95 +18706,95 @@ Oh
 bX
 MY
 MY
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
-bX
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
+FY
 FY
 rQ
 "}


### PR DESCRIPTION
## About The Pull Request

Title

## Testing Evidence

Booted server, placed a map insert where I put the center tile. It was the center tile

## Why It's Good For The Game

Makes it so u dont have to find the center tile everytime

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:SpartanBobby
map: Marks the center tile of the admin event area (non multiz one) for quick and easy maploading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
