### PR TITLE
snip snip

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -632,7 +632,7 @@
 		update_icon()
 		return TRUE
 
-	if(istype(I, /obj/item/rogueweapon/huntingknife/scissors))
+	if(/datum/intent/snip in I.possible_item_intents)
 		if(prune_count >= 4)
 			to_chat(user, span_warning("The tree has been fully pruned already!"))
 			return TRUE


### PR DESCRIPTION
## About The Pull Request
Allows you to prune Eoran trees with anything that has a snip intent (and is therefore 'scissor-like') rather than just scissors

## Testing Evidence
<img width="168" height="150" alt="image" src="https://github.com/user-attachments/assets/a34fec9b-35b1-42c0-94c4-e8437e973456" />

<img width="326" height="58" alt="image" src="https://github.com/user-attachments/assets/abc7f74c-346d-407d-aa13-f3c83bb61c50" />


## Why It's Good For The Game
Having it check for scissor type path is unintuitive. Having it check for the presence of a snip intent means anything that is intended to work like scissors, works like scissors. Shears, laborer's knives, etc should work if they can salvage clothing. This is what intents are for

## Changelog

:cl:
qol: Eoran tree pruning now checks for the presence of snip intent, rather than scissors type path; which basically means 'anything that works like scissors can prune them now'
/:cl: