### PR TITLE
Unarmed loadout for Luminary

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -330,12 +330,13 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel
 	neck = /obj/item/clothing/neck/roguetown/coif/padded
+	var/gets_poke = TRUE
 
 	if(H.mind)
-		var/weapons = list("Arming Sword", "Shortsword + Shield", "Mace + Shield", "Quarterstaff", "Spear", "Unarmed") // you may want to upgrade for a better sword
+		var/weapons = list("Arming Sword + Poke Spell", "Shortsword + Shield", "Mace + Shield", "Quarterstaff + Poke Spell", "Spear + Poke Spell", "Unarmed Pugilist") // you may want to upgrade for a better sword
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
-			if("Arming Sword")
+			if("Arming Sword + Poke Spell")
 				r_hand = /obj/item/rogueweapon/sword
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
@@ -345,7 +346,8 @@
 				backr = /obj/item/rogueweapon/shield/wood
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
-			if("Quarterstaff")
+				gets_poke = FALSE
+			if("Quarterstaff + Poke Spell")
 				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE)
@@ -354,15 +356,17 @@
 				backr = /obj/item/rogueweapon/shield/wood
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
-			if("Spear")
+				gets_poke = FALSE
+			if("Spear + Poke Spell")
 				r_hand = /obj/item/rogueweapon/spear
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
-			if("Unarmed")
+			if("Unarmed Pugilist")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted
 				ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+				gets_poke = FALSE
 
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	backpack_contents = list(
@@ -371,7 +375,8 @@
 		/obj/item/book/spellbook = 1,
 		/obj/item/chalk = 1,
 		)
-	grant_poke_spell(H)
+	if(gets_poke)
+		grant_poke_spell(H)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WITCH, devotion_limit = CLERIC_REQ_1)
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -332,7 +332,7 @@
 	neck = /obj/item/clothing/neck/roguetown/coif/padded
 
 	if(H.mind)
-		var/weapons = list("Arming Sword", "Shortsword + Shield", "Mace + Shield", "Quarterstaff", "Spear") // you may want to upgrade for a better sword
+		var/weapons = list("Arming Sword", "Shortsword + Shield", "Mace + Shield", "Quarterstaff", "Spear", "Unarmed") // you may want to upgrade for a better sword
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Arming Sword")
@@ -358,6 +358,11 @@
 				r_hand = /obj/item/rogueweapon/spear
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
+			if("Unarmed")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
+				gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted
+				ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	backpack_contents = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -330,13 +330,12 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel
 	neck = /obj/item/clothing/neck/roguetown/coif/padded
-	var/gets_poke = TRUE
 
 	if(H.mind)
-		var/weapons = list("Arming Sword + Poke Spell", "Shortsword + Shield", "Mace + Shield", "Quarterstaff + Poke Spell", "Spear + Poke Spell", "Unarmed Pugilist") // you may want to upgrade for a better sword
+		var/weapons = list("Arming Sword", "Shortsword + Shield", "Mace + Shield", "Quarterstaff", "Spear", "Unarmed Pugilist") // you may want to upgrade for a better sword
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
-			if("Arming Sword + Poke Spell")
+			if("Arming Sword")
 				r_hand = /obj/item/rogueweapon/sword
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
@@ -346,8 +345,7 @@
 				backr = /obj/item/rogueweapon/shield/wood
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
-				gets_poke = FALSE
-			if("Quarterstaff + Poke Spell")
+			if("Quarterstaff")
 				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE)
@@ -356,17 +354,14 @@
 				backr = /obj/item/rogueweapon/shield/wood
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
-				gets_poke = FALSE
-			if("Spear + Poke Spell")
+			if("Spear")
 				r_hand = /obj/item/rogueweapon/spear
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
 			if("Unarmed Pugilist")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted
 				ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
-				gets_poke = FALSE
 
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	backpack_contents = list(
@@ -375,8 +370,7 @@
 		/obj/item/book/spellbook = 1,
 		/obj/item/chalk = 1,
 		)
-	if(gets_poke)
-		grant_poke_spell(H)
+	grant_poke_spell(H)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WITCH, devotion_limit = CLERIC_REQ_1)
 	if(H.mind)


### PR DESCRIPTION
## About The Pull Request

Adds unarmed as a gear loadout for luminary, granting pugilist, jman unarmed/wrestling, and weighted bandages.

Also updates the class so that any loadout stronger than what you could get from T&R (so, sword+shield, mace+shield, or the new unarmed option) loses the poke spell they would otherwise get.

## Testing Evidence

<img width="802" height="649" alt="image" src="https://github.com/user-attachments/assets/a95ba806-46d1-4ad1-a820-a0b44d760046" />

## Why It's Good For The Game

A magic-wielding unarmed class that isn't locked into spellfist's weird snowflake mechanics is a meaningfully different and interesting playstyle. Luminary is a tame enough class balance-wise (and overshadowed by its stronger brother, T&R sage) that giving it something T&R sage can't quite replicate would be good and healthy for the class.

And before I hear "unarmed is in too spicy of a balance state RN sorry", this is just about the most tame and baseline expression of unarmed possible as an equivalent to other fighting styles. Adding this would genuinely be _healthy_ for the state of unarmed, because it would give us more sane examples for what an unarmed adventurer looks like than monk and its +10 stat weight, expert weaponskill, and also T1 miracles just 'cuz.

Unarmed will never be balanced unless we can have more mundane examples of it as an actual comparison point, so that we can sand down the edges until it really is just an equivalent alternative to other weapon setups. No more and no less. If it really is **that** much of a concern then just let this PR sit until the unarmed bugfixes are in, I guess.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: adds an unarmed loadout for luminary
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
