### PR TITLE
[FIX] Properly excludes constructs from race locked mercs, removes gnome grudgebearer

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -153,6 +153,7 @@ Balloon Alert / Floating Text defines
 	/datum/species/goblinp,\
 	/datum/species/dullahan,\
 	/datum/species/dwarf/gnome,\
+	/datum/species/construct/metal,\
 	/datum/species/ooze,\
 
 // All but elves & half-elves.
@@ -177,6 +178,7 @@ Balloon Alert / Floating Text defines
 	/datum/species/goblinp,\
 	/datum/species/dullahan,\
 	/datum/species/dwarf/gnome,\
+	/datum/species/construct/metal,\
 	/datum/species/ooze,\
 
 // All but dwarves.
@@ -203,6 +205,8 @@ Balloon Alert / Floating Text defines
 	/datum/species/kobold,\
 	/datum/species/goblinp,\
 	/datum/species/dullahan,\
+	/datum/species/dwarf/gnome,\
+	/datum/species/construct/metal,\
 	/datum/species/ooze,\
 
 // All but Dwarves, Gnomes, Kobolds, D. Elves, Oozes, Moths & Anthrosmall


### PR DESCRIPTION
## About The Pull Request

Constructs were apparently never added to the race lock define
now they're added
it makes sense

also removed the ability for gnomes to be grudgebearers as #7651 was closed and picking the class right now is just a trap as they spawn naked

## Testing Evidence

<img width="552" height="718" alt="Screenshot 2026-06-21 191226" src="https://github.com/user-attachments/assets/cf64e2d0-1244-41c3-9219-2be9a9cd3460" />


## Why It's Good For The Game

constructs are not elves
better to fix before someone else bases their whole character around this

## Changelog

:cl:
fix: excluded constructs from: Black Oaks, Grudgebearer an Anthraxi
fix: excluded gnomes from Grudgebearers
/:cl: