### PR TITLE
Disable event driven antag migration waves except for Unknightly Journey, unbound death knight and sblade.

### DIFF
--- a/code/modules/events/antagonist/migrant_waves/_base.dm
+++ b/code/modules/events/antagonist/migrant_waves/_base.dm
@@ -3,6 +3,17 @@
 	max_occurrences = 5
 
 	var/datum/migrant_wave/wave_type
+	var/wave_enabled = FALSE
+
+/datum/round_event_control/antagonist/migrant_wave/canSpawnEvent(players_amt, gamemode, fake_check)
+	if(!wave_enabled)
+		return FALSE
+	return ..()
+
+/datum/round_event_control/antagonist/migrant_wave/preRunEvent()
+	if(!wave_enabled)
+		return EVENT_CANT_RUN
+	return ..()
 
 /datum/round_event/migrant_wave
 	var/datum/migrant_wave/wave_type

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -36,10 +36,6 @@
 		if(bandit_job.total_positions < bandit_maxcap)
 			SSmapping.retainer.bandit_goal += 1 * rand(200, 400)
 			SSrole_class_handler.bandits_in_round = TRUE
-			for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
-				if(!player.client)
-					continue
-				to_chat(player, span_danger("Matthios, is this true? Bandits flock to Azuria. four bandit slots have been opened."))
 	if(evilmode == "gnolls")
 		var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
 		var/gnoll_maxcap = max(SSgamemode.story_antag_slot_cap(/datum/antagonist/gnoll), gnoll_job.total_positions)

--- a/code/modules/events/antagonist/migrant_waves/dark_itinerant_knight_wave.dm
+++ b/code/modules/events/antagonist/migrant_waves/dark_itinerant_knight_wave.dm
@@ -1,6 +1,7 @@
 /datum/round_event_control/antagonist/migrant_wave/evil_knight
 	name = "The Unknightly Journey"
 	wave_type = /datum/migrant_wave/evil_knight
+	wave_enabled = TRUE
 
 	weight = 6
 	max_occurrences = 1

--- a/code/modules/events/antagonist/migrant_waves/exiled_adventurer.dm
+++ b/code/modules/events/antagonist/migrant_waves/exiled_adventurer.dm
@@ -69,6 +69,7 @@
 /datum/round_event_control/antagonist/migrant_wave/unbound_death_knight
 	name = "Death Knight (Unbound)"
 	wave_type = /datum/migrant_wave/unbound_death_knight
+	wave_enabled = TRUE
 
 	weight = 6
 	max_occurrences = 2
@@ -103,6 +104,7 @@
 /datum/round_event_control/antagonist/migrant_wave/unbound_spellblade
 	name = "Ancient Spellblade (Unbound)"
 	wave_type = /datum/migrant_wave/unbound_spellblade
+	wave_enabled = TRUE
 
 	weight = 6
 	max_occurrences = 2


### PR DESCRIPTION
## About The Pull Request
My migration rework made rolling antag wave far more visible and they includes a lone lich, vampires, 3 gnolls or 3 bandits. These has now all been disabled. 

I kept in Unknightly Journey, Unbound Death Knight and Unbound Spellblade which feels pretty interesting and not OP.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Test tis on Prod, Xire
<img width="870" height="261" alt="Code_3Ttzuc8Ssv" src="https://github.com/user-attachments/assets/36b738bd-ac22-4757-8eb9-da530837af22" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
3 gnolls / bandits / lone lich / vampire rolling in randomly is kinda coal, especially on Extended round

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Event driven antagonist waves includes a lone lich, vampires, 3 gnolls or 3 bandits has now all been disabled. Unknightly Journey, Unbound Slade or DK is untouched.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
