### PR TITLE
Pottery changes

### DIFF
--- a/code/game/objects/items/rogueitems/ceramics.dm
+++ b/code/game/objects/items/rogueitems/ceramics.dm
@@ -212,7 +212,7 @@
 	desc = "A statue made of fine glass. An incredible amount of skill must have went into this fragile masterpiece!"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "statueglass1"
-	smeltresult = null	//No resource return
+	smeltresult = /obj/item/natural/glass
 	glaze_bonus_pct = GLAZE_BONUS_PCT
 
 /obj/item/roguestatue/glass/Initialize()

--- a/code/game/objects/items/rogueitems/ceramics.dm
+++ b/code/game/objects/items/rogueitems/ceramics.dm
@@ -11,7 +11,7 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claybottleraw"
 	cooked_type = /obj/item/reagent_containers/glass/bottle/claybottle
-	desc = "A bottle fashioned from clay. Still needs to be fired to be useful."
+	desc = "A bottle fashioned from clay. It still needs to be fired to be useful."
 	smeltresult = /obj/item/reagent_containers/glass/bottle/claybottle
 
 /obj/item/natural/clay/claybottleclassic
@@ -19,7 +19,7 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claybottleraw"
 	cooked_type = /obj/item/reagent_containers/glass/bottle/claybottleclassic
-	desc = "A bottle fashioned from clay. Still needs to be fired to be useful."
+	desc = "A bottle fashioned from clay. It still needs to be fired to be useful."
 	smeltresult = /obj/item/reagent_containers/glass/bottle/claybottleclassic
 
 /obj/item/reagent_containers/glass/bottle/claybottle
@@ -50,7 +50,7 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clayvaseraw"
 	cooked_type = /obj/item/reagent_containers/glass/bottle/clayvase
-	desc = "A vase fashioned from clay. Still needs to be fired to be useful."
+	desc = "A vase fashioned from clay. It still needs to be fired to be useful."
 	smeltresult = /obj/item/reagent_containers/glass/bottle/clayvase
 
 /obj/item/natural/clay/clayvaseclassic
@@ -58,7 +58,7 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clayvaseraw"
 	cooked_type = /obj/item/reagent_containers/glass/bottle/clayvaseclassic
-	desc = "A vase fashioned from clay. Still needs to be fired to be useful."
+	desc = "A vase fashioned from clay. It still needs to be fired to be useful."
 	smeltresult = /obj/item/reagent_containers/glass/bottle/clayvaseclassic
 
 /obj/item/reagent_containers/glass/bottle/clayvase
@@ -89,7 +89,7 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clayfancyvaseraw"
 	cooked_type = /obj/item/reagent_containers/glass/bottle/clayfancyvase
-	desc = "A fancy vase fashioned from clay. Still needs to be fired to be useful."
+	desc = "A fancy vase fashioned from clay. It still needs to be fired to be useful."
 	smeltresult = /obj/item/reagent_containers/glass/bottle/clayfancyvase
 
 /obj/item/natural/clay/clayfancyvaseclassic
@@ -97,7 +97,7 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clayfancyvaseraw"
 	cooked_type = /obj/item/reagent_containers/glass/bottle/clayfancyvaseclassic
-	desc = "A fancy vase fashioned from clay. Still needs to be fired to be useful."
+	desc = "A fancy vase fashioned from clay. It still needs to be fired to be useful."
 	smeltresult = /obj/item/reagent_containers/glass/bottle/clayfancyvaseclassic
 
 /obj/item/reagent_containers/glass/bottle/clayfancyvase
@@ -128,7 +128,7 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claycupraw"
 	cooked_type = /obj/item/reagent_containers/glass/cup/claycup
-	desc = "A small flask fashioned from clay. Still needs to be fired to be useful."
+	desc = "A small flask fashioned from clay. It still needs to be fired to be useful."
 	smeltresult = /obj/item/reagent_containers/glass/cup/claycup
 
 /obj/item/natural/clay/claycupclassic
@@ -136,7 +136,7 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claycupraw"
 	cooked_type = /obj/item/reagent_containers/glass/cup/claycupclassic
-	desc = "A small flask fashioned from clay. Still needs to be fired to be useful."
+	desc = "A small flask fashioned from clay. It still needs to be fired to be useful."
 	smeltresult = /obj/item/reagent_containers/glass/cup/claycupclassic
 
 /obj/item/reagent_containers/glass/cup/claycup
@@ -161,26 +161,26 @@
 
 // Raw teapot
 /obj/item/natural/clay/rawteapot
-	name = "raw teapot"
+	name = "unfired teapot"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "teapot_raw"
-	desc = "A teapot fashioned from clay. Still needs to be baked to be useful."
+	desc = "A teapot fashioned from clay. It still needs to be fired to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/bucket/pot/teapot
 	smeltresult = /obj/item/reagent_containers/glass/bucket/pot/teapot
 
 // Raw teacup
 /obj/item/natural/clay/rawteacup
-	name = "raw teacup"
+	name = "unfired teacup"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "teacup_raw"
-	desc = "A teacup fashioned from clay. Still needs to be baked to be useful."
+	desc = "A teacup fashioned from clay. It still needs to be fired to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/cup/ceramic
 	smeltresult = /obj/item/reagent_containers/glass/cup/ceramic
 
 //Bricks - Makes bricks which are used for building. (Need brick-wall sprites for this.. augh..)
 /obj/item/natural/clay/claybrick
-	name = "uncooked clay brick"
-	desc = "An uncooked clay brick. It still needs to be cooked in a furnace."
+	name = "unfired clay brick"
+	desc = "An uncooked clay brick. It still needs to be fired to be useful."
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claybrickraw"
 	cooked_type = /obj/item/natural/brick
@@ -188,8 +188,8 @@
 
 //Statues - Basically cheapest version of the metal-made statues, but way easier to make given no rare material usage. Just skill. Plus, dyeable.
 /obj/item/natural/clay/claystatue
-	name = "uncooked clay statue"
-	desc = "An uncooked clay statue. It still needs to be cooked in a furnace."
+	name = "unfired clay statue"
+	desc = "An uncooked clay statue. It still needs to be fired to be useful."
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claystatueraw"
 	cooked_type = /obj/item/roguestatue/clay

--- a/code/game/objects/items/rogueitems/ceramics.dm
+++ b/code/game/objects/items/rogueitems/ceramics.dm
@@ -2,23 +2,25 @@
 
 /* Items made from Pottery */
 
-// Uncooked items -- Still need to be brought to a kiln
+// Uncooked items -- Still need to be brought to a smelter or an oven. Kilns do not exist as of 6/20/2026.
 // Those are all children of natural/clay so that they can inherit the Glaze method.
 
 //Bottle - subtype of glass bottle
 /obj/item/natural/clay/claybottle
-	name = "unglazed clay bottle"
+	name = "unfired clay bottle"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claybottleraw"
-	desc = "A bottle fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/bottle/claybottle
+	desc = "A bottle fashioned from clay. Still needs to be fired to be useful."
+	smeltresult = /obj/item/reagent_containers/glass/bottle/claybottle
 
 /obj/item/natural/clay/claybottleclassic
-	name = "unglazed clay bottle"
+	name = "unfired clay bottle"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claybottleraw"
-	desc = "A bottle fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/bottle/claybottleclassic
+	desc = "A bottle fashioned from clay. Still needs to be fired to be useful."
+	smeltresult = /obj/item/reagent_containers/glass/bottle/claybottleclassic
 
 /obj/item/reagent_containers/glass/bottle/claybottle
 	name = "clay vessel"
@@ -44,18 +46,20 @@
 
 //Vase - bigger bottle
 /obj/item/natural/clay/clayvase
-	name = "unglazed clay vase"
+	name = "unfired clay vase"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clayvaseraw"
-	desc = "A vase fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/bottle/clayvase
+	desc = "A vase fashioned from clay. Still needs to be fired to be useful."
+	smeltresult = /obj/item/reagent_containers/glass/bottle/clayvase
 
 /obj/item/natural/clay/clayvaseclassic
-	name = "unglazed clay vase"
+	name = "unfired clay vase"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clayvaseraw"
-	desc = "A vase fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/bottle/clayvaseclassic
+	desc = "A vase fashioned from clay. Still needs to be fired to be useful."
+	smeltresult = /obj/item/reagent_containers/glass/bottle/clayvaseclassic
 
 /obj/item/reagent_containers/glass/bottle/clayvase
 	name = "ceramic vase"
@@ -81,18 +85,20 @@
 
 //Fancy vase - bigger bottle + fancy
 /obj/item/natural/clay/clayfancyvase
-	name = "unglazed fancy clay vase"
+	name = "unfired fancy clay vase"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clayfancyvaseraw"
-	desc = "A fancy vase fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/bottle/clayfancyvase
+	desc = "A fancy vase fashioned from clay. Still needs to be fired to be useful."
+	smeltresult = /obj/item/reagent_containers/glass/bottle/clayfancyvase
 
 /obj/item/natural/clay/clayfancyvaseclassic
-	name = "unglazed fancy clay vase"
+	name = "unfired fancy clay vase"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clayfancyvaseraw"
-	desc = "A fancy vase fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/bottle/clayfancyvaseclassic
+	desc = "A fancy vase fashioned from clay. Still needs to be fired to be useful."
+	smeltresult = /obj/item/reagent_containers/glass/bottle/clayfancyvaseclassic
 
 /obj/item/reagent_containers/glass/bottle/clayfancyvase
 	name = "fancy ceramic vase"
@@ -118,18 +124,20 @@
 
 //Flask (was a cup) - subtype of regular cup but can shatter.
 /obj/item/natural/clay/claycup
-	name = "unglazed clay flask"
+	name = "unfired clay flask"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claycupraw"
-	desc = "A small flask fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/cup/claycup
+	desc = "A small flask fashioned from clay. Still needs to be fired to be useful."
+	smeltresult = /obj/item/reagent_containers/glass/cup/claycup
 
 /obj/item/natural/clay/claycupclassic
-	name = "unglazed clay flask"
+	name = "unfired clay flask"
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claycupraw"
-	desc = "A small flask fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/cup/claycupclassic
+	desc = "A small flask fashioned from clay. Still needs to be fired to be useful."
+	smeltresult = /obj/item/reagent_containers/glass/cup/claycupclassic
 
 /obj/item/reagent_containers/glass/cup/claycup
 	name = "clay flask"
@@ -158,6 +166,7 @@
 	icon_state = "teapot_raw"
 	desc = "A teapot fashioned from clay. Still needs to be baked to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/bucket/pot/teapot
+	smeltresult = /obj/item/reagent_containers/glass/bucket/pot/teapot
 
 // Raw teacup
 /obj/item/natural/clay/rawteacup
@@ -166,22 +175,25 @@
 	icon_state = "teacup_raw"
 	desc = "A teacup fashioned from clay. Still needs to be baked to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/cup/ceramic
+	smeltresult = /obj/item/reagent_containers/glass/cup/ceramic
 
 //Bricks - Makes bricks which are used for building. (Need brick-wall sprites for this.. augh..)
 /obj/item/natural/clay/claybrick
 	name = "uncooked clay brick"
-	desc = "An uncooked clay brick. It still needs to be cooked in a kiln."
+	desc = "An uncooked clay brick. It still needs to be cooked in a furnace."
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claybrickraw"
 	cooked_type = /obj/item/natural/brick
+	smeltresult = /obj/item/natural/brick
 
 //Statues - Basically cheapest version of the metal-made statues, but way easier to make given no rare material usage. Just skill. Plus, dyeable.
 /obj/item/natural/clay/claystatue
 	name = "uncooked clay statue"
-	desc = "An uncooked clay statue. It still needs to be cooked in a kiln."
+	desc = "An uncooked clay statue. It still needs to be cooked in a furnace."
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claystatueraw"
 	cooked_type = /obj/item/roguestatue/clay
+	smeltresult = /obj/item/roguestatue/clay
 
 /obj/item/roguestatue/clay
 	name = "ceramic statue"

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_grind_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_grind_recipes.dm
@@ -44,7 +44,7 @@
 	bonus_chance_outputs = list(/obj/item/alch/bonemeal = 50)
 
 /datum/alch_grind_recipe/horn
-
+	name = "Horn"
 	valid_input = /obj/item/alch/horn
 	valid_outputs = list(/obj/item/alch/earthdust = 1,/obj/item/alch/bonemeal = 2)
 	bonus_chance_outputs = list(/obj/item/alch/earthdust = 66)

--- a/code/modules/roguetown/roguecrafting/ceramics.dm
+++ b/code/modules/roguetown/roguecrafting/ceramics.dm
@@ -145,7 +145,7 @@
 /datum/crafting_recipe/roguetown/ceramics/glass/statue
 	name = "glass statue"
 	result = list(/obj/item/roguestatue/glass)
-	reqs = list(/obj/item/natural/glass = 2)
+	reqs = list(/obj/item/natural/glass = 1)
 	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/ceramics/portable_hookah

--- a/code/modules/roguetown/roguecrafting/ceramics.dm
+++ b/code/modules/roguetown/roguecrafting/ceramics.dm
@@ -107,7 +107,7 @@
 	* A silica source, like sand, quartz or flint (This is the primary material. Silica has a melting point
 		of about 1700C.)
 	* flux, like soda ash (Na2CO3), potash(K2CO3) or Natron (sodium carbonate IIRC?), commonly used in ancient egyptian glassmaking.
-		Flux is paramount to reduce the melting point of silica to something achievable in a kiln.
+		Flux is paramount to reduce the melting point of silica to something achievable in a kiln (or oven/furnace in the case of this game).
 	* a Stablizer, like limestone, bone ash, or marble dust.
 		Did you know 'pure' glass dissolves in water? The stablizer is what binds everything together and makes it strong.
 	In reality, those different components will be abstracted in game, respectively to:
@@ -125,7 +125,7 @@
 	tools = list(/obj/item/reagent_containers/glass/mortar, /obj/item/pestle)
 	result = list(/obj/item/natural/glassbatch)
 	reqs = list(/obj/item/natural/clay = 2, /obj/item/ash = 2, /obj/item/natural/stone = 1)
-	craftdiff = 2
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/ceramics/clay/claystatue
 	name = "clay statue"

--- a/code/modules/roguetown/roguecrafting/ceramics.dm
+++ b/code/modules/roguetown/roguecrafting/ceramics.dm
@@ -121,10 +121,17 @@
 	*/// -SunriseOYH
 
 /datum/crafting_recipe/roguetown/ceramics/glassraw
-	name = "glass batch"
+	name = "glass batch (using limestone)"
 	tools = list(/obj/item/reagent_containers/glass/mortar, /obj/item/pestle)
 	result = list(/obj/item/natural/glassbatch)
 	reqs = list(/obj/item/natural/clay = 2, /obj/item/ash = 2, /obj/item/natural/stone = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/ceramics/glassraw_bone
+	name = "glass batch (using bonemeal)"
+	tools = list(/obj/item/reagent_containers/glass/mortar, /obj/item/pestle)
+	result = list(/obj/item/natural/glassbatch)
+	reqs = list(/obj/item/natural/clay = 2, /obj/item/ash = 2, /obj/item/alch/bonemeal = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/ceramics/clay/claystatue
@@ -147,6 +154,6 @@
 	reqs = list(
 	/obj/item/natural/hide/cured = 1,
 	/obj/item/natural/clay = 2,
-	/obj/item/candle/yellow = 1
+	/obj/item/candle = 1
 	)
 	craftdiff = 4

--- a/code/modules/roguetown/roguecrafting/ceramics.dm
+++ b/code/modules/roguetown/roguecrafting/ceramics.dm
@@ -118,14 +118,14 @@
 	Smelting it into a pane is a fairly straightforward process with a mold.
 	The goal should be to make it hard enough that only a dedicated potter can do it
 	But not to the point of apothecary health potions where no one bothers with it.
-	*/// -SunriseOYH 
+	*/// -SunriseOYH
 
 /datum/crafting_recipe/roguetown/ceramics/glassraw
-	name = "glass clay"			// This is not a clay, but I don't personally think 'batch' is fitting ICly.
+	name = "glass batch"
 	tools = list(/obj/item/reagent_containers/glass/mortar, /obj/item/pestle)
 	result = list(/obj/item/natural/glassbatch)
 	reqs = list(/obj/item/natural/clay = 2, /obj/item/ash = 2, /obj/item/natural/stone = 1)
-	craftdiff = 4 // Knowing how to mix glass is not a trivial knowledge.
+	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/ceramics/clay/claystatue
 	name = "clay statue"
@@ -135,7 +135,7 @@
 
 /* 5 diff */ // High-end glass containers. Should be a direct upgrade to clay in every possible way.
 
-/datum/crafting_recipe/roguetown/ceramics/glass/statue 
+/datum/crafting_recipe/roguetown/ceramics/glass/statue
 	name = "glass statue"
 	result = list(/obj/item/roguestatue/glass)
 	reqs = list(/obj/item/natural/glass = 2)

--- a/code/modules/roguetown/roguejobs/ceramicist/clay_and_glass.dm
+++ b/code/modules/roguetown/roguejobs/ceramicist/clay_and_glass.dm
@@ -10,7 +10,7 @@
 	slot_flags = null
 	obj_flags = null
 	w_class = WEIGHT_CLASS_TINY
-	var/cooked_type = /obj/item/natural/stone // What does this item turn into when glazed in a kiln?
+	var/cooked_type = /obj/item/natural/stone // What does this item turn into when glazed in an oven?
 											  // A regular clay lump just becomes an ordinary stone.
 					// ...Possibly used to make bricks in a separate PR? Interesting way to integrate
 					// the mason's construction work with the new Potter profession. - SunriseOYH


### PR DESCRIPTION
## About The Pull Request

Whoever decided that clay items had to be made in a _baking_ oven, I hate you.
Whoever decided to say clay items had to be made in a "kiln" when they meant oven, I really hate you.
Whoever decided you needed *expert pottery* to make a glass batch, may you never find the cold side of your pillow.
Whoever decided to call it "glass clay" instead of "glass batch" in the crafting menu, I will find your place of dwelling, sneak into your house in the middle of the night, and place a single 2x1 Lego™ brick in your work shoe.

## Testing Evidence

It compiles.

## Why It's Good For The Game

Joking hostility aside. To be clear I don't really mean any of it.

I can tell that whoever added these pottery mechanics had some pretty good knowledge about glass making. I suspect they either have a real life hobby/profession in it, or they went out of their way to do lots of research. Very well done.

Unfortunately, the game's mechanics at this time make pottery frustrating and tedious, and the use of industry correct terminology just makes it fucking impossible to figure out without having to code dive and figure out what the fuck a kiln is supposed to be, or how to make a glass batch, etc.

This PR will make pottery and glass making a lot more intuitive. Maybe someday, someone makes an actual kiln for pottery. Today is not that day. Strongly recommend still using a proper furnace for glass, though.

Also you can now make the glass batches with bonemeal instead of stone if you happen to have bonemeal on hand.
Also glass statues now can be smelted back into glass if you want.
Also portable hookahs can be made from any kind of candle now instead of _specifically_ yellow candles.
Also one tiny out-of-scope fix, an alchemy recipe is missing a name. Fixed that.

## Changelog
:cl:
add: Pottery items can now be fired in smelting furnaces in addition to baking ovens.
add: Additional recipe for glass batch that uses bonemeal.
qol: Changed the names and descriptions of many unfinished pottery items so players can better understand what to do.
balance: Glass batch no longer requires expert skill to make.
balance: Glass statues can now be smelted back into glass.
fix: alch_grind_recipe for horn was missing its name, this is now fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
