### PR TITLE
Fixes shotgun projectile not applying damage reduction to armor

### DIFF
--- a/code/modules/spells/spell_types/wizard/ferramancy/sawblade_volley.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/sawblade_volley.dm
@@ -68,6 +68,14 @@
 	var/hits = 0
 	var/max_hits = 3
 
+/obj/projectile/magic/sawblade/prehit(atom/target)
+	if(ismob(target))
+		var/mob/living/M = target
+		if(M.mob_timers[MT_SAWBLADE] && world.time < M.mob_timers[MT_SAWBLADE] + SAWBLADE_HIT_IMMUNITY)
+			return FALSE
+		M.mob_timers[MT_SAWBLADE] = world.time
+	return ..()
+
 /obj/projectile/magic/sawblade/on_hit(target)
 	if(ismob(target))
 		var/mob/living/M = target
@@ -76,11 +84,6 @@
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
-		// Same-volley duplicate hit immunity
-		if(M.mob_timers[MT_SAWBLADE] && world.time < M.mob_timers[MT_SAWBLADE] + SAWBLADE_HIT_IMMUNITY)
-			qdel(src)
-			return BULLET_ACT_BLOCK
-		M.mob_timers[MT_SAWBLADE] = world.time
 		playsound(get_turf(target), hitsound, 80, TRUE)
 	. = ..()
 	if(!ismob(target))

--- a/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
@@ -79,6 +79,15 @@
 	damage = 26
 	arcshot = TRUE
 
+/obj/projectile/energy/stygian/prehit(atom/target)
+	if(ismob(target))
+		var/mob/living/M = target
+		if(M.mob_timers[MT_STYGIAN] && world.time < M.mob_timers[MT_STYGIAN] + STYGIAN_DR_DURATION)
+			damage = reduced_damage
+		else
+			M.mob_timers[MT_STYGIAN] = world.time
+	return ..()
+
 /obj/projectile/energy/stygian/on_hit(target)
 	if(ismob(target))
 		var/mob/living/M = target
@@ -87,10 +96,6 @@
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
-		if(M.mob_timers[MT_STYGIAN] && world.time < M.mob_timers[MT_STYGIAN] + STYGIAN_DR_DURATION)
-			damage = reduced_damage
-		else
-			M.mob_timers[MT_STYGIAN] = world.time
 	. = ..()
 
 #undef MT_STYGIAN

--- a/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
@@ -80,6 +80,17 @@
 	damage = 20
 	arcshot = TRUE
 
+/obj/projectile/magic/gravel_blast/prehit(atom/target)
+	if(ismob(target))
+		var/mob/living/M = target
+		if(M == firer)
+			damage = round(damage / 2)
+		else if(M.mob_timers[MT_ROCKSHOT] && world.time < M.mob_timers[MT_ROCKSHOT] + ROCKSHOT_DR_DURATION)
+			damage = reduced_damage
+		else
+			M.mob_timers[MT_ROCKSHOT] = world.time
+	return ..()
+
 /obj/projectile/magic/gravel_blast/on_hit(target)
 	if(ismob(target))
 		var/mob/living/M = target
@@ -88,12 +99,6 @@
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
-		if(M == firer)
-			damage = round(damage / 2)
-		else if(M.mob_timers[MT_ROCKSHOT] && world.time < M.mob_timers[MT_ROCKSHOT] + ROCKSHOT_DR_DURATION)
-			damage = reduced_damage
-		else
-			M.mob_timers[MT_ROCKSHOT] = world.time
 	. = ..()
 
 // --- Lesser Gravel Blast: 3-projectile variant for poke option picks ---


### PR DESCRIPTION
## About The Pull Request
- Fixes shotgun projectile not applying damage reduction to armor
- Also make sawblade pierce as intended

thanks to kiwides for report

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="760" height="600" alt="dreamseeker_Akt4SPLFTP" src="https://github.com/user-attachments/assets/5410019d-6a51-4ef0-a272-bc3b5f1d33f7" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This must be speedmerged ASAP. This bug is causing single-target point blank:
- Sawblade Volley to deal 180 instead of 60 damage
- Gravel Blast to deal 130 instead of 78 damage
- Stygian to deal 102 instead of 70 damage

To armor. Damage reduction works against limbs, but not against armor.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Fixes shotgun projectile not applying damage reduction to armor. Point Blank GBlast / Sawblade / Stygian will no longer massively overperform at point blank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
