### PR TITLE
Phoron's Random Packs of Econ n Spells n Contracts

### DIFF
--- a/code/__DEFINES/economy/internal_trade_and_quests.dm
+++ b/code/__DEFINES/economy/internal_trade_and_quests.dm
@@ -49,7 +49,7 @@
 #define STANDING_ORDER_POP_SCALE_PER_PLAYER 0
 #define STANDING_ORDER_POP_SCALE_MAX 3.0
 
-#define STANDING_ORDER_BASE_BONUS 0.75
+#define STANDING_ORDER_BASE_BONUS 1.0
 
 // Partial Fulfillment: Let players fulfill an order with 50% by VALUE for 85% payout
 // So that steward / towners are still soft encouraged to fulfill the whole order

--- a/code/__DEFINES/economy/questing.dm
+++ b/code/__DEFINES/economy/questing.dm
@@ -64,9 +64,7 @@ GLOBAL_LIST_INIT(defense_quest_tier_costs, list(
 #define QUEST_KILL_MAX_MOBS 20
 // Floor for TP to avoid no TP mob from being spammed
 #define QUEST_MOB_MIN_TP 10
-// Contract/quest corpses linger this long, then dust away to nothing (no ash left behind).
 #define QUEST_MOB_DUST_DELAY (5 MINUTES)
-// A head cut from a contract/quest mob dusts almost immediately so it can't be carted around.
 #define QUEST_HEAD_DUST_DELAY (5 SECONDS)
 
 #define QUEST_TP_BUDGET_KILL_EASY 35

--- a/code/__DEFINES/economy/questing.dm
+++ b/code/__DEFINES/economy/questing.dm
@@ -62,8 +62,12 @@ GLOBAL_LIST_INIT(defense_quest_tier_costs, list(
 
 // Max mobs for kill request to avoid lagging
 #define QUEST_KILL_MAX_MOBS 20
-// Floor for TP to avoid no TP mob from being spammed 
+// Floor for TP to avoid no TP mob from being spammed
 #define QUEST_MOB_MIN_TP 10
+// Contract/quest corpses linger this long, then dust away to nothing (no ash left behind).
+#define QUEST_MOB_DUST_DELAY (5 MINUTES)
+// A head cut from a contract/quest mob dusts almost immediately so it can't be carted around.
+#define QUEST_HEAD_DUST_DELAY (5 SECONDS)
 
 #define QUEST_TP_BUDGET_KILL_EASY 35
 #define QUEST_TP_BUDGET_CLEAR_OUT 80

--- a/code/__DEFINES/trade_goods.dm
+++ b/code/__DEFINES/trade_goods.dm
@@ -198,10 +198,10 @@
 #define TRADE_GOOD_STRONG_STAM_POTION "STRONG_STAM_POTION"
 #define TRADE_GOOD_ANTIDOTE_POTION "ANTIDOTE_POTION"
 #define TRADE_GOOD_STRONG_ANTIDOTE_POTION "STRONG_ANTIDOTE_POTION"
-#define TRADE_GOOD_STRENGTH_POTION "STRENGTH_POTION"
 #define TRADE_GOOD_PERCEPTION_POTION "PERCEPTION_POTION"
 #define TRADE_GOOD_INTELLIGENCE_POTION "INTELLIGENCE_POTION"
 #define TRADE_GOOD_SPEED_POTION "SPEED_POTION"
+#define TRADE_GOOD_TRANSIS_DUST "TRANSIS_DUST"
 
 // ---- Sellprices ----
 // Minerals
@@ -333,17 +333,16 @@
 // Potions (50dr bottle = one base unit). Priced below steel-ingot / armor pieces since
 // alchemy is faster and materially cheaper than smithing. The 1.75x order bonus brings
 // per-order payout into the same ballpark as a raw-goods basket.
-#define SELLPRICE_HEALTH_POTION 20
-#define SELLPRICE_STRONG_HEALTH_POTION 30
-#define SELLPRICE_MANA_POTION 20
-#define SELLPRICE_STRONG_MANA_POTION 35
-#define SELLPRICE_STAM_POTION 20
-#define SELLPRICE_STRONG_STAM_POTION 35
-#define SELLPRICE_ANTIDOTE_POTION 20
+#define SELLPRICE_HEALTH_POTION 25
+#define SELLPRICE_STRONG_HEALTH_POTION 35
+#define SELLPRICE_MANA_POTION 25
+#define SELLPRICE_STRONG_MANA_POTION 40
+#define SELLPRICE_STAM_POTION 25
+#define SELLPRICE_STRONG_STAM_POTION 40
+#define SELLPRICE_ANTIDOTE_POTION 25
 #define SELLPRICE_STRONG_ANTIDOTE_POTION 40
-// Stat-buff potions are showpiece alchemy. Uniform price - all four buff this round are
-// of equal mechanical weight, and pricing them differently invites min-maxing the petition.
-#define SELLPRICE_BUFF_POTION 48
+#define SELLPRICE_BUFF_POTION 60
+#define SELLPRICE_TRANSIS_DUST 60
 
 // Enchantment scrolls. Tier-priced — basic scrolls are a routine commission, greater
 // scrolls represent serious leyline-tier work. Mythics aren't shippable: they're bespoke

--- a/code/controllers/subsystem/rogue/regional_threat/regional_threat.dm
+++ b/code/controllers/subsystem/rogue/regional_threat/regional_threat.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(regionthreat)
 	// Lowpop tick = THREAT_LOWPOP_TICK_RATE (10%) of max_ambush.
 	// Basin & Grove & Terrorbog are fully tameable (min 0). Coast & Decap stay dangerous (min > 0).
 	// Budget = player_factor * pool * 3%. Solo combat budgets shown at max pool.
-	// Additive group drain: 5-man party drains at 3x/player_factor efficiency (0.5x per extra player).
+	// Additive group drain: 5-man party drains at 3x/player_factor efficiency (0.5x per extra player).s
 	var/list/threat_regions = list(
 		new /datum/threat_region(
 			_region_name = THREAT_REGION_AZURE_BASIN,
@@ -68,6 +68,7 @@ SUBSYSTEM_DEF(regionthreat)
 			),
 			_tp_budget_multiplier = 1.5,
 			_delivery_reward_multiplier = 2.0,
+			_payout_multiplier = 1.3,
 			_allowed_quest_types = list(QUEST_CLEAR_OUT, QUEST_RAID, QUEST_BOUNTY, QUEST_COURIER, QUEST_RETRIEVAL, QUEST_RECOVERY, QUEST_TOWNER_SMITH_CARAVAN, QUEST_TOWNER_MINER_OREVEIN),
 			_kill_target_floor = 4,
 			_evergreen_target = 3
@@ -133,6 +134,7 @@ SUBSYSTEM_DEF(regionthreat)
 			),
 			_tp_budget_multiplier = 1.5,
 			_delivery_reward_multiplier = 2.0,
+			_payout_multiplier = 1.2,
 			_allowed_quest_types = list(QUEST_CLEAR_OUT, QUEST_RAID, QUEST_BOUNTY, QUEST_RECOVERY, QUEST_TOWNER_SMITH_CARAVAN, QUEST_TOWNER_MINER_OREVEIN),
 			_kill_target_floor = 3
 		)

--- a/code/controllers/subsystem/rogue/regional_threat/threat_region.dm
+++ b/code/controllers/subsystem/rogue/regional_threat/threat_region.dm
@@ -13,6 +13,7 @@
 	/// Multiplier on the threat-scaled bonus paid to retrieval/courier quests.
 	/// Independent of tp_budget_multiplier so reward and combat scaling tune separately.
 	var/delivery_reward_multiplier = 1.0
+	var/payout_multiplier = 1.0
 	// Ambush budget percent - uses the higher one for safer region so that they can still spawn some relevant ambushes without needing to adjust the max_ambush downward
 	var/ambush_budget_pct = AMBUSH_BUDGET_PCT_REGULAR
 	/// Quest types this region will host. Default is everything; set per region to restrict (e.g. a dangerous region that won't host trivial kill-easy quests).
@@ -20,7 +21,7 @@
 	var/kill_target_floor = 2
 	var/evergreen_target = 0
 
-/datum/threat_region/New(_region_name, _latent_ambush, _min_ambush, _max_ambush, _fixed_ambush, _lowpop_tick, _highpop_tick, _ambush_budget_pct = AMBUSH_BUDGET_PCT_REGULAR, _faction_weights, _tp_budget_multiplier = 1.0, _allowed_quest_types, _kill_target_floor = 2, _evergreen_target = 0, _delivery_reward_multiplier = 1.0)
+/datum/threat_region/New(_region_name, _latent_ambush, _min_ambush, _max_ambush, _fixed_ambush, _lowpop_tick, _highpop_tick, _ambush_budget_pct = AMBUSH_BUDGET_PCT_REGULAR, _faction_weights, _tp_budget_multiplier = 1.0, _allowed_quest_types, _kill_target_floor = 2, _evergreen_target = 0, _delivery_reward_multiplier = 1.0, _payout_multiplier = 1.0)
 	region_name = _region_name
 	latent_ambush = _latent_ambush
 	min_ambush = _min_ambush
@@ -32,6 +33,7 @@
 		faction_weights = _faction_weights
 	tp_budget_multiplier = _tp_budget_multiplier
 	delivery_reward_multiplier = _delivery_reward_multiplier
+	payout_multiplier = _payout_multiplier
 	ambush_budget_pct = _ambush_budget_pct
 	if(_allowed_quest_types)
 		allowed_quest_types = _allowed_quest_types

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1243,31 +1243,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		else
 			return 0
 
-	if(nuforce < 10)
-		return 0
-
-	var/probability = nuforce * (total_dam / affecting.max_damage)
-	var/hard_dismember = HAS_TRAIT(affecting, TRAIT_HARDDISMEMBER)
-	var/easy_dismember = affecting.rotted || affecting.skeletonized || HAS_TRAIT(affecting, TRAIT_EASYDISMEMBER)
-	var/easy_decapitation = HAS_TRAIT(affecting, TRAIT_EASYDECAPITATION)
-	if(affecting.owner)
-		if(!hard_dismember)
-			hard_dismember = HAS_TRAIT(affecting.owner, TRAIT_HARDDISMEMBER)
-		if(!easy_dismember)
-			easy_dismember = HAS_TRAIT(affecting.owner, TRAIT_EASYDISMEMBER)
-		if(!easy_decapitation)
-			easy_decapitation = HAS_TRAIT(affecting.owner, TRAIT_EASYDECAPITATION)
-	// If you don't have easy dismember, then you must hit 90% damage or more to dismember a limb.
-	if((affecting.get_damage() <= (affecting.max_damage * CRIT_DISMEMBER_DAMAGE_THRESHOLD)) && !easy_dismember)
-		return FALSE
-	if(easy_decapitation && zone_sel == BODY_ZONE_PRECISE_NECK)
-		// May want to include hard dismember compatibility.
-		return probability * 1.5
-	if(hard_dismember)
-		return min(probability, 5)
-	else if(easy_dismember)
-		return probability * 1.5
-	return probability
+	return affecting.dismemberment_chance_from_force(nuforce, zone_sel)
 
 /obj/item/proc/get_dismember_sound()
 	if(damtype == BURN)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -39,8 +39,16 @@
 
 /mob/living/carbon/check_projectile_dismemberment(obj/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(check_zone(def_zone))
-	if(affecting && affecting.dismemberable && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))
-		affecting.dismember(P.damtype, P.woundclass)
+	if(!affecting || !affecting.dismemberable)
+		return
+	if(P.dismember_by_default && (P.woundclass == BCLASS_CUT || P.woundclass == BCLASS_CHOP))
+		var/dismember_chance = affecting.get_spell_dismemberment_chance(P.damage, P.woundclass, def_zone)
+		if(dismember_chance && prob(dismember_chance))
+			var/mob/living/shooter = isliving(P.firer) ? P.firer : null
+			affecting.dismember(P.damage_type, P.woundclass, shooter, def_zone)
+		return
+	if(P.dismemberment && (affecting.get_damage() >= (affecting.max_damage - P.dismemberment)))
+		affecting.dismember(P.damage_type, P.woundclass)
 
 /mob/living/carbon/proc/can_catch_item(skip_throw_mode_check)
 	. = FALSE

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -85,6 +85,8 @@ GLOBAL_LIST_EMPTY(last_words)
 #undef DUST_ANIMATION_TIME
 
 /mob/living/proc/spawn_dust(just_ash = FALSE)
+	if(contract_spawned)
+		return
 	for(var/i in 1 to 3)
 		new /obj/item/ash(loc)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -3,6 +3,8 @@
 	var/melee_cooldown = CLICK_CD_MELEE
 	var/pain_threshold = 0
 	var/no_head_bounty = FALSE
+	var/contract_spawned = FALSE
+	var/contract_dust_scheduled = FALSE
 
 
 /mob/living/Initialize()
@@ -2633,11 +2635,28 @@
 	SEND_SIGNAL(offered_item, COMSIG_OBJ_HANDED_OVER, src, offerer)
 	offerer.stop_offering_item()
 
-/mob/living/proc/strip_head_bounty()
+/// Marks a freshly-spawned mob as belonging to a contract/quest: strips its head bounty so it
+/// can't be farmed at a HEADEATER, and arranges for the corpse to dust shortly after death.
+/mob/living/proc/mark_contract_spawned()
 	no_head_bounty = TRUE
+	contract_spawned = TRUE
+	RegisterSignal(src, COMSIG_LIVING_DEATH, PROC_REF(on_contract_death))
 
-/mob/living/carbon/strip_head_bounty()
+/mob/living/carbon/mark_contract_spawned()
 	. = ..()
 	var/obj/item/bodypart/head/head = get_bodypart(BODY_ZONE_HEAD)
 	if(istype(head))
 		head.no_head_bounty = TRUE
+
+/mob/living/proc/on_contract_death(datum/source, gibbed)
+	SIGNAL_HANDLER
+	if(gibbed || contract_dust_scheduled) // already torn apart, or a timer is already pending
+		return
+	contract_dust_scheduled = TRUE
+	addtimer(CALLBACK(src, PROC_REF(dust_contract_corpse)), QUEST_MOB_DUST_DELAY)
+
+/mob/living/proc/dust_contract_corpse()
+	contract_dust_scheduled = FALSE
+	if(QDELETED(src) || stat != DEAD) // skip if it was somehow revived in the meantime
+		return
+	dust()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -211,7 +211,7 @@
 			apply_effects(stun = P.stun, knockdown = P.knockdown, unconscious = P.unconscious, slur = P.slur, stutter = P.stutter, eyeblur = P.eyeblur, drowsy = P.drowsy, blocked = armor, stamina = P.stamina, jitter = P.jitter, paralyze = P.paralyze, immobilize = P.immobilize)
 		if(!nodmg)
 			if(!P.out_of_effective_range())
-				if(P.dismemberment)
+				if(P.dismemberment || P.dismember_by_default)
 					check_projectile_dismemberment(P, def_zone,armor)
 				if(P.woundclass)
 					check_projectile_wounding(P, def_zone, armor)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -692,6 +692,10 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 			user.mind.add_sleep_experience(/datum/skill/labor/butchering, user.STAINT * BUTCHERING_EXP_FINISH)
 		gib()
 
+/mob/living/simple_animal/mark_contract_spawned()
+	. = ..()
+	head_butcher = null
+
 /mob/living/proc/butcher_summary(botch_count, normal_count, perfect_count, botch_chance, perfect_chance)
     var/list/parts = list()
     if(botch_count)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -135,6 +135,7 @@
 	var/stamina = 0
 	var/jitter = 0
 	var/dismemberment = 0 //The higher the number, the greater the bonus to dismembering. 0 will not dismember at all.
+	var/dismember_by_default = FALSE
 	var/impact_effect_type //what type of impact effect to show when hitting something
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -12,6 +12,7 @@
 	dam_falloff_factor = 0.5
 	suppress_effects_past_range = TRUE
 	max_range = 7
+	dismember_by_default = TRUE
 	var/explode_sound = list('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg')
 	var/mob/living/carbon/human/sender
 	/// Impact visual intensity. SPELL_IMPACT_NONE / SPELL_IMPACT_LOW / SPELL_IMPACT_MEDIUM / SPELL_IMPACT_HIGH
@@ -24,6 +25,7 @@
 	dam_falloff_factor = 0.5
 	suppress_effects_past_range = TRUE
 	max_range = 7
+	dismember_by_default = TRUE
 
 /obj/projectile/magic/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/roguetown/roguemachine/questing/types/__quest.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/__quest.dm
@@ -213,7 +213,11 @@
 /datum/quest/proc/calculate_reward(turf/origin_turf, turf/target_turf)
 	var/base = get_base_reward()
 	var/additional = get_additional_reward(origin_turf, target_turf)
-	return round((base + additional + get_difficulty_bonus()) * QUEST_REWARD_GLOBAL_MULT)
+	var/payout_mult = QUEST_REWARD_GLOBAL_MULT
+	var/datum/threat_region/TR = SSregionthreat.get_region(region)
+	if(TR)
+		payout_mult *= TR.payout_multiplier
+	return round((base + additional + get_difficulty_bonus()) * payout_mult)
 
 /// Flat reward sweetener keyed off difficulty, applied to every quest type at the reward chokepoint.
 /datum/quest/proc/get_difficulty_bonus()

--- a/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
@@ -195,7 +195,7 @@
 		new_mob.faction |= "quest"
 		if(faction?.faction_tag)
 			new_mob.faction |= faction.faction_tag
-		new_mob.strip_head_bounty()
+		new_mob.mark_contract_spawned()
 		new_mob.AddComponent(/datum/component/quest_object/kill, src)
 		// Suppress AI scanning while dormant inside the spawn_effect — without this the AI tries
 		// to build a proximity field while not on a turf, fails, and stays catatonic forever.

--- a/code/modules/roguetown/roguemachine/questing/types/kill/quest_bounty.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/quest_bounty.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(quest_bounty_goblin_goons, list(
 	boss.faction |= "quest"
 	if(faction?.faction_tag)
 		boss.faction |= faction.faction_tag
-	boss.strip_head_bounty()
+	boss.mark_contract_spawned()
 	boss.AddComponent(/datum/component/quest_object/kill, src)
 	ADD_TRAIT(boss, TRAIT_FRESHSPAWN, "[type]")
 	addtimer(TRAIT_CALLBACK_REMOVE(boss, TRAIT_FRESHSPAWN, "[type]"), 60 SECONDS)
@@ -132,7 +132,7 @@ GLOBAL_LIST_INIT(quest_bounty_goblin_goons, list(
 		goon.faction |= "quest"
 		if(faction?.faction_tag)
 			goon.faction |= faction.faction_tag
-		goon.strip_head_bounty()
+		goon.mark_contract_spawned()
 		ADD_TRAIT(goon, TRAIT_FRESHSPAWN, "[type]")
 		addtimer(TRAIT_CALLBACK_REMOVE(goon, TRAIT_FRESHSPAWN, "[type]"), 60 SECONDS)
 		spawn_effect.contained_atom = goon
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(quest_bounty_goblin_goons, list(
 		var/goon_path = pick(GLOB.quest_bounty_goblin_goons)
 		var/mob/living/goon = new goon_path(spawn_effect)
 		goon.faction |= "quest"
-		goon.strip_head_bounty()
+		goon.mark_contract_spawned()
 		ADD_TRAIT(goon, TRAIT_FRESHSPAWN, "[type]")
 		addtimer(TRAIT_CALLBACK_REMOVE(goon, TRAIT_FRESHSPAWN, "[type]"), 60 SECONDS)
 		spawn_effect.contained_atom = goon

--- a/code/modules/roguetown/roguestock/standing_order.dm
+++ b/code/modules/roguetown/roguestock/standing_order.dm
@@ -635,7 +635,7 @@ GLOBAL_LIST_EMPTY(standing_order_pool)
 		TRADE_REGION_NORTHFORT = list("a frontier strike-band", "a watch sergeant's chosen", "a local adventuring fellowship"),
 	)
 	var/list/buff_pool = list(
-		TRADE_GOOD_STRENGTH_POTION,
+		TRADE_GOOD_TRANSIS_DUST,
 		TRADE_GOOD_PERCEPTION_POTION,
 		TRADE_GOOD_INTELLIGENCE_POTION,
 		TRADE_GOOD_SPEED_POTION,

--- a/code/modules/roguetown/roguestock/trade_goods/alchemical.dm
+++ b/code/modules/roguetown/roguestock/trade_goods/alchemical.dm
@@ -5,3 +5,9 @@
 	category = ITEM_CAT_REAGENT_ALCHEMICAL
 	display_category = ITEM_CAT_REAGENT_ALCHEMICAL
 	item_type = /obj/item/alch
+
+/datum/trade_good/alchemical_reagent/transisdust
+	id = TRADE_GOOD_TRANSIS_DUST
+	name = "Sui Dust"
+	base_price = SELLPRICE_TRANSIS_DUST
+	item_type = /obj/item/alch/transisdust

--- a/code/modules/roguetown/roguestock/trade_goods/potions.dm
+++ b/code/modules/roguetown/roguestock/trade_goods/potions.dm
@@ -65,13 +65,6 @@
 	reagent_type = /datum/reagent/medicine/strong_antidote
 	required_volume = 30
 
-/datum/trade_good/potion/strength
-	id = TRADE_GOOD_STRENGTH_POTION
-	name = "Strength Potion - 30dr bottle"
-	base_price = SELLPRICE_BUFF_POTION
-	reagent_type = /datum/reagent/buff/strength
-	required_volume = 30
-
 /datum/trade_good/potion/perception
 	id = TRADE_GOOD_PERCEPTION_POTION
 	name = "Perception Potion - 30dr bottle"

--- a/code/modules/spells/spell_types/classunique/spellblade/anime_spells_helper.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/anime_spells_helper.dm
@@ -92,6 +92,9 @@ without going through the click pipeline, so spells can deliver weapon-style str
 				var/obj/item/bodypart/affecting = C.get_bodypart(check_zone(def_zone))
 				if(affecting)
 					affecting.bodypart_attacked_by(blade_class, wound_damage, user, def_zone, crit_message = TRUE, weapon = weapon)
+					var/dismember_chance = affecting.get_spell_dismemberment_chance(damage, blade_class, def_zone)
+					if(dismember_chance && prob(dismember_chance))
+						affecting.dismember(damage_type, blade_class, user, def_zone)
 			else
 				target.simple_woundcritroll(blade_class, wound_damage, user, def_zone, crit_message = TRUE)
 

--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -2,6 +2,40 @@
 /obj/item/bodypart/proc/can_dismember(obj/item/I)
 	return dismemberable
 
+/obj/item/bodypart/proc/get_spell_dismemberment_chance(force, bclass, zone_precise = src.body_zone)
+	if(!can_dismember())
+		return 0
+	if(bclass != BCLASS_CUT && bclass != BCLASS_CHOP)
+		return 0
+	if(bclass == BCLASS_CHOP)
+		force *= 1.1
+	return dismemberment_chance_from_force(force, zone_precise)
+
+/obj/item/bodypart/proc/dismemberment_chance_from_force(nuforce, zone_precise = src.body_zone)
+	if(nuforce < 10)
+		return 0
+	var/total_dam = get_damage()
+	var/probability = nuforce * (total_dam / max_damage)
+	var/hard_dismember = HAS_TRAIT(src, TRAIT_HARDDISMEMBER)
+	var/easy_dismember = rotted || skeletonized || HAS_TRAIT(src, TRAIT_EASYDISMEMBER)
+	var/easy_decapitation = HAS_TRAIT(src, TRAIT_EASYDECAPITATION)
+	if(owner)
+		if(!hard_dismember)
+			hard_dismember = HAS_TRAIT(owner, TRAIT_HARDDISMEMBER)
+		if(!easy_dismember)
+			easy_dismember = HAS_TRAIT(owner, TRAIT_EASYDISMEMBER)
+		if(!easy_decapitation)
+			easy_decapitation = HAS_TRAIT(owner, TRAIT_EASYDECAPITATION)
+	if((total_dam <= (max_damage * CRIT_DISMEMBER_DAMAGE_THRESHOLD)) && !easy_dismember)
+		return 0
+	if(easy_decapitation && zone_precise == BODY_ZONE_PRECISE_NECK)
+		return probability * 1.5
+	if(hard_dismember)
+		return min(probability, 5)
+	else if(easy_dismember)
+		return probability * 1.5
+	return probability
+
 /obj/item/bodypart/proc/can_disable(obj/item/I)
 	return disableable
 

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -65,6 +65,17 @@
 	if(sellprice && !no_head_bounty)
 		. += span_notice("This head seems to be wanted by the Judiciary of Azuria. It can be turned in at a HEADEATER.")
 
+/obj/item/bodypart/head/drop_limb(special)
+	. = ..()
+	if(. && no_head_bounty && !special)
+		addtimer(CALLBACK(src, PROC_REF(dust_contract_head)), QUEST_HEAD_DUST_DELAY)
+
+/obj/item/bodypart/head/proc/dust_contract_head()
+	if(QDELETED(src))
+		return
+	dust_animation()
+	QDEL_IN(src, 1.2 SECONDS)
+
 /obj/item/bodypart/head/grabbedintents(mob/living/user, precise)
 	var/used_limb = precise
 	switch(used_limb)


### PR DESCRIPTION
## About The Pull Request
- Standing Order Bonus adjusted to 1.0 from 0.75 after reading a conversation about how smith order is not profitable enough. Since I changed to dynamic instead of fixed pricing I suspect smithing order became less relatively profitable so this should improve it again
- Corpses from Contract should dust within 5 minutes if not butchered. Heads that are cut off will dust nearly instantly (without producing ash). Simple animals from contracts should no longer produce heads. This should help with massive amount of clutters since I made Quest Good Again
- Spells and Arcyne Strike can now dismember people as I originally intended but somehow forgot, fully fulfilling the anime / swordcery fantasy I intend to enable later when I rework Ferramancy and also making Spellblade overly popular again
- Underdark and Terrorbog Quest now have a relative 1.2x and 1.3x rewards multiplier to encourage people to clear out these problem spots more, if you are up for the challenge
- Increased potion price, replaced strength potion (very hard to make) with sui dust in the potion standing order pool

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="750" height="570" alt="O6BWaY9UI8" src="https://github.com/user-attachments/assets/0c4c6a38-1392-443a-b248-95f1c24a230e" />
<img width="948" height="359" alt="dreamseeker_zWrIFR2bjO" src="https://github.com/user-attachments/assets/876655d3-05a1-413e-9048-e5c4d0b96a26" />
<img width="157" height="225" alt="dreamseeker_eK4tOxbsJs" src="https://github.com/user-attachments/assets/3a7b19f0-c253-4db0-8575-af87016ee361" />
<img width="193" height="229" alt="dreamseeker_1RHJBPH4AP" src="https://github.com/user-attachments/assets/40975840-6a63-4664-8955-bae947d0f796" />
<img width="208" height="261" alt="dreamseeker_mbGBWf5cIz" src="https://github.com/user-attachments/assets/e58ab82c-a7ec-42e8-87e5-0108c8bbc022" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Adjustments for parts of the game I work on / "own"

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Standing Order Bonus adjusted to 1.0 from 0.75 after reading a conversation about how smith order is not profitable enough. Since I changed to dynamic instead of fixed pricing I suspect smithing order became less relatively profitable so this should improve it again
add: Corpses from Contract should dust within 5 minutes if not butchered. Heads that are cut off will dust nearly instantly (without producing ash). Simple animals from contracts should no longer produce heads. This should help with massive amount of clutters since I made Quest Good Again
add: Spells and Arcyne Strike can now dismember people as I originally intended but somehow forgot, fully fulfilling the anime / swordcery fantasy I intend to enable later when I rework Ferramancy and also making Spellblade overly popular again
add: Underdark and Terrorbog Quest now have a relative 1.2x and 1.3x rewards multiplier to encourage people to clear out these problem spots more, if you are up for the challenge
add: Increased potion price, replaced strength potion (very hard to make) with sui dust in the potion standing order pool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
