### PR TITLE
Lightning Tweaks / Rebal

### DIFF
--- a/code/datums/magic_items/greater_items/greater.dm
+++ b/code/datums/magic_items/greater_items/greater.dm
@@ -51,19 +51,13 @@
 
 	if(isliving(target))
 		var/mob/living/L = target
-		L.Immobilize(0.5 SECONDS)
-		L.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
-		L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
-		L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 6 SECONDS)
+		L.lightning_shock(src)
 
 		for(var/mob/living/nearby in range(2, target))
 			if(nearby == target || nearby == user)
 				continue
 			if(prob(30))
-				nearby.Immobilize(0.5 SECONDS)
-				nearby.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
-				nearby.electrocute_act(1, src, 1, SHOCK_NOSTUN)
-				nearby.apply_status_effect(/datum/status_effect/buff/lightningstruck, 6 SECONDS)
+				nearby.lightning_shock(src)
 				new /obj/effect/temp_visual/lightning(get_turf(target), get_turf(nearby))
 	last_used[source] = world.time
 

--- a/code/game/objects/structures/rune_ward_structure.dm
+++ b/code/game/objects/structures/rune_ward_structure.dm
@@ -85,16 +85,7 @@
 /obj/structure/rune_ward/stun/rune_effect(mob/living/L)
 	to_chat(L, span_danger("<B>The rune erupts with arcyne lightning!</B>"))
 	playsound(src, 'sound/magic/lightning.ogg', 80, TRUE)
-	L.electrocute_act(1, src, 1, flags = SHOCK_NOSTUN)
-	if(!L.mob_timers[MT_LIGHTNING_ADAPTATION] || world.time > L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN)
-		L.Immobilize(0.5 SECONDS)
-		L.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
-		L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 6 SECONDS)
-		L.balloon_alert_to_viewers("<font color='#ffcc00'>shocked! (6s)</font>")
-		L.mob_timers[MT_LIGHTNING_ADAPTATION] = world.time
-	else
-		var/remaining = round((L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN - world.time) / 10)
-		L.balloon_alert_to_viewers("<font color='#ffcc00'>shock adapted ([remaining]s)</font>")
+	L.lightning_shock(src)
 
 /obj/structure/rune_ward/fire
 	name = "flame rune"

--- a/code/modules/clothing/rogueclothes/gloves/contraption.dm
+++ b/code/modules/clothing/rogueclothes/gloves/contraption.dm
@@ -187,10 +187,7 @@
 			if(HAS_TRAIT(C, TRAIT_SHOCKIMMUNE))
 				continue
 			else
-				C.Immobilize(0.5 SECONDS)
-				C.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
-				C.electrocute_act(1, src, 1, SHOCK_NOSTUN)
-				C.apply_status_effect(/datum/status_effect/buff/lightningstruck, 6 SECONDS)
+				C.lightning_shock(src)
 		else
 			playsound(user, 'sound/items/stunmace_toggle (3).ogg', 100)
 			user.visible_message(span_warning("The voltaic link fizzles out!"), span_warning("[C] is too far away!"))

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/lightning_bolt.dm
@@ -1,12 +1,10 @@
 // Lightning Bolt - Fulgurmancy staple hitscan CC spell
-// Hitscan projectile that immobilizes, applies clickcd debuff and lightningstruck (speed -2 for 6s)
+// Hitscan projectile that immobilizes and applies lightningstruck (speed -2 for 6s)
 // Has lightning adaptation: ALL CC effects cannot be reapplied within 15 seconds
-
-
 /datum/action/cooldown/spell/projectile/lightning_bolt
 	button_icon = 'icons/mob/actions/mage_fulgurmancy.dmi'
 	name = "Bolt of Lightning"
-	desc = "Emit a bolt of lightning that burns a target, preventing them from attacking and slowing them down for 6 seconds. \
+	desc = "Emit a bolt of lightning that burns a target, slowing them down and impairing their accuracy for 6 seconds. \
 	Damage is increased by 100% versus simple-minded creechurs. \
 	The CC effects cannot be reapplied to the same target within 15 seconds."
 	button_icon_state = "lightning_bolt"
@@ -46,7 +44,7 @@
 	movement_type = UNSTOPPABLE
 	guard_deflectable = TRUE
 	light_color = LIGHT_COLOR_WHITE
-	damage = 45
+	damage = 60
 	npc_simple_damage_mult = 2
 	damage_type = BURN
 	accuracy = 40
@@ -68,17 +66,7 @@
 			var/mob/living/L = target
 			if(out_of_effective_range())
 				return
-			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
-			// Lightning Adaptation: all CC effects gated behind the adaptation timer
-			if(!L.mob_timers[MT_LIGHTNING_ADAPTATION] || world.time > L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN)
-				L.Immobilize(0.5 SECONDS)
-				L.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
-				L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 6 SECONDS)
-				L.balloon_alert_to_viewers("<font color='#ffcc00'>shocked! (6s)</font>")
-				L.mob_timers[MT_LIGHTNING_ADAPTATION] = world.time
-			else
-				var/remaining = round((L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN - world.time) / 10)
-				L.balloon_alert_to_viewers("<font color='#ffcc00'>shock adapted ([remaining]s)</font>")
+			L.lightning_shock(src)
 	else if(isatom(target))
 		var/atom/A = target
 		A.fire_act()

--- a/code/modules/spells/spell_types/wizard/projectiles_single/blood_lightning.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/blood_lightning.dm
@@ -59,14 +59,5 @@
 			var/mob/living/L = target
 			if(out_of_effective_range())
 				return
-			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
-			if(!L.mob_timers[MT_LIGHTNING_ADAPTATION] || world.time > L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN)
-				L.Immobilize(0.5 SECONDS)
-				L.apply_status_effect(/datum/status_effect/debuff/clickcd, 8 SECONDS)
-				L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 8 SECONDS)
-				L.balloon_alert_to_viewers("<font color='#ffcc00'>shocked! (8s)</font>")
-				L.mob_timers[MT_LIGHTNING_ADAPTATION] = world.time
-			else
-				var/remaining = round((L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN - world.time) / 10)
-				L.balloon_alert_to_viewers("<font color='#ffcc00'>shock adapted ([remaining]s)</font>")
+			L.lightning_shock(src)
 	qdel(src)

--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -85,27 +85,28 @@
 	id = "lightningstruck"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/lightningstruck
 	duration = 6 SECONDS
-	effectedstats = list("speed" = -2)
+	effectedstats = list(STATKEY_SPD = -2, STATKEY_PER = -2, STATKEY_INT = -2)
 
 /atom/movable/screen/alert/status_effect/buff/lightningstruck
 	name = "Lightning Struck"
-	desc = "I can feel the electricity coursing through me."
+	desc = "Shocked, slowed, and disoriented. I can't swing my blade or think properly."
 	icon_state = "debuff"
 	color = "#ffff00"
 
 /datum/status_effect/buff/lightningstruck/on_apply()
 	. = ..()
 	var/mob/living/target = owner
-	ADD_TRAIT(target, TRAIT_SPELLCOCKBLOCK, TRAIT_STATUS_EFFECT)
 	target.update_vision_cone()
 	target.add_movespeed_modifier(MOVESPEED_ID_LIGHTNINGSTRUCK, update=TRUE, priority=100, multiplicative_slowdown=4, movetypes=GROUND)
+	target.stamina_add(25)
+	ADD_TRAIT(target, TRAIT_REVERSE_GUIDANCE, TRAIT_STATUS_EFFECT)
 
 /datum/status_effect/buff/lightningstruck/on_remove()
 	. = ..()
 	var/mob/living/target = owner
-	REMOVE_TRAIT(target, TRAIT_SPELLCOCKBLOCK, TRAIT_STATUS_EFFECT)
 	target.update_vision_cone()
 	target.remove_movespeed_modifier(MOVESPEED_ID_LIGHTNINGSTRUCK, TRUE)
+	REMOVE_TRAIT(target, TRAIT_REVERSE_GUIDANCE, TRAIT_STATUS_EFFECT)
 
 /datum/status_effect/buff/lightningstruck/minor
 	duration = 3 SECONDS
@@ -115,6 +116,18 @@
 	. = ..()
 	var/mob/living/target = owner
 	target.add_movespeed_modifier(MOVESPEED_ID_LIGHTNINGSTRUCK, update=TRUE, priority=100, multiplicative_slowdown=1, movetypes=GROUND)
+
+/mob/living/proc/lightning_shock(source)
+	electrocute_act(1, source, 1, SHOCK_NOSTUN)
+	if(!mob_timers[MT_LIGHTNING_ADAPTATION] || world.time > mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN)
+		Immobilize(0.5 SECONDS)
+		apply_status_effect(/datum/status_effect/buff/lightningstruck)
+		balloon_alert_to_viewers("<font color='#ffcc00'>shocked! (6s)</font>")
+		mob_timers[MT_LIGHTNING_ADAPTATION] = world.time
+		return TRUE
+	var/remaining = round((mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN - world.time) / 10)
+	balloon_alert_to_viewers("<font color='#ffcc00'>shock adapted ([remaining]s)</font>")
+	return FALSE
 
 
 // arcane marks plus helper procs


### PR DESCRIPTION
## About The Pull Request
- Removed the 6 seconds no cast / hard CC (clickCD) from lightning bolt
- Replaced it with a package of -2 PER, -2 INT (so it affects caster too) and Reverse Guidance effects, making them more vulnerable
- The multiplicative speed penalty etc. stays unchanged, it is still a very powerful CC to be hit by
- Increased LBolt damage from 45 -> 60 to compensate partially
- **This is applied universally to every call site, including voltaic gloves, blood lighting, lighting enchantments** - The same functionalities was copy pasted 6 times with minor variations and some of them do not apply shock adaptation. This has been remedied.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="511" height="197" alt="dreamseeker_4jksEI8VZj" src="https://github.com/user-attachments/assets/d266662d-3e85-4715-b1ae-9f3576011ccc" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Hard CC that completely shuts you out of the game is frustrating to deal with.

This keep the potency, increases damage a bit to compensate, and still make it a powerful CC without completely robbing your agency.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Lightning Bolt / Shock effects has been reworked to no longer impose clickCD for 6 seconds but instead also deduct your Int and Perception by -2 and applies Reverse Guidance (-20% parry / dodge chance) so it remains a powerful, but not completely agency robbing CC effects. In addition, all call sites like blood lightning, voltaic gloves, rune wards and enchantment is unified to use this proc and includes the adaptation effect to prevent chaining the CC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
