### PR TITLE
you can now sleepheal arteries... technically

### DIFF
--- a/code/datums/wounds/types/arteries.dm
+++ b/code/datums/wounds/types/arteries.dm
@@ -17,7 +17,7 @@
 	can_sew = TRUE
 	can_cauterize = TRUE
 	critical = TRUE
-	sleep_healing = 0
+	sleep_healing = 0.5
 	embed_chance = 75
 
 	werewolf_infection_probability = 100
@@ -125,7 +125,7 @@
 	can_sew = TRUE
 	can_cauterize = TRUE
 	critical = TRUE
-	sleep_healing = 0
+	sleep_healing = 0.5
 	embed_chance = 75
 
 	werewolf_infection_probability = 0


### PR DESCRIPTION
## About The Pull Request
title. sleeping will now heal arteries... theoretically. it's half the speed of a normal bleeding wound, and those already heal _incredibly_ slowly (speaking from experience), so this will not save you from dying - arteries will kill you far, far faster than any kind of sleepheal can prevent

so why make this PR?

bloodless. bloodless is the reason. currently, if you are a bloodless char and you get arteried, manage to get somewhere safe, and collapse asleep, you can slowly- over the course of over an hour- heal enough to get back up. except the artery won't heal, so you will be stuck in deathcrit forever, unable to actually die or get up, and you just have to HOPE someone finds you, which isn't always reasonable - it's happened before in areas like the bog spider caves, and it was effectively a round-removal. i don't think the balance implications of "sleep for an hour to heal off your artery" are really that impactful, and it removes a soft-RR and adds immense aura to getting back up from that

## Testing Evidence
var change

## Why It's Good For The Game
answered in section 1