### PR TITLE
Aaaaaaaaaaaa [fixes sunder not clearing on death + WWs still immune to pain even while sunderflamed vs undead]

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -209,9 +209,6 @@
 #define DISGUST_LEVEL_GROSS 25
 #define DISGUST_LEVEL_SLIGHTLYGROSS 10
 
-//Workaround to cap SUNDER stacks
-#define SUNDER_STACK_MAXEDOUT 140
-
 //Used as an upper limit for species that continuously gain nutriment
 #define NUTRITION_LEVEL_ALMOST_FULL 995
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -209,6 +209,9 @@
 #define DISGUST_LEVEL_GROSS 25
 #define DISGUST_LEVEL_SLIGHTLYGROSS 10
 
+//Workaround to cap SUNDER stacks
+#define SUNDER_STACK_MAXEDOUT 140
+
 //Used as an upper limit for species that continuously gain nutriment
 #define NUTRITION_LEVEL_ALMOST_FULL 995
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -57,7 +57,8 @@
 
 /mob/living/carbon/handle_random_events()//BP/WOUND BASED PAIN
 	//Being sundered will shut off no_pain trait, until the sunder flames wear off.
-	if(HAS_TRAIT(src, TRAIT_NOPAIN) && (!has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed)))
+	//Werewolves are exempt.
+	if(HAS_TRAIT(src, TRAIT_NOPAIN) && !HAS_TRAIT(src, TRAIT_LYCANRESILENCE) && (!has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed)))
 		return
 	if(!stat)
 		var/painpercent = get_complex_pain() / pain_threshold
@@ -88,7 +89,7 @@
 						addtimer(CALLBACK(src, PROC_REF(Stun), 110), 10)
 						addtimer(CALLBACK(src, PROC_REF(Knockdown), 110), 10)
 						mob_timers["painstun"] = world.time + 160
-					if(prob(probby) && HAS_TRAIT(src, TRAIT_NOPAINSTUN) && (has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed)))
+					if(prob(probby) && HAS_TRAIT(src, TRAIT_NOPAINSTUN) && !HAS_TRAIT(src, TRAIT_LYCANRESILENCE)  && (has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed)))
 						Immobilize(10)
 						emote("painscream")
 						to_chat(src, span_userdanger("THE SACRED FLAMES, I FEEL PAIN AGAIN!"))

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -42,8 +42,8 @@
 /mob/living/carbon/set_disgust(amount)
 	disgust = CLAMP(amount, 0, DISGUST_LEVEL_MAXEDOUT)
 
-/mob/living/carbon/set_sunder(amount)
-	sunder_stacks = (amount) //Don't set over 140 because players will suffer for this.
+/mob/living/carbon/set_sunder(amount) //Don't set over 140 because players will suffer for this.
+	sunder_stacks = (amount)
 
 
 ////////////////////////////////////////TRAUMAS/////////////////////////////////////////

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -43,7 +43,7 @@
 	disgust = CLAMP(amount, 0, DISGUST_LEVEL_MAXEDOUT)
 
 /mob/living/carbon/set_sunder(amount)
-	sunder_stacks = CLAMP(amount, 0) //Don't call over 140-100 because players will suffer for this.
+	sunder_stacks = (amount, 0) //Don't call over 140-100 because players will suffer for this.
 
 
 ////////////////////////////////////////TRAUMAS/////////////////////////////////////////

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -43,7 +43,7 @@
 	disgust = CLAMP(amount, 0, DISGUST_LEVEL_MAXEDOUT)
 
 /mob/living/carbon/set_sunder(amount)
-	sunder_stacks = CLAMP(amount, 0, SUNDER_STACK_MAXEDOUT) //Don't set over 140 because players will suffer for this.
+	sunder_stacks = (amount) //Don't set over 140 because players will suffer for this.
 
 
 ////////////////////////////////////////TRAUMAS/////////////////////////////////////////

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -42,6 +42,9 @@
 /mob/living/carbon/set_disgust(amount)
 	disgust = CLAMP(amount, 0, DISGUST_LEVEL_MAXEDOUT)
 
+/mob/living/carbon/set_sunder(amount)
+	sunder_stacks = CLAMP(amount, 0, DISGUST_LEVEL_MAXEDOUT)
+
 
 ////////////////////////////////////////TRAUMAS/////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -43,7 +43,7 @@
 	disgust = CLAMP(amount, 0, DISGUST_LEVEL_MAXEDOUT)
 
 /mob/living/carbon/set_sunder(amount)
-	sunder_stacks = (amount, 0) //Don't call over 140-100 because players will suffer for this.
+	sunder_stacks = CLAMP(amount, 0, SUNDER_STACK_MAXEDOUT) //Don't set over 140 because players will suffer for this.
 
 
 ////////////////////////////////////////TRAUMAS/////////////////////////////////////////

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -43,7 +43,7 @@
 	disgust = CLAMP(amount, 0, DISGUST_LEVEL_MAXEDOUT)
 
 /mob/living/carbon/set_sunder(amount)
-	sunder_stacks = CLAMP(amount, 0, DISGUST_LEVEL_MAXEDOUT)
+	sunder_stacks = CLAMP(amount, 0) //Don't call over 140-100 because players will suffer for this.
 
 
 ////////////////////////////////////////TRAUMAS/////////////////////////////////////////

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -118,6 +118,7 @@ GLOBAL_LIST_EMPTY(last_words)
 	set_drugginess(0)
 	set_disgust(0)
 	SetSleeping(0, 0)
+	set_sunder(0) //So deadites aren't PSzsghdhrfrliorfing almost post-death
 	reset_perspective(null)
 	reload_fullscreen()
 	update_mob_action_buttons()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -922,6 +922,7 @@
 		clear_alert("not_enough_oxy")
 		reload_fullscreen()
 		remove_client_colour(/datum/client_colour/monochrome)
+		set_sunder(0) //Just in case we didn't
 		// Add message about struggling to recall death circumstances
 		to_chat(src, "<span class='notice'><b>As you return to life, you struggle to recall the circumstances of your death...</b></span>")
 		to_chat(src, "<span class='italic'>Your memories of your final moments are hazy and fragmented.</span>")
@@ -948,6 +949,7 @@
 	SetParalyzed(0, FALSE)
 	SetSleeping(0, FALSE)
 	setStaminaLoss(0)
+	set_sunder(0)
 	SetUnconscious(0, FALSE)
 	if(should_update_mobility)
 		update_mobility()
@@ -966,6 +968,7 @@
 	setCloneLoss(0, 0)
 	remove_CC(FALSE)
 	set_disgust(0)
+	set_sunder(0)
 	set_nutrition(NUTRITION_LEVEL_FED + 50)
 	bodytemperature = BODYTEMP_NORMAL
 	set_blindness(0)

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -119,6 +119,10 @@
 /mob/proc/set_disgust(amount)
 	return
 
+///Set the disgust level of a mob
+/mob/proc/set_sunder(amount)
+	return
+
 ///Adjust the body temperature of a mob, with min/max settings
 /mob/proc/adjust_bodytemperature(amount,min_temp=0,max_temp=INFINITY)
 	if(bodytemperature >= min_temp && bodytemperature <= max_temp)


### PR DESCRIPTION
## About The Pull Request

Adds set_sunder Proc.

Death + Aheals call this. you don't need to varedit it away anymore.

The slurring + debuff will take a short moment to clear after either are called, but past that it clears off perfectly fine.


WWs no longer feel pain sundered
---

My dumbass forgot to add this cuz deadites + rotcured exist.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

gave a goblin XX all stats + psydonic flail, spawned in as rotcured.

go forth my boy, break my kneecaps.

*spoilers*
it broke my ribs instead and killed me, oh well. Aheal + Revive cleared the sunderstacks + Death
revival should also clear it.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Khg-z-z-hfgPSYF-hjg djghsPsz-z-zfgPSY djghsSYF-hjg djghsPsz-z-zfgPSY djghsPsz-z-zfgPSY-hfgPSYF-SYF-hjg djghsPsz-z-zfgPSY djghsPsz-z-zfgPSY-hfgPSYF-SYF-hjg djghsPsz-z-zfgPSY djghsPsz-z-zfgPSY-hfgPSYF-SYF-hjg djghsPsz-z-zfgPSY djghsPsz-z-zfgPSY-hfgPSYF-SYF-hjg djghsPsz-z-zfgPSY djghsPsz-z-zfgPSY-hfgPSYF-Psz-z-zfgPSY-hfgPSYF-SYF-hjg djghsPsz-z-zfgPSY djghsPsz-z-zfgPSY-hfgPSYF-

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: sunderstacks clear on death + revival + aheal + revives, you don't need to varedit it away.
balance: Werewolves are immune to pain even while doused in sunderflames.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
