### PR TITLE
Fur now accepts subtypes

### DIFF
--- a/code/modules/roguetown/roguestock/trade_goods/textile.dm
+++ b/code/modules/roguetown/roguestock/trade_goods/textile.dm
@@ -42,6 +42,7 @@
 	base_price = SELLPRICE_FUR
 	source_region_id = TRADE_REGION_ROSAWOOD
 	item_type = /obj/item/natural/fur
+	accept_subtypes = TRUE
 
 /datum/trade_good/cured_leather
 	id = TRADE_GOOD_CURED_LEATHER


### PR DESCRIPTION
## About The Pull Request
Fur now accepts subtypes
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Fur now accepts subtypes
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fur now accepts subtypes
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fur now accepts subtypes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
