### PR TITLE
Recruit-role touchups

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -230,6 +230,7 @@ GLOBAL_LIST_EMPTY(species_list)
 	var/titles_pref = null
 	var/clothes_pref = CLOTHES_M
 	var/obscured_flags = NONE
+	var/override_advclass_examine = FALSE // if you get converted to a different role like servant with advjob_examine set to true, your title won't change on examine bcs your advclass hasn't actually changed - so we override that setting
 
 /**
  * Timed action involving one mob user. Target is optional.

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -538,7 +538,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		recruit.job = new_role
 		recruit.override_advclass_examine = TRUE // makes your servants display as 'servant' instead of like. 'witch' or w/e
 		for(var/trait in applied_traits)
-			ADD_TRAIT(recruit, trait)
+			ADD_TRAIT(recruit, trait, JOB_TRAIT)
 		SEND_SIGNAL(SSdcs, COMSIG_GLOB_ROLE_CONVERTED, recruiter, recruit, new_role)
 		message_admins("ROLE RECRUITMENT: [recruiter.real_name] ([recruiter.ckey]) has converted [recruit.real_name] ([recruit.ckey]) to [new_role]")
 		log_game("ROLE RECRUITMENT: [recruiter.real_name] ([recruiter.ckey]) has converted [recruit.real_name] ([recruit.ckey]) to [new_role]")

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -533,6 +533,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		recruit.say(accept_message, forced = "[name]")
 	if(new_role) //We assign our role here. + log it.
 		recruit.job = new_role
+		recruit.override_advclass_examine = TRUE // makes your servants display as 'servant' instead of like. 'witch' or w/e
 		SEND_SIGNAL(SSdcs, COMSIG_GLOB_ROLE_CONVERTED, recruiter, recruit, new_role)
 		message_admins("ROLE RECRUITMENT: [recruiter.real_name] ([recruiter.ckey]) has converted [recruit.real_name] ([recruit.ckey]) to [new_role]")
 		log_game("ROLE RECRUITMENT: [recruiter.real_name] ([recruiter.ckey]) has converted [recruit.real_name] ([recruit.ckey]) to [new_role]")

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -473,6 +473,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	var/refuse_message = "I refuse."
 	ignore_los = 1 // this needs to ignore normal "range", it looks like
 	range = 3
+	/// traits to apply on recruitment - currently only used to let new maids use the vomitorium to cook
+	/// since that's an administrative thing not an innate trait
+	var/applied_traits = list()
 
 /obj/effect/proc_holder/spell/self/convertrole/cast(list/targets,mob/user = usr)
 	. = ..()
@@ -534,6 +537,8 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	if(new_role) //We assign our role here. + log it.
 		recruit.job = new_role
 		recruit.override_advclass_examine = TRUE // makes your servants display as 'servant' instead of like. 'witch' or w/e
+		for(var/trait in applied_traits)
+			ADD_TRAIT(recruit, trait)
 		SEND_SIGNAL(SSdcs, COMSIG_GLOB_ROLE_CONVERTED, recruiter, recruit, new_role)
 		message_admins("ROLE RECRUITMENT: [recruiter.real_name] ([recruiter.ckey]) has converted [recruit.real_name] ([recruit.ckey]) to [new_role]")
 		log_game("ROLE RECRUITMENT: [recruiter.real_name] ([recruiter.ckey]) has converted [recruit.real_name] ([recruit.ckey]) to [new_role]")
@@ -563,6 +568,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	accept_message = "FOR THE CROWN!"
 	refuse_message = "I refuse."
 	recharge_time = 100
+	applied_traits = list(TRAIT_FOOD_STIPEND)
 
 /obj/effect/proc_holder/spell/self/convertrole/bog
 	name = "Recruit Warden"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1162,7 +1162,7 @@
 		used_title =  J.display_title || J.title
 		if(J.f_title && (titles_pref == TITLES_F))
 			used_title = J.f_title
-		if(J.advjob_examine)
+		if(J.advjob_examine && !override_advclass_examine)
 			used_title = advjob
 	return used_title
 


### PR DESCRIPTION
## About The Pull Request
- overrides advclass_examine for recruited players, so that their new job actually displays instead of their old advclass (which is never actually changed and probably should not be!), previously recruiting would appear to fail because your job would be 'servant' but your advclass would make it show up as 'witch'
- allows recruitment to add traits, for things that aren't really "traits" as much as "administrative matters", like giving new servants access to the vomitoriums so they can actually cook

## Testing Evidence
<img width="539" height="738" alt="2026-06-20_22-30" src="https://github.com/user-attachments/assets/4cf62760-26a9-4b9d-9eac-2a918011c3db" />
<img width="519" height="688" alt="image" src="https://github.com/user-attachments/assets/6056ec4c-4613-4f04-b5a0-fd8cfb3be05a" />

## Why It's Good For The Game
Recruitments are rare, and when they happen they should Probably actually display that a change has happened, instead of not doing that at all. Also, being recruited as a servant and then not being able to pull ingredients out of the vomitorium is bad, and it's immersion-breaking that literally nobody can do anything about it, so it's no longer a thing

## Changelog

:cl:
add: Recruitment spells will now properly make you show your new job title on examine
add: Recruited servants can now access the vomitorium like roundstart servants - though they don't get the other traits
/:cl:
