### PR TITLE
Summons Adjustment for Decancerization Purpose

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/behemoth.dm
@@ -155,7 +155,7 @@
 		shake_camera(screenshaken, 5, 5)
 	for (var/mob/living/shaken in view(1, focalpoint))
 		to_chat(shaken, span_danger("<B>The ground ruptures beneath your feet!</B>"))
-		shaken.Paralyze(50)
+		shaken.Slowdown(4)
 		var/obj/structure/flora/rock/giant_rock = new(get_turf(shaken))
 		QDEL_IN(giant_rock, 200)
 	return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/behemoth.dm
@@ -52,6 +52,7 @@
 	STASPD = 5
 
 	var/rock_cd
+	var/yeet_cd
 	inherent_spells = list(/obj/effect/proc_holder/spell/invoked/ele_quake)
 
 /mob/living/simple_animal/hostile/retaliate/rogue/elemental/behemoth/Initialize()
@@ -69,11 +70,12 @@
 		return FALSE //but more importantly return before attack_animal called
 	SEND_SIGNAL(src, COMSIG_HOSTILE_ATTACKINGTARGET, target)
 	in_melee = TRUE
-	if(!target)
+	if(QDELETED(target))
 		return
-	addtimer(CALLBACK(src,PROC_REF(yeet),target), 1 SECONDS)
-	if(!QDELETED(target))
-		return target.attack_animal(src)
+	. = target.attack_animal(src)
+	if(. && world.time >= yeet_cd)
+		yeet_cd = world.time + 8 SECONDS
+		addtimer(CALLBACK(src, PROC_REF(yeet), target), 1 SECONDS)
 
 /obj/effect/temp_visual/marker
 	icon = 'icons/effects/effects.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sylph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sylph.dm
@@ -28,8 +28,8 @@
 	aggro_vision_range = 9
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	simple_detect_bonus = 20
-	retreat_distance = 4
-	minimum_distance = 4
+	retreat_distance = 2
+	minimum_distance = 1
 	food_type = list()
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	pooptype = null
@@ -50,9 +50,6 @@
 	rapid = 3
 	projectiletype = /obj/projectile/magic/frostbolt/greater
 	ranged_message = "throws icy magick"
-	var/shroom_cd = 0
-	var/summon_cd = 0
-	inherent_spells = list(/obj/effect/proc_holder/spell/invoked/create_shrooms)
 
 /obj/projectile/magic/frostbolt/greater
 	name = "greater frostbolt"
@@ -67,55 +64,8 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/simple_add_wound(datum/wound/wound, silent = FALSE, crit_message = FALSE)	//no wounding the fiend
 	return
 
-/mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/OpenFire(atom/A)
-	if(CheckFriendlyFire(A))
-		return
-	visible_message(span_danger("<b>[src]</b> [ranged_message] at [A]!"))
-
-	if(world.time >= shroom_cd + 25 SECONDS && !mind)
-		var/mob/living/targetted = target
-		create_shroom(targetted)
-		src.shroom_cd = world.time
-	if(rapid > 1)
-		var/datum/callback/cb = CALLBACK(src, PROC_REF(Shoot), A)
-		for(var/i in 1 to rapid)
-			addtimer(cb, (i - 1)*rapid_fire_delay)
-	else
-		Shoot(A)
-	ranged_cooldown = world.time + ranged_cooldown_time
-
-
-/mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/proc/create_shroom(atom/target)
-	if(!target)
-		return
-	var/turf/target_turf = target // need to handle it this way so player sylphs can target turfs with this spell
-	if(isliving(target))
-		target_turf = target.loc
-	for(var/turf/turf as anything in RANGE_TURFS(3,target_turf))
-		if(prob(30))
-			new /obj/structure/glowshroom(turf)
-
-
 /mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/death(gibbed)
 	..()
 	update_icon()
 	spill_embedded_objects()
 	qdel(src)
-
-/obj/effect/proc_holder/spell/invoked/create_shrooms
-	name = "Spread Kneestingers"
-	recharge_time = 20 SECONDS
-	sound = 'sound/magic/churn.ogg'
-	overlay_state = "blesscrop"
-	chargetime = 0
-	range = 15
-
-/obj/effect/proc_holder/spell/invoked/create_shrooms/cast(list/targets, mob/living/user = usr)
-	if(istype(user, /mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph))
-		var/mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/treeguy = user
-		if(world.time <= treeguy.shroom_cd + 200)//shouldn't ever happen cuz the spell cd is the same as summon_cd but I'd rather it check with the internal cd just in case
-			to_chat(user,span_warning("Too soon!"))
-			revert_cast()
-			return FALSE
-		treeguy.create_shroom(targets[1])
-		treeguy.shroom_cd = world.time

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sylph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sylph.dm
@@ -22,14 +22,14 @@
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	health = 700
 	maxHealth = 700
-	melee_damage_lower = 20
-	melee_damage_upper = 30
+	melee_damage_lower = 28
+	melee_damage_upper = 40
 	vision_range = 7
 	aggro_vision_range = 9
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	simple_detect_bonus = 20
-	retreat_distance = 2
-	minimum_distance = 1
+	retreat_distance = 4
+	minimum_distance = 3
 	food_type = list()
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	pooptype = null
@@ -50,12 +50,11 @@
 	rapid = 3
 	projectiletype = /obj/projectile/magic/frostbolt/greater
 	ranged_message = "throws icy magick"
+	var/frost_cd = 0
 
 /obj/projectile/magic/frostbolt/greater
 	name = "greater frostbolt"
-	damage = 25
-	range = 6
-	speed = 6 //higher is slower
+	damage = 36
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/Initialize()
 	src.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
@@ -63,6 +62,20 @@
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/simple_add_wound(datum/wound/wound, silent = FALSE, crit_message = FALSE)	//no wounding the fiend
 	return
+
+/mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/AttackingTarget()
+	if(SEND_SIGNAL(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, target) & COMPONENT_HOSTILE_NO_PREATTACK)
+		return FALSE
+	SEND_SIGNAL(src, COMSIG_HOSTILE_ATTACKINGTARGET, target)
+	in_melee = TRUE
+	if(QDELETED(target))
+		return
+	. = target.attack_animal(src)
+	if(. && isliving(target) && world.time >= frost_cd)
+		frost_cd = world.time + 3 SECONDS
+		var/mob/living/L = target
+		apply_frost_stack(L)
+		L.visible_message(span_danger("[src]'s frozen touch bites deep into [L]!"))
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/death(gibbed)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sylph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sylph.dm
@@ -54,6 +54,7 @@
 
 /obj/projectile/magic/frostbolt/greater
 	name = "greater frostbolt"
+	min_range = 1
 	damage = 36
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/Initialize()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/watcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/watcher.dm
@@ -29,8 +29,8 @@
 	aggro_vision_range = 9
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
 	simple_detect_bonus = 20
-	retreat_distance = 4
-	minimum_distance = 3
+	retreat_distance = 2
+	minimum_distance = 1
 	food_type = list()
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	pooptype = null
@@ -59,20 +59,6 @@
 
 /mob/living/simple_animal/hostile/retaliate/rogue/infernal/watcher/simple_add_wound(datum/wound/wound, silent = FALSE, crit_message = FALSE)	//no wounding the watcher
 	return
-
-/mob/living/simple_animal/hostile/retaliate/rogue/infernal/watcher/MeleeAction(patience = TRUE)
-	for(var/t in RANGE_TURFS(1, src))
-		new /obj/effect/hotspot(t)
-		src.visible_message(span_danger("[src] emits a burst of flames from its core!"))
-	if(rapid_melee > 1)
-		var/datum/callback/cb = CALLBACK(src, PROC_REF(CheckAndAttack))
-		var/delay = SSnpcpool.wait / rapid_melee
-		for(var/i in 1 to rapid_melee)
-			addtimer(cb, (i - 1)*delay)
-	else
-		AttackingTarget()
-	if(patience)
-		GainPatience()
 
 /mob/living/simple_animal/hostile/retaliate/rogue/infernal/watcher/death(gibbed)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/other/leyline_lycan.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/other/leyline_lycan.dm
@@ -3,7 +3,6 @@
 	source = portal
 	ADD_TRAIT(src, TRAIT_NOBREATH, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_GENERIC)
-	ADD_TRAIT(src, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 
 /mob/living/simple_animal/hostile/retaliate/rogue/leylinelycan
 	icon = 'icons/mob/summonable/32x32.dmi'
@@ -18,7 +17,6 @@
 	emote_see = null
 	turns_per_move = 8
 	see_in_dark = 9
-	move_to_delay = 1
 	vision_range = 9
 	aggro_vision_range = 9
 
@@ -59,7 +57,7 @@
 		return 0
 	if(target in possible_targets)
 		var/target_distance = get_dist(targets_from,target)
-		if(world.time >= teleport_cooldown)
+		if(target_distance > 4 && world.time >= teleport_cooldown)
 			leyline_teleport(target)
 		if(ranged) //We ranged? Shoot at em
 			if(!target.Adjacent(targets_from) && ranged_cooldown <= world.time) //But make sure they're not in range for a melee attack and our range attack is off cooldown
@@ -104,12 +102,10 @@
 	duration = 3
 
 /mob/living/simple_animal/hostile/retaliate/rogue/leylinelycan/proc/leyline_teleport(target)
-	var/turf/turf_target = get_step(get_step(get_turf(target), src.dir), src.dir)
-	if(!(turf_target in view(12, src)))
-		return
-	if(!isopenturf(turf_target))
-		return
 	teleport_cooldown = world.time + 70
+	var/turf/turf_target = get_step(get_turf(target), get_dir(target, src))
+	if(!isopenturf(turf_target) || !(turf_target in view(12, src)))
+		return
 	var/turf/source = get_turf(src)
 	new /obj/effect/temp_visual/lycan(turf_target, src)
 	new /obj/effect/temp_visual/lycan(source, src)


### PR DESCRIPTION
## About The Pull Request
These are basic adjustments to the summon lines, many of which are actively extremely hostile to melee build while does nothing to challenge ranged build or just plain unfair and unfun to fight. 

We will need a more comrpehensive rework to make simple animals joyous to fight, these are basically band-aids to make it better till then: 
- Watcher no longer spew fire carpet around themselves making it one of the **worst** mobs to ever engage in melee
- Earth Elemental now yeet less often
- Behemoth's rock now applies a slowdown of 4, not a 5 seconds paralyze if you are hit
- Leyline Lycan's move to step reduced from 1 to default (5) so they no longer hit you like crack and nyoom across your entire screen
- Sylph no longer drop glowshroom around themselves
- Unnerfed Sylph's projectile so that it has a proper speed and can actually threaten or hit kiter
- Added a minimal range of 1 to sylph to reward you for sticking close

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Fought a few of these locally

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Tries to make it so that fighting simple summons in melee isn't utterly suicidal while in theory, presenting slightly higher or the same challenge for mages who primarily fight from range.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Watcher no longer spew fire carpet around themselves making it one of the **worst** mobs to ever engage in melee
balance: Earth Elemental now yeet less often
balance: Behemoth's rock now applies a slowdown of 4, not a 5 seconds paralyze if you are hit
balance: Leyline Lycan's move to step reduced from 1 to default (5) so they no longer hit you like crack and nyoom across your entire screen
balance: Sylph no longer drop glowshroom around themselves
balance: Unnerfed Sylph's projectile so that it has a proper speed and can actually threaten or hit kiter
balance: Added a minimal range of 1 to sylph to reward you for sticking close
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
