### PR TITLE
[Abyssor] tweaks dream item examine tooltips

### DIFF
--- a/code/__DEFINES/highlight_examine_defines.dm
+++ b/code/__DEFINES/highlight_examine_defines.dm
@@ -29,6 +29,8 @@
 #define HERESYDESC_BAOTHA_ICON "It bears the icon of debauched Baotha"
 #define HERESYDESC_BAOTHA_MISC "A known design of Baotha"
 
+// Abyssor dream items
+#define HERESYDESC_DREAM_ITEM "A piece of Abyssor's dream. It is dangerous, and shouldn't be seen outside of capable, sanctified hands."
 // Dreamwalker items
 #define HERESYDESC_DREAMWALKER_WEAPON "A weapon of the enigmatic and violent Dreamwalkers"
 #define HERESYDESC_DREAMWALKER_ARMOR "An armor piece of the enigmatic and violent Dreamwalkers"

--- a/code/game/objects/items/ritualcircles.dm
+++ b/code/game/objects/items/ritualcircles.dm
@@ -733,6 +733,9 @@
 	var/faith_locked = TRUE
 	var/obj/upgraded_rune_type = /obj/structure/active_abyssor_rune/greater
 
+/obj/item/abyssal_marker/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, "It shatters the barrier between reality and NIGHTMARE")
+
 /obj/item/abyssal_marker/volatile
 	name = "volatile abyssal marker"
 	effect_desc = " Whispers fill your head. The crystal yearns to be used, it shall bring forth a beautiful dream. The first use shall mark, the second shall unleash. Seems fragile, like it might explode violently with energies when thrown..."
@@ -740,9 +743,6 @@
 	icon_state = "abyssal_marker_volatile"
 	var/cooldown = 0
 	var/creation_time
-
-/obj/item/abyssal_marker/volatile/get_examine_highlight_status()
-	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, "It shatters the barrier between reality and NIGHTMARE")
 
 /obj/item/abyssal_marker/tidal
 	name = "tidal abyssal marker"

--- a/code/game/objects/weapons/axes.dm
+++ b/code/game/objects/weapons/axes.dm
@@ -23,3 +23,9 @@
 	icon_state = "dreamaxeactive"
 	max_blade_int = 500
 	wdefense = 6
+
+/obj/item/rogueweapon/greataxe/dreamscape/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ODD, HERESYDESC_DREAM_ITEM)
+
+/obj/item/rogueweapon/greataxe/dreamscape/active/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_DREAMWALKER_WEAPON)

--- a/code/modules/antagonists/roguetown/villain/dreamwalker/dreamwalker_gear.dm
+++ b/code/modules/antagonists/roguetown/villain/dreamwalker/dreamwalker_gear.dm
@@ -78,7 +78,7 @@
 	wdefense = 8
 
 /obj/item/rogueweapon/halberd/glaive/dreamscape/get_examine_highlight_status()
-	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_DREAMWALKER_WEAPON)
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ODD, HERESYDESC_DREAM_ITEM)
 
 /obj/item/rogueweapon/halberd/glaive/dreamscape/active
 	desc = "A strange spear, who knows where it came from. Strange harmonious sounds ring out as wind passes through the holes."
@@ -87,6 +87,9 @@
 	wdefense = 9
 	force = 20
 	force_wielded = 35
+
+/obj/item/rogueweapon/halberd/glaive/dreamscape/active/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_DREAMWALKER_WEAPON)
 
 /obj/item/rogueweapon/greatsword/bsword/dreamscape
 	name = "otherworldly sword"
@@ -104,7 +107,7 @@
 	alt_grips = list(/datum/alt_grip/mordhau/broadsword/dream_broadsword)
 
 /obj/item/rogueweapon/greatsword/bsword/dreamscape/get_examine_highlight_status()
-	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_DREAMWALKER_WEAPON)
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ODD, HERESYDESC_DREAM_ITEM)
 
 /obj/item/rogueweapon/greatsword/bsword/dreamscape/active
 	name = "otherworldly sword"
@@ -114,6 +117,9 @@
 	force = 30
 	force_wielded = 35
 	wdefense = 5
+
+/obj/item/rogueweapon/greatsword/bsword/dreamscape/active/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_DREAMWALKER_WEAPON)
 
 /obj/item/rogueweapon/spear/dreamscape_trident
 	name = "otherworldly trident"
@@ -133,7 +139,7 @@
 	var/shockwave_damage = FALSE
 
 /obj/item/rogueweapon/spear/dreamscape_trident/get_examine_highlight_status()
-	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_DREAMWALKER_WEAPON)
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ODD, HERESYDESC_DREAM_ITEM)
 
 /obj/item/rogueweapon/spear/dreamscape_trident/active
 	name = "Iridescent trident"
@@ -147,6 +153,9 @@
 	shockwave_cooldown_interval = 30 SECONDS
 	shockwave_divisor = 2
 	shockwave_damage = TRUE
+
+/obj/item/rogueweapon/spear/dreamscape_trident/active/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_DREAMWALKER_WEAPON)
 
 // Update weapon initializations with specific effects
 /obj/item/rogueweapon/greataxe/dreamscape/active/Initialize()


### PR DESCRIPTION
## About The Pull Request
- Unactivated dream items are now only odd with their own description.
- Dream Markers both regular and volatile are now dangerously heretical
- Activated dream items, which can only be fielded by dreamwalkers are now dangerously heretical.

## Testing Evidence
Simple changes

## Why It's Good For The Game
Given some of these can be obtained via fishing & dreaming, they shouldn't be defacto heretical.

## Changelog

:cl:
fix: Made dream items less heretical on examine.
/:cl:
