### PR TITLE
scrapyards - minor alternative to PR #7690; reduces the skill needed to make improvised repair kits (while adding them as +5 TRI items), adds further clarification to iron scrap

### DIFF
--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -148,6 +148,18 @@
 	triumph_cost = 5
 	sort_category = "Triumphs"
 
+/datum/loadout_item/triumph_metalrepairkit
+	name = "Repair Kit, Metal"
+	path = /obj/item/repair_kit/metal/bad
+	triumph_cost = 5
+	sort_category = "Triumphs"
+
+/datum/loadout_item/triumph_clothrepairkit
+	name = "Repair Kit, Cloth"
+	path = /obj/item/repair_kit/bad
+	triumph_cost = 5
+	sort_category = "Triumphs"
+
 /datum/loadout_item/triumph_scabbardnoble
 	name = "Decorated Scabbard, Silver"
 	path = /obj/item/rogueweapon/scabbard/sword/noble

--- a/code/game/objects/items/rogueitems/repair_kits.dm
+++ b/code/game/objects/items/rogueitems/repair_kits.dm
@@ -152,8 +152,7 @@
 
 /obj/item/scrap
 	name = "iron scrap"
-	desc = "Shingles and scrap, born from violence upon iron. There may yet still be a use for these \ 
-	pieces.. </br>Iron scrap can be crafted into metal repair kits, which - when stuffed with iron scrap - can repair damaged equipment without the need for a blacksmith's hammer."
+	desc = "Shingles and scrap, born from violence upon iron. There may yet still be a use for these pieces.. </br>Iron scrap can be crafted into metal repair kits, which - when stuffed with iron scrap - can repair damaged equipment without the need for a blacksmith's hammer."
 	icon_state = "scrap"
 	icon = 'icons/roguetown/items/misc.dmi'
 	grid_width = 32

--- a/code/game/objects/items/rogueitems/repair_kits.dm
+++ b/code/game/objects/items/rogueitems/repair_kits.dm
@@ -120,8 +120,7 @@
 
 /obj/item/armorkit_empty
 	name = "empty metal kit"
-	desc = "An empty metal box that is suitable for storing various pieces of hardware and other scrap. \
-	Fill with iron objects to create a repair kit."
+	desc = "An empty metal box that is suitable for storing various pieces of hardware and other scrap. </br>Stuff this with three pieces of iron scrap, obtainable by destroying iron equipment, to create a metal repair kit."
 	icon_state = "armorkit_empty"
 	icon = 'icons/roguetown/items/misc.dmi'
 	grid_width = 64
@@ -153,7 +152,8 @@
 
 /obj/item/scrap
 	name = "iron scrap"
-	desc = "Shingles and scrap, born from violence upon iron. There may yet still be a use for these pieces.. </br>Iron scrap can be crafted into metal repair kits, which can repair damaged equipment without the need for a blacksmith's hammer."
+	desc = "Shingles and scrap, born from violence upon iron. There may yet still be a use for these \ 
+	pieces.. </br>Iron scrap can be crafted into metal repair kits, which - when stuffed with iron scrap - can repair damaged equipment without the need for a blacksmith's hammer."
 	icon_state = "scrap"
 	icon = 'icons/roguetown/items/misc.dmi'
 	grid_width = 32

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -29,25 +29,25 @@
 		/obj/item/natural/fibers = 2,
 		/obj/item/rope = 1,
 		)
-	craftdiff = 3
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/survival/repairkitmetalingot
-	name = "empty metal kit (iron bar)"
+	name = "empty metal repair kit (iron bar)"
 	display_category = ITEM_CAT_TOOLS_WORKSHOP
 	result = /obj/item/armorkit_empty
 	reqs = list(
 		/obj/item/ingot/iron = 1,
 		)
-	craftdiff = 3
+	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/survival/repairkitmetalscrap
-	name = "empty metal kit (scrap)"
+	name = "empty metal repair kit (iron scrap)"
 	display_category = ITEM_CAT_TOOLS_WORKSHOP
 	result = /obj/item/armorkit_empty
 	reqs = list(
 		/obj/item/scrap = 3,
 		)
-	craftdiff = 3
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/survival/repairkitcloth
 	name = "sewing kit"


### PR DESCRIPTION
## About The Pull Request

This is a proposed alternative to [PR #7690](https://github.com/Azure-Peak/Azure-Peak/pull/7690), which was chiefly created to reduce the potential tedium of repairing equipment.
While I agree with their points, I think their particular resolution would result in more ramifications than intended.

I decided to make a very minor alternative, in exchange. In short..
* Improvised repair kits now only require Novice-level crafting skills _(or a flat INT value of XI+)_ to create.
* Metal repair kits in particular _(alongside iron scrap)_ now have a more articulate description to hint at how they're used.
* Improvised metal- and fabric repair kits can now be purchased for -5 TRI on the Triumph menu.

## Testing Evidence

* Three line changes, relatively simple.

## Why It's Good For The Game

* Makes it much more feasible for people to obtain a means of skill-divorced repairing, in a low-popped round without a smith.
* Offers another _(and likely much more appetizing)_ avenue for spending excess Triumphs, for the sake of convenience.

## Changelog

:cl:
add: Improvised repair kits now only require Novice-level skills to create.
add: Descriptions for metal repair kits and iron scrap are clarified to make it easier for newcomers to understand how it works.
add: Improvised metal- and fabric-repair kits can now be purchased on the Triumph menu for 5 TRI each.
/:cl: