### PR TITLE
Tempo distribution tweaks

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		to_chat(H, span_warning("My limbs are too frail and my body too tough... the contradiction leaves me unable to resist critical wounds."))
 		
 	var/datum/advclass/advclass = SSrole_class_handler.get_advclass_by_name(H.advjob)
-	if(advclass.tempo_capable && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer") // (Easier to filter these out than apply the bool to every subclass)
+	if(advclass.tempo_capable && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Towner") // (Easier to filter these out than apply the bool to every subclass)
 		if(!H.mind.has_antag_datum(/datum/antagonist/skeleton) && !H.mind.has_antag_datum(/datum/antagonist/lich) && !H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/vampire/lord))
 			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)		
 	return TRUE

--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -72,7 +72,8 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		REMOVE_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, null)
 		to_chat(H, span_warning("My limbs are too frail and my body too tough... the contradiction leaves me unable to resist critical wounds."))
 		
-	if((H.advjob != "Knight Banneret" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician" && H.mind.assigned_role != "Inquisitor"))
+	var/datum/advclass/advclass = SSrole_class_handler.get_advclass_by_name(H.advjob)
+	if(advclass.tempo_capable && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer") // (Easier to filter these out than apply the bool to every subclass)
 		if(!H.mind.has_antag_datum(/datum/antagonist/skeleton) && !H.mind.has_antag_datum(/datum/antagonist/lich) && !H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/vampire/lord))
 			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)		
 	return TRUE

--- a/code/game/objects/items/ritualcircles.dm
+++ b/code/game/objects/items/ritualcircles.dm
@@ -1585,7 +1585,7 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_purple("They are ignorant, backwards, without hope. You. You will be powerful."))
-		REMOVE_TRAIT(target, TRAIT_TEMPO, TRAIT_SPECIES)
+		REMOVE_TRAIT(target, TRAIT_TEMPO, SPECIES_TRAIT)
 
 /datum/outfit/job/roguetown/darksteelrite
 	var/obj/item/clothing/head/roguetown/helmet/heavy/selected_helm_path = /obj/item/clothing/head/roguetown/helmet/heavy/zizo
@@ -1729,7 +1729,7 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_cult("More to the maw, this shall help feed our greed."))
-		REMOVE_TRAIT(target, TRAIT_TEMPO, TRAIT_SPECIES)
+		REMOVE_TRAIT(target, TRAIT_TEMPO, SPECIES_TRAIT)
 
 /// Performs the de-noblification ritual, which requires a noble character in the center of the circle. TRUE on success, FALSE on failure.
 /obj/structure/ritualcircle/matthios/proc/defenestration()
@@ -1947,7 +1947,7 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_cult("Break them."))
-		REMOVE_TRAIT(target, TRAIT_TEMPO, TRAIT_SPECIES)
+		REMOVE_TRAIT(target, TRAIT_TEMPO, SPECIES_TRAIT)
 
 /// Performs the war ritual, which requires a noble, clergy, or inquisition member in the center of the circle. TRUE on success, FALSE on failure.
 /obj/structure/ritualcircle/graggar/proc/perform_warritual()
@@ -2151,7 +2151,7 @@
 	backr = /obj/item/rogueweapon/spear/partizan/baotha
 
 	H.mind.AddSpell(new /datum/action/cooldown/spell/mending/lesser)
-	REMOVE_TRAIT(H, TRAIT_TEMPO, TRAIT_SPECIES)
+	REMOVE_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 
 //
 

--- a/code/game/objects/items/ritualcircles.dm
+++ b/code/game/objects/items/ritualcircles.dm
@@ -1585,6 +1585,7 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_purple("They are ignorant, backwards, without hope. You. You will be powerful."))
+		REMOVE_TRAIT(target, TRAIT_TEMPO, TRAIT_SPECIES)
 
 /datum/outfit/job/roguetown/darksteelrite
 	var/obj/item/clothing/head/roguetown/helmet/heavy/selected_helm_path = /obj/item/clothing/head/roguetown/helmet/heavy/zizo
@@ -1728,6 +1729,7 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_cult("More to the maw, this shall help feed our greed."))
+		REMOVE_TRAIT(target, TRAIT_TEMPO, TRAIT_SPECIES)
 
 /// Performs the de-noblification ritual, which requires a noble character in the center of the circle. TRUE on success, FALSE on failure.
 /obj/structure/ritualcircle/matthios/proc/defenestration()
@@ -1945,6 +1947,7 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_cult("Break them."))
+		REMOVE_TRAIT(target, TRAIT_TEMPO, TRAIT_SPECIES)
 
 /// Performs the war ritual, which requires a noble, clergy, or inquisition member in the center of the circle. TRUE on success, FALSE on failure.
 /obj/structure/ritualcircle/graggar/proc/perform_warritual()
@@ -2148,6 +2151,7 @@
 	backr = /obj/item/rogueweapon/spear/partizan/baotha
 
 	H.mind.AddSpell(new /datum/action/cooldown/spell/mending/lesser)
+	REMOVE_TRAIT(H, TRAIT_TEMPO, TRAIT_SPECIES)
 
 //
 

--- a/code/game/objects/items/ritualcircles.dm
+++ b/code/game/objects/items/ritualcircles.dm
@@ -1585,7 +1585,6 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_purple("They are ignorant, backwards, without hope. You. You will be powerful."))
-		REMOVE_TRAIT(target, TRAIT_TEMPO, SPECIES_TRAIT)
 
 /datum/outfit/job/roguetown/darksteelrite
 	var/obj/item/clothing/head/roguetown/helmet/heavy/selected_helm_path = /obj/item/clothing/head/roguetown/helmet/heavy/zizo
@@ -1729,7 +1728,6 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_cult("More to the maw, this shall help feed our greed."))
-		REMOVE_TRAIT(target, TRAIT_TEMPO, SPECIES_TRAIT)
 
 /// Performs the de-noblification ritual, which requires a noble character in the center of the circle. TRUE on success, FALSE on failure.
 /obj/structure/ritualcircle/matthios/proc/defenestration()
@@ -1947,7 +1945,6 @@
 		target.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 		spawn(40)
 			to_chat(target, span_cult("Break them."))
-		REMOVE_TRAIT(target, TRAIT_TEMPO, SPECIES_TRAIT)
 
 /// Performs the war ritual, which requires a noble, clergy, or inquisition member in the center of the circle. TRUE on success, FALSE on failure.
 /obj/structure/ritualcircle/graggar/proc/perform_warritual()
@@ -2151,7 +2148,6 @@
 	backr = /obj/item/rogueweapon/spear/partizan/baotha
 
 	H.mind.AddSpell(new /datum/action/cooldown/spell/mending/lesser)
-	REMOVE_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 
 //
 

--- a/code/modules/jobs/job_types/roguetown/Inquisition/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/inquisitor.dm
@@ -82,6 +82,8 @@
 		"The Book" = /obj/item/book/rogue/bibble/psy
 	)
 
+	tempo_capable = TRUE
+
 /datum/outfit/job/roguetown/inquisitor/inspector/pre_equip(mob/living/carbon/human/H)
 	..()
 	has_loadout = TRUE
@@ -215,6 +217,7 @@
 	subclass_stashed_items = list(
 		"The Book" = /obj/item/book/rogue/bibble/psy
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/inquisitor/ordinator/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -71,6 +71,8 @@
 
 	var/class_tempo_faction = null
 
+	var/tempo_capable = TRUE
+
 /datum/advclass/New()
 	if(ispath(age_mod) && !istype(age_mod))
 		var/datum/class_age_mod/newmod = new age_mod()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -47,6 +47,9 @@
 	)
 	vice_restrictions = list(/datum/charflaw/hunted, /datum/charflaw/targeted)
 
+/datum/advclass/gnoll
+	tempo_capable = FALSE
+
 /datum/job/roguetown/gnoll/special_job_check(mob/dead/new_player/player)
 	if(is_storyteller_soft_antag_blocked())
 		return FALSE

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -35,6 +35,7 @@
     )
 
 	extra_context = "This subclass gain the Wound Heal miracle and the Convert Heretic spell."
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/wretch/heretic
 	has_loadout = TRUE
@@ -318,6 +319,7 @@
         "Sewing Kit" =  /obj/item/repair_kit,
     )
 	extra_context = "This subclass gain the Wound Heal miracle and the Convert Heretic spell."
+	tempo_capable = FALSE
 
 
 /datum/outfit/job/roguetown/wretch/hereticspy

--- a/code/modules/jobs/job_types/roguetown/burghers/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/apothecary.dm
@@ -61,6 +61,7 @@
 		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/apothecary/basic/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/burghers/bathmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/bathmaster.dm
@@ -59,6 +59,7 @@
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/bathmaster/basic/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/burghers/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/guildmaster.dm
@@ -66,6 +66,7 @@
 		/datum/skill/craft/traps = SKILL_LEVEL_EXPERT, //setting to higher level to counter an antag trap maker
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/guildmaster
 	has_loadout = TRUE

--- a/code/modules/jobs/job_types/roguetown/burghers/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/guildsman.dm
@@ -31,6 +31,9 @@
 	)
 	spells = list()
 
+/datum/advclass/guildsman
+	tempo_capable = FALSE
+
 /datum/advclass/guildsman/blacksmith
 	name = "Guild Blacksmith"
 	tutorial = "You've studied for many yils under quite a number of master smiths. Whether it's cookware or tools of war, you're unmatched at the art of bending metal to your will."

--- a/code/modules/jobs/job_types/roguetown/burghers/innkeep.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/innkeep.dm
@@ -55,6 +55,7 @@
 		/datum/skill/craft/carpentry = SKILL_LEVEL_APPRENTICE, //apprentice to do some basic repairs around the inn if need be
 		/datum/skill/misc/music = SKILL_LEVEL_APPRENTICE,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/innkeeper/basic/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
@@ -39,6 +39,9 @@
 	// Base gear defaults moved to each subclass pre_equip to avoid
 	// inheritance issues with adept's stoplag-based chant selection.
 
+/datum/advclass/wapprentice
+	tempo_capable = FALSE
+
 /datum/advclass/wapprentice/associate
 	name = "Magician's Associate"
 	tutorial = "No one could truly master the entirety of the arcyne arts. But commanding the fundamentals \

--- a/code/modules/jobs/job_types/roguetown/burghers/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/merchant.dm
@@ -62,6 +62,7 @@ The priests will whisper that you follow the Sun-Thief. Frown, shake your head, 
 		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_APPRENTICE,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/merchant/basic/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/burghers/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/physician.dm
@@ -70,6 +70,7 @@
 		/datum/skill/craft/sewing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/medicine = SKILL_LEVEL_LEGENDARY,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/physician
 	job_bitflag = BITFLAG_ROYALTY

--- a/code/modules/jobs/job_types/roguetown/burghers/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/tailor.dm
@@ -44,6 +44,7 @@
 		/datum/skill/labor/farming = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/tailor/basic/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -55,6 +55,7 @@
 	subclass_stashed_items = list(
 		"The Verses and Acts of the Ten" = /obj/item/book/rogue/bibble,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/monk
 	name = "Acolyte"

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -75,6 +75,7 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	subclass_stashed_items = list(
 		"The Verses and Acts of the Ten" = /obj/item/book/rogue/bibble,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/priest
 	job_bitflag = BITFLAG_HOLY_WARRIOR

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -31,6 +31,7 @@
 	job_subclasses = list(
 		/datum/advclass/courtmage
 	)
+	tempo_capable = FALSE
 
 /datum/advclass/courtmage
 	name = "Court Magician"

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -31,7 +31,6 @@
 	job_subclasses = list(
 		/datum/advclass/courtmage
 	)
-	tempo_capable = FALSE
 
 /datum/advclass/courtmage
 	name = "Court Magician"
@@ -70,6 +69,7 @@
 		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER,
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 	)
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/magician
 	job_bitflag = BITFLAG_ROYALTY

--- a/code/modules/jobs/job_types/roguetown/nobility/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/prince.dm
@@ -30,6 +30,8 @@
 		/datum/advclass/heir/scamp
 	)
 
+/datum/advclass/heir
+	tempo_capable = FALSE
 
 /datum/outfit/job/roguetown/heir/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/retinue/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/knight.dm
@@ -574,6 +574,8 @@
 		/datum/virtue/utility/riding
 	)
 
+	tempo_capable = FALSE
+
 /datum/outfit/job/roguetown/knightchampion/pre_equip(mob/living/carbon/human/H)
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,


### PR DESCRIPTION
## About The Pull Request
Finally added a (frankly dreadful) `tempo_capable` var to the advclass datum. This in turn means we can be a bit more granular about which classes do or don't get Tempo. Anyway, here are some notable differences:

- Towners no longer get Tempo -- it was kinda odd they did anyway.
- Gnolls no longer get Tempo -- they seem to not really need it, with or without current ongoing PRs in context.
- Heretic Wretches (& Spy) no longer get Tempo -- 
~maybe too much, maybe not, but this is the other highly contentious 1vX class that gets explicitly equipped *to deal* with those numbers. I doubt they truly -need- it.
In context of just-as-annoying Tennite H. Wretches, it might be best if the subclass didn't get it at all. I'll leave it for Free tomorrow.~
EDIT from Free of that same evening: nah just remove it from both. They get immense utility & power and should make use of that if outnumbered.
- *Inquisitor* gets it, Ordinator does not. -- this seemed like a neater way to distinguish the subclasses, came to me as I was tweaking this.
- All heirs appropriately do not get Tempo now, previously it was only male ones, I think.
- Removes it from all burghers -- They were mostly non-combat classes (guild, merchant, tailor) except for mage assoc, that probably really doesn't need it.
- Removes it from Bishop -- Ditto
- Removes it from Acolyte -- Ditto

That's it. I really just added a bool.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The half-debug check from yonder was left in the code for way too long, this is some basic sanitization and cleanup. I left the antag datum checks in (even though antag datums themselves purge the trait) because I wasn't sure of the exact order of operations for skeletons etc. (the antag datum might be granted before or after the pre_equip of their class)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Inquisitor subclass now gets Tempo. Ordinator does not.
balance: Gnolls no longer gain Tempo.
balance: Heretic Wretches no longer gain Tempo.
balance: Towners no longer have Tempo.
balance: Burghers no longer have Tempo. This includes Mage Associates.
balance: Bishop no longer have Tempo.
balance: Acolytes no longer have Tempo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
