### PR TITLE
chewing once releases the bite / drinking has a do_after

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -295,6 +295,7 @@
 	to_chat(user, span_danger("I bite [C]'s [parse_zone(sublimb_grabbed)].[C.next_attack_msg.Join()]"))
 	C.next_attack_msg.Cut()
 	log_combat(user, C, "limb chewed [sublimb_grabbed] ")
+	qdel(src)
 
 //this is for carbon mobs being drink only
 /obj/item/grabbing/bite/proc/drinklimb(mob/living/user) //implies limb_grabbed and sublimb are things
@@ -304,6 +305,10 @@
 
 	if(!limb_grabbed.get_bleed_rate())
 		to_chat(user, span_warning("Sigh. It's not bleeding."))
+		return
+
+	var/list/check_health = list("health" = user.health)
+	if(!do_after(user, 2 SECONDS, target = grabbed, extra_checks = CALLBACK(user, TYPE_PROC_REF(/mob, break_do_after_checks), check_health, FALSE)))
 		return
 
 	user.drinksomeblood(grabbed, sublimb_grabbed)

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -681,32 +681,6 @@
 	desc = ""
 	icon_state = "intake"
 
-/obj/item/grabbing/bite
-	name = "bite"
-	icon_state = "bite"
-	d_type = "stab"
-	slot_flags = ITEM_SLOT_MOUTH
-	bleed_suppressing = 1
-
-/obj/item/grabbing/bite/Click(location, control, params)
-	var/list/modifiers = params2list(params)
-	if(!valid_check())
-		return
-	if(iscarbon(usr))
-		var/mob/living/carbon/C = usr
-		if(C != grabbee || C.incapacitated() || C.stat == DEAD)
-			qdel(src)
-			return 1
-		if(modifiers["right"])
-			qdel(src)
-			return 1
-		var/_y = text2num(params2list(params)["icon-y"])
-		if(_y>=17)
-			bitelimb(C)
-		else
-			drinklimb(C)
-	return 1
-
 /datum/status_effect/buff/oiled
 	id = "oiled"
 	duration = 5 MINUTES


### PR DESCRIPTION
## About The Pull Request

as it says on the tin

also drinking has a 2s do_after that can be canceled on movement/drinker being attacked.

## Testing Evidence

sure.

## Why It's Good For The Game

you really shouldn't be able to cling on like that dealing full damage consistently.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Chewing once drops a bite, needing you to bite again.
balance: drinking has a 2s do_after that can be canceled on movement/drinker being attacked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
