### PR TITLE
hotfix #I (2) - ensures headpieces with offsets are properly adjusted when worn in the helmet cosmetic slot (thanks to Siggy)

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -181,8 +181,8 @@
 					continue
 				var/mutable_appearance/thing_appearance = thing.build_worn_icon(default_layer, default_icon_file, isinhands, femaleuniform, override_state, female, customi, sleeveindex, boobed_overlay, clip_mask)
 				thing_appearance.appearance_flags = RESET_COLOR
-				thing_appearance.pixel_x = -standing.pixel_x
-				thing_appearance.pixel_y = -standing.pixel_y
+            	thing_appearance.pixel_x -= standing.pixel_x
+                thing_appearance.pixel_y -= standing.pixel_y
 				standing.add_overlay(thing_appearance)
 	return standing
 

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -181,8 +181,8 @@
 					continue
 				var/mutable_appearance/thing_appearance = thing.build_worn_icon(default_layer, default_icon_file, isinhands, femaleuniform, override_state, female, customi, sleeveindex, boobed_overlay, clip_mask)
 				thing_appearance.appearance_flags = RESET_COLOR
-            	thing_appearance.pixel_x -= standing.pixel_x
-                thing_appearance.pixel_y -= standing.pixel_y
+				thing_appearance.pixel_x -= standing.pixel_x
+				thing_appearance.pixel_y -= standing.pixel_y
 				standing.add_overlay(thing_appearance)
 	return standing
 


### PR DESCRIPTION
## About The Pull Request

Self-explanatory; wearing a headpiece with a X/Y offset'll probably apply said-offsets, when worn on the helmet's cosmetic slot.
_(Likewise, it'll properly render any decorations placed onto that headpiece with the right offsets.)_

## Testing Evidence

<img width="85" height="98" alt="b407b7fab93f246c987b38b8a9fc35b3" src="https://github.com/user-attachments/assets/c6bd4b30-fd80-477c-86c7-e42f6c2be710" />
<img width="74" height="108" alt="ea72bda282c99b0d43378363dce99549" src="https://github.com/user-attachments/assets/b079d027-fbda-4219-b476-3bb8af1fbaf3" />


## Why It's Good For The Game

Optimizes the application of drip, and ensures offset-related headpiece decorations'll work without issue in most regards.

## Changelog

:cl:
fix: Wearing a headpiece with a coordinate-based offset now properly applies said-offset, when worn in a helmet's cosmetic slot. Likewise, said-offset will now properly be applied to any regular decorations placed in said-headpiece. Thanks, Siggy!
/:cl: