### PR TITLE
Zizonic Emote-Equality Lawes - 1513 AP

### DIFF
--- a/code/modules/mob/living/carbon/human/voicepacks/other/lich.dm
+++ b/code/modules/mob/living/carbon/human/voicepacks/other/lich.dm
@@ -33,6 +33,12 @@
 			used = list('sound/vo/blink.ogg')
 		if("stomp")
 			used = list('sound/foley/brickdrop.ogg')
+		if("salute")
+			used = 'sound/vo/salute.ogg'
+		if("crack")
+			used = 'sound/vo/knuckles.ogg'
+		if("facepalm")
+			used = list('sound/vo/facepalm1.ogg', 'sound/vo/facepalm2.ogg')
 	if(!used)
 		used = ..(soundin, modifiers)
 	return used

--- a/code/modules/mob/living/carbon/human/voicepacks/other/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/voicepacks/other/skeleton.dm
@@ -6,7 +6,7 @@
 		if("rage")
 			used = pick('sound/vo/mobs/skel/skeleton_rage (1).ogg','sound/vo/mobs/skel/skeleton_rage (2).ogg','sound/vo/mobs/skel/skeleton_rage (3).ogg')
 		if ("warcry")
-			used = list('sound/vo/lich/rage (1).ogg') //Close enough
+			used = list('sound/vo/mobs/skel/skeleton_rage (1).ogg','sound/vo/mobs/skel/skeleton_rage (2).ogg','sound/vo/mobs/skel/skeleton_rage (3).ogg') //RAGE AGAINST THE LYVING
 		if("laugh")
 			used = pick('sound/vo/mobs/skel/skeleton_laugh.ogg')
 		if("deathgurgle")

--- a/code/modules/mob/living/carbon/human/voicepacks/other/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/voicepacks/other/skeleton.dm
@@ -5,6 +5,8 @@
 			used = pick('sound/vo/mobs/skel/skeleton_rage (1).ogg','sound/vo/mobs/skel/skeleton_rage (2).ogg','sound/vo/mobs/skel/skeleton_rage (3).ogg')
 		if("rage")
 			used = pick('sound/vo/mobs/skel/skeleton_rage (1).ogg','sound/vo/mobs/skel/skeleton_rage (2).ogg','sound/vo/mobs/skel/skeleton_rage (3).ogg')
+		if ("warcry")
+			used = list('sound/vo/lich/rage (1).ogg') //Close enough
 		if("laugh")
 			used = pick('sound/vo/mobs/skel/skeleton_laugh.ogg')
 		if("deathgurgle")
@@ -37,5 +39,10 @@
 			used = list('sound/vo/blink.ogg')
 		if("stomp")
 			used = list('sound/foley/brickdrop.ogg')
-
+		if("salute")
+			used = 'sound/vo/salute.ogg'
+		if("crack")
+			used = 'sound/vo/knuckles.ogg'
+		if("facepalm")
+			used = list('sound/vo/facepalm1.ogg', 'sound/vo/facepalm2.ogg')
 	return used

--- a/code/modules/mob/living/carbon/human/voicepacks/other/zombie.dm
+++ b/code/modules/mob/living/carbon/human/voicepacks/other/zombie.dm
@@ -21,6 +21,12 @@
 			used = pick('sound/vo/mobs/zombie/firescream (1).ogg','sound/vo/mobs/zombie/firescream (2).ogg','sound/vo/mobs/zombie/firescream (3).ogg')
 		if("warcry") //Close enough
 			used = pick('sound/vo/mobs/zombie/firescream (1).ogg','sound/vo/mobs/zombie/firescream (2).ogg','sound/vo/mobs/zombie/firescream (3).ogg')
+		if("clap")
+			used = list('sound/vo/slowclap.ogg') //HILARIOUS
+		if("slowclap")
+			used = list('sound/vo/slowclap.ogg')
+		if("clap1")
+			used = list('sound/vo/claponce.ogg')
 		if("snap")
 			used = list('sound/vo/fsnap1.ogg')
 		if("snap2")
@@ -31,6 +37,10 @@
 			used = list('sound/vo/blink.ogg')
 		if("stomp")
 			used = list('sound/foley/brickdrop.ogg')
+		if("salute")
+			used = 'sound/vo/salute.ogg'
+		if("crack")
+			used = 'sound/vo/knuckles.ogg'
 	return used
 
 /datum/voicepack/zombie/f/get_sound(soundin, modifiers)
@@ -56,6 +66,12 @@
 			used = pick('sound/vo/mobs/zombie/firescream (1).ogg','sound/vo/mobs/zombie/firescream (2).ogg','sound/vo/mobs/zombie/firescream (3).ogg')
 		if("warcry") //Close enough
 			used = pick('sound/vo/mobs/zombie/firescream (1).ogg','sound/vo/mobs/zombie/firescream (2).ogg','sound/vo/mobs/zombie/firescream (3).ogg')
+		if("clap")
+			used = list('sound/vo/slowclap.ogg') //HILARIOUS
+		if("slowclap")
+			used = list('sound/vo/slowclap.ogg')
+		if("clap1")
+			used = list('sound/vo/claponce.ogg')
 		if("snap")
 			used = list('sound/vo/fsnap1.ogg')
 		if("snap2")
@@ -66,4 +82,10 @@
 			used = list('sound/vo/blink.ogg')
 		if("stomp")
 			used = list('sound/foley/brickdrop.ogg')
+		if("salute")
+			used = 'sound/vo/salute.ogg'
+		if("crack")
+			used = 'sound/vo/knuckles.ogg'
+		if("facepalm")
+			used = list('sound/vo/facepalm1.ogg', 'sound/vo/facepalm2.ogg')
 	return used


### PR DESCRIPTION
## About The Pull Request

Gives skeles/liches the new knucklecrack emotes, lets skeles warcry (Its just the rage emote)

deadites can also clap now, it uses the slowclap emote because its funny.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

spawned a skele ingame, possessed it, did the funny emotes.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Xylix

*also makes metaing skeles by reasonable noises like salutes not showing up harder. as well as giving feedback to emotes that should make some noises (warcries)*

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added some emote noises to skeles/zombies that were missing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
