### PR TITLE
Limit Mystic and Sage identity sidestepping using virtues

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -1,8 +1,18 @@
-/datum/advclass/mystic
+/datum/job/roguetown/Luminary
+	title = "Luminary"
+	faction = "Station"
+	job_subclasses = /datum/advclass/mystic/holyblade
+
+/datum/job/roguetown/mystic
+	title = "Mystic and Sage"
+	faction = "Station"
+	virtue_restrictions = list(/datum/virtue/combat/combat_virtue, /datum/virtue/combat/crossbowman, /datum/virtue/combat/bowman)
+	job_subclasses = list(/datum/advclass/mystic/mystic, /datum/advclass/mystic/resilientsoul)
+
+/datum/advclass/mystic/
 	name = "Mystic"
 	tutorial = "I have spent my youth deepening my faith, only to be lured by the way of the magi, to the great regret of my family"
 	allowed_sexes = list(MALE, FEMALE)
-	virtue_restrictions = list(/datum/virtue/combat/combat_virtue, /datum/virtue/combat/crossbowman, /datum/virtue/combat/bowman)
 	outfit = /datum/outfit/job/roguetown/adventurer/mystic
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
@@ -150,7 +160,6 @@
 	name = "Sage"
 	tutorial = "I have spent my youth studying both the Arcyne and Miraculous ways, and developed my mastery of shielding and preserving lyfe under my care."
 	allowed_sexes = list(MALE, FEMALE)
-	virtue_restrictions = list(/datum/virtue/combat/combat_virtue, /datum/virtue/combat/crossbowman, /datum/virtue/combat/bowman)
 	outfit = /datum/outfit/job/roguetown/adventurer/resilient
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -7,7 +7,7 @@
 	title = "Mystic and Sage"
 	faction = "Station"
 	virtue_restrictions = list(/datum/virtue/combat/combat_virtue, /datum/virtue/combat/crossbowman, /datum/virtue/combat/bowman)
-	job_subclasses = list(/datum/advclass/mystic/mystic, /datum/advclass/mystic/resilientsoul)
+	job_subclasses = list(/datum/advclass/mystic/, /datum/advclass/mystic/resilientsoul)
 
 /datum/advclass/mystic/
 	name = "Mystic"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -2,7 +2,7 @@
 	name = "Mystic"
 	tutorial = "I have spent my youth deepening my faith, only to be lured by the way of the magi, to the great regret of my family"
 	allowed_sexes = list(MALE, FEMALE)
-	
+	virtue_restrictions = list(/datum/virtue/combat/combat_virtue, /datum/virtue/combat/crossbowman, /datum/virtue/combat/bowman)
 	outfit = /datum/outfit/job/roguetown/adventurer/mystic
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
@@ -150,7 +150,7 @@
 	name = "Sage"
 	tutorial = "I have spent my youth studying both the Arcyne and Miraculous ways, and developed my mastery of shielding and preserving lyfe under my care."
 	allowed_sexes = list(MALE, FEMALE)
-	
+	virtue_restrictions = list(/datum/virtue/combat/combat_virtue, /datum/virtue/combat/crossbowman, /datum/virtue/combat/bowman)
 	outfit = /datum/outfit/job/roguetown/adventurer/resilient
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)


### PR DESCRIPTION
## About The Pull Request

Restrict Mystic and Sage to become Luminary+ by paying the Virtue TaxTM

## Testing Evidence

ooops guess who fugged up again!

## Why It's Good For The Game

Luminary lose a lot of substance by the existence of Trained and Ready and others weapon training virtues. because Mystic and Sage can just take them

## Changelog

:cl:

qol: Mystic and Sage are no longer able to pick Trained and Ready, Bow and Crossbow virtues
/:cl:
