### PR TITLE
[Miracles] - Limits the max heal of all lesser miracles.

### DIFF
--- a/code/modules/spells/pantheon/divine/undivided.dm
+++ b/code/modules/spells/pantheon/divine/undivided.dm
@@ -143,7 +143,6 @@
 	fluff_desc = "Within Their realm disease and ailments hold no sway over the devout, even the deepest wound shall soon come apart in Their light."
 	background_icon = 'icons/mob/actions/undividedmiracles.dmi'
 	button_icon = 'icons/mob/actions/undividedmiracles.dmi'
-	primary_resource_cost = SPELLCOST_MIRACLE
 
 //////////////////////////////////////////////////////////////////////////////////
 // T1 - Recuperation - Restore ENERGY to a target and provide restoration buff. //

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -1,3 +1,6 @@
+#define BASE_HEALING_PER_TICK 3
+#define MAX_BONUS_HEAL 0.5
+
 /datum/action/cooldown/spell/miracle
 	background_icon = 'icons/mob/actions/genericmiracles.dmi'
 	button_icon = 'icons/mob/actions/genericmiracles.dmi'
@@ -107,11 +110,11 @@
 
 	H.patron.on_lesser_heal(owner, spelltarget, &message_out, &message_self, &conditional_buff, &situational_bonus, &is_inhumen)
 
-	var/healing = 2.5
+	var/healing = BASE_HEALING_PER_TICK
 
 	if(conditional_buff)
 		to_chat(owner, "Channeling my patron's power is easier in these conditions!")
-		healing += situational_bonus
+		healing += min(MAX_BONUS_HEAL, situational_bonus)
 
 	if(!ishuman(spelltarget))
 		spelltarget.apply_status_effect(/datum/status_effect/buff/healing, healing, is_inhumen)
@@ -382,3 +385,6 @@
 		bloodbeam.End()
 		return TRUE
 	return FALSE
+
+#undef BASE_HEALING_PER_TICK
+#undef MAX_BONUS_HEAL


### PR DESCRIPTION
## About The Pull Request
- Base heal for lesser miracle up from 2.5 to 3
- Conditionals are capped out at providing a maximum of 0.5 bonus heal.
- Previously, many conditionals could hit 5, or in rare cases even higher.
- undivided heal miracle cost 30 => 15 stamina, to compensate for its heal being standardized to 3.5 max instead of 4.5 at all times.

## Testing Evidence
<img width="1864" height="982" alt="image" src="https://github.com/user-attachments/assets/ff820aca-c786-4352-8308-3009c6f337f4" />

## Why It's Good For The Game
Stopgap measure I think should've been done long ago.
Lesser miracle isn't supposed to be good. It's -lesser- for a reason. But especially overtime, folks have been adding better conditionals that heal for more, or are easier to trigger.

a good example of this is the graggar heal, which just requires blood puddles to be nearby. You can give yourself a minor bleed to heal 5/s instead of 2.5/s, after spreading some puddles out.

Other heals like astrata, required daytime or noble status, so you'd basically be casting at 2.5 for most of the game, given the day is so short, and rarely the boosted value of 4.5-7?? why was it 7 on the high end??

Eora's heal could reach 7.625 as well.

Conditionals shouldn't be something people powergame around. It should be just a small bonus/incentive to do something that befits your faith. But not a surefire way to boost your healing effectiveness past reasonable limits.

This nips the inconsistencies in the butt and standardizes the healing to be reasonable for lesser miracle. If a patron is supposed to heal more, make a dedicated healing spell instead... Lesser miracle is meant to be a cheap, relatively ineffective healing miracle since it's a T1 miracle.

## Changelog
:cl:
balance: capped lesser miracle conditional healing to a minor amount, base healing slightly increased.
/:cl: