### PR TITLE
[PORT] - Noelle's Optimize Lighting Subsystem Fire ()

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -39,56 +39,87 @@ SUBSYSTEM_DEF(lighting)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	while(length(sources_queue))
-		var/datum/light_source/L = sources_queue[1]
-		sources_queue.Cut(1, 2)
-
-		if(!L || QDELETED(L))
-			continue
+	var/list/queue = sources_queue
+	// anything added while processing gets deferred to the next tick
+	var/current_index = 0
+	while(current_index < length(queue))
+		current_index += 1
+		var/datum/light_source/L = queue[current_index]
 
 		L.update_corners()
-		L.needs_update = LIGHTING_NO_UPDATE
+		// update_corners() can qdel(L) in certain conditions, and we don't count
+		// those for the cut because they're already removed from the queue
+		if(!QDELING(L))
+			L.needs_update = LIGHTING_NO_UPDATE
+		else
+			current_index -= 1
 
 		if(init_tick_checks)
-			CHECK_TICK
+			if(!TICK_CHECK)
+				continue
+			queue.Cut(1, current_index + 1)
+			current_index = 0
+			stoplag()
 		else if(MC_TICK_CHECK)
 			break
+	if(current_index)
+		queue.Cut(1, current_index + 1)
+		current_index = 0
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	while(length(corners_queue))
-		var/datum/lighting_corner/C = corners_queue[1]
-		corners_queue.Cut(1, 2)
-
-		if(!C || QDELETED(C))
-			continue
+	queue = corners_queue
+	while(current_index < length(queue))
+		current_index += 1
+		var/datum/lighting_corner/C = queue[current_index]
 
 		C.update_objects()
-		C.needs_update = FALSE
+		C.needs_update = FALSE //update_objects() can call qdel if the corner is storing no data
+		if(QDELING(C))
+			current_index -= 1
 
 		if(init_tick_checks)
-			CHECK_TICK
+			if(!TICK_CHECK)
+				continue
+			queue.Cut(1, current_index + 1)
+			current_index = 0
+			stoplag()
 		else if(MC_TICK_CHECK)
 			break
+	if(current_index)
+		queue.Cut(1, current_index + 1)
+		current_index = 0
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	while(length(objects_queue))
-		var/atom/movable/lighting_object/O = objects_queue[1]
-		objects_queue.Cut(1, 2)
+	queue = objects_queue
+	while(current_index < length(queue))
+		current_index += 1
+		var/atom/movable/lighting_object/O = queue[current_index]
 
-		if(!O || QDELETED(O))
+		if(QDELETED(O))
 			continue
 
+		// these can't delete themselves in update(), so nothing here is removed from the queue mid-loop
 		O.update()
 		O.needs_update = FALSE
 
 		if(init_tick_checks)
-			CHECK_TICK
+			if(!TICK_CHECK)
+				continue
+			queue.Cut(1, current_index + 1)
+			current_index = 0
+			stoplag()
 		else if(MC_TICK_CHECK)
 			break
+	if(current_index)
+		queue.Cut(1, current_index + 1)
+		current_index = 0
+
+	if(!init_tick_checks)
+		MC_SPLIT_TICK
 
 /datum/controller/subsystem/lighting/Recover()
 	if(SSlighting)


### PR DESCRIPTION
## About The Pull Request
Port of https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1958

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="780" height="1077" alt="dreamseeker_kCcA3Hh1a6" src="https://github.com/user-attachments/assets/942b3dd4-d0b1-4c5f-aacf-b180c6cb7d09" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Improve lighting performance, one of our big eater.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Ported lighting subsystem fire() optimization by Noelle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
