### PR TITLE
oopsies - reverts PR #7655

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/keeper.dm
+++ b/code/modules/jobs/job_types/roguetown/church/keeper.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 2
 	allowed_ages = ALL_AGES_LIST
 	allowed_patrons = list(/datum/patron/divine/pestra)
-
+	forbidden_races = list(RACES_DESPISED)
 	outfit = /datum/outfit/job/roguetown/keeper
 	display_order = JDO_KEEPER
 	give_bank_account = TRUE


### PR DESCRIPTION
## About The Pull Request

Reverts [this](https://github.com/Azure-Peak/Azure-Peak/pull/7655) pull request, which allowed Revenants into the Keepers.

## Testing Evidence

Likewise, a one-line-change.

## Why It's Good For The Game

Doing this on Dakken's behalf, as he's the fellow currently in charge of handling the lore for Revenants.
Revenants aren't meant to have access to Church roles, at the _moment_ - including the fringe groups associated with 'em.
I don't have any skin in the game, personally, but it's good to fix this accidental discrepancy before it has time to solidify.

## Changelog

:cl:
del: Keepers can no longer be Revenants. Minor lore discrepancy - false alarm.
/:cl: