### PR TITLE
matthios revive lorefix

### DIFF
--- a/code/modules/spells/pantheon/inhumen/_inhumen_spell_items.dm
+++ b/code/modules/spells/pantheon/inhumen/_inhumen_spell_items.dm
@@ -412,9 +412,6 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		return
 	if(HAS_TRAIT(target, TRAIT_DNR))
 		to_chat(user, span_danger("The Geald within the vial does not react to them at all. Strange."))
-		return	
-	if(HAS_TRAIT(target, TRAIT_NOBLE))
-		to_chat(user, span_notice("You have a feeling that Matthios would personally eviscerate you for trying this on them."))
 		return
 
 	to_chat(user, span_notice("You begin pouring the lyfestruth over [target.name]..."))
@@ -502,8 +499,8 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		var/obj/item/roguegem/G = I
 		return G.sellprice
 
-	if(istype(I, /obj/item/riddleofsteel))	
-		var/obj/item/riddleofsteel/R = I	
+	if(istype(I, /obj/item/riddleofsteel))
+		var/obj/item/riddleofsteel/R = I
 		return R.sellprice
 
 	return 0
@@ -817,7 +814,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		funny_smoke(src)
 		qdel(src)
 		return
-	
+
 	if(!ishungry && prob(80 - miraclecheck)) // bread troll
 		to_chat(user, span_warning("The mixture shifts... simplifying itself into something more befitting your greed."))
 		new /obj/item/reagent_containers/food/snacks/rogue/bread(get_turf(src))
@@ -827,7 +824,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		qdel(src)
 		return
 
-	if(ishungry && prob(25)) 
+	if(ishungry && prob(25))
 		to_chat(user, span_notice("Matthios takes pity on your mortal limitations. You compulsively shout in gratitude!"))
 		user.say(pick("PRAISE YOU, O' GENEROUS MATTHIOS!!","AT LAST, THE TRUE GOLD OF CULINARY ALCHEMY!!","BLESSED BE THY HANDS WHICH GRANT ME SUSTENANCE, MATTHIOS!!","I SHALL GIVE ALL FOR THY SMILE, LORD OF FREEDOM!!"), language = /datum/language/common)
 
@@ -848,7 +845,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 /obj/item/matthios_canister/goodnite
 	name = "vial of goodnite base"
 	desc = "A dim, cloudy fluid rests inside, barely moving. Occasionally, something viscous streaks through it— like diluted brain matter. The glass feels warm, almost comforting. Staring at too long makes your eyelids heavy, and you get an odd compulsion to drink it."
-	
+
 	var/max_ingredients = 5
 
 	required_ingredients = list(
@@ -954,7 +951,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		return
 
 	if(target == user)
-		to_chat(user, span_notice("You begin administering the vial to [target.name]'s forehead..."))	
+		to_chat(user, span_notice("You begin administering the vial to [target.name]'s forehead..."))
 	else
 		to_chat(user, span_notice("You begin administering the vial to your own forehead..."))
 
@@ -1337,7 +1334,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 			return TRUE
 
 		var/amount = min(20, R.reagents.total_volume)
-		
+
 		if(do_after(user, 2 SECONDS))
 			if(has_blood)
 				path = "blood"
@@ -1736,7 +1733,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios/gilded/examine(mob/user)
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_FREEMAN) && stolen_fyre)
-		. += span_notice("<i>As coin begets coin, so too does Her pride beget ruin. She believes Her will absolute, yet She stands as anything but. The theft of Her fyre was merely the first proof. The future belongs to the free. To humenkind. Not to the rule of a weak tyrant and their blood-bound puppets.</i>")	
+		. += span_notice("<i>As coin begets coin, so too does Her pride beget ruin. She believes Her will absolute, yet She stands as anything but. The theft of Her fyre was merely the first proof. The future belongs to the free. To humenkind. Not to the rule of a weak tyrant and their blood-bound puppets.</i>")
 	if(HAS_TRAIT(user, TRAIT_FREEMAN))
 		. += span_warning("This amulet can be swapped into another form by using it on your hand.")
 
@@ -1759,7 +1756,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		icon_state = "matthios"
 		to_chat(user, span_warning("The gilded amulet settles back into familiar weight. You feel a grin, as He commends you for your boldness."))
 		playsound(user.loc, 'sound/magic/swap.ogg', 25, TRUE, -2)
-	
+
 	update_icon()
 
 /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios/gilded/equipped(mob/living/carbon/human/user, slot)
@@ -1830,7 +1827,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 /obj/item/clothing/mask/rogue/spectacles/matthios/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(obj_broken || active_item)
-		return		
+		return
 	if(slot == SLOT_WEAR_MASK || slot == SLOT_HEAD)
 		if(HAS_TRAIT(user, TRAIT_FREEMAN))
 			active_item = TRUE
@@ -2203,7 +2200,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 
 /obj/item/rope/chain/matthios
 	name = "gilded chain"
-	desc = "A heavy, gilded chain that thrums with latent divine power. It resonates negatively with the essence of nobility, as if stirred by divine rebuke."	
+	desc = "A heavy, gilded chain that thrums with latent divine power. It resonates negatively with the essence of nobility, as if stirred by divine rebuke."
 	color = "#fdff86"
 	aura_color = "#fff385"
 	matthios_chains = TRUE


### PR DESCRIPTION
## About The Pull Request

stops a matthios revives from not working on nobles; not lore compliant.

## Testing Evidence

linechange, should be good

## Why It's Good For The Game

matthios doesn't inherently hate nobility. see: lirvas, drakkyn lore, etc

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: lifesvial can be used on nobles now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
