### PR TITLE
[Balance] Alchemy Expert and Alchemy Skill Audit + Adjustments

### DIFF
--- a/code/datums/migrants/migrant_waves/grenzel_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/grenzel_noble_roles.dm
@@ -157,7 +157,7 @@
 /datum/advclass/grenzel_priest
 	name = "Envoy Priest"
 	outfit = /datum/outfit/job/roguetown/grenzel/priest
-	traits_applied = list(TRAIT_CHOSEN, TRAIT_RITUALIST, TRAIT_SOUL_EXAMINE, TRAIT_GRAVEROBBER, TRAIT_HOMESTEAD_EXPERT, TRAIT_MEDICINE_EXPERT, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_CHOSEN, TRAIT_RITUALIST, TRAIT_SOUL_EXAMINE, TRAIT_GRAVEROBBER, TRAIT_HOMESTEAD_EXPERT, TRAIT_MEDICINE_EXPERT)
 	category_tags = list(CTAG_GRENZEL_PRIEST)
 	subclass_stats = list(
 		STATKEY_STR = -1,
@@ -171,7 +171,7 @@
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_LEGENDARY,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/cooking = SKILL_LEVEL_APPRENTICE,

--- a/code/datums/migrants/migrant_waves/runaway_prisoners.dm
+++ b/code/datums/migrants/migrant_waves/runaway_prisoners.dm
@@ -89,7 +89,7 @@
 	name = "Runaway Prisoner (Mage)"
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/adventurer/runaway_prisoner
-	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_ARCYNE)
 	category_tags = list(CTAG_RUNAWAY_PRISONER)
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 1, "utilities" = 6, "ward" = TRUE)
 	subclass_stats = list(

--- a/code/datums/special_traits/traits/traits.dm
+++ b/code/datums/special_traits/traits/traits.dm
@@ -181,8 +181,7 @@
 /datum/special_trait/arsonist/on_apply(mob/living/carbon/human/character, silent)
 	character.mind.special_items["Firebomb One"] = /obj/item/bomb
 	character.mind.special_items["Firebomb Two"] = /obj/item/bomb
-	ADD_TRAIT(character, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
-	character.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 1, TRUE)
+	character.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 2, TRUE)
 
 /datum/special_trait/pineapple
 	name = "The safeword is \"Pineapple\""

--- a/code/game/objects/items/rogueweapons/ranged/runicflask.dm
+++ b/code/game/objects/items/rogueweapons/ranged/runicflask.dm
@@ -6,7 +6,7 @@
 
 #define TINCTURE_MAX_CHARGES 20
 #define TINCTURE_REFUEL_AMOUNT 20
-#define TINCTURE_REFUEL_SKILL SKILL_LEVEL_JOURNEYMAN
+#define TINCTURE_REFUEL_SKILL SKILL_LEVEL_NONE
 
 /obj/item/runicflask
 	name = "runic tincture flask"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_shaman.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_shaman.dm
@@ -2,7 +2,7 @@
 	name = "Gnoll Shaman"
 	tutorial = "Leader in faith, often the main source of wisdom within a gnoll pack. Few are closer to Graggar himself as you are. You may chose to waylay the hunt, in order to nurture fallen oppponents back to health, so they may grow stronger, providing a true challenge in a future fight."
 	outfit = /datum/outfit/job/roguetown/gnoll/shaman
-	traits_applied = list(TRAIT_RITUALIST, TRAIT_DODGEEXPERT, TRAIT_ALCHEMY_EXPERT) // Surely this won't be broken.
+	traits_applied = list(TRAIT_RITUALIST, TRAIT_DODGEEXPERT) // Surely this won't be broken.
 	reset_stats = TRUE
 	subclass_stats = list(
 		STATKEY_PER = 2,
@@ -25,7 +25,7 @@
 		/datum/skill/craft/traps = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/hunting = SKILL_LEVEL_EXPERT,
 		/datum/skill/labor/butchering = SKILL_LEVEL_APPRENTICE,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgemage.dm
@@ -9,7 +9,7 @@
 	cmode_music = 'sound/music/cmode/antag/combat_thewall.ogg'
 	maximum_possible_slots = 1 //Shadow wizard money gang
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 2, "minor" = 3, "utilities" = 9, "ward" = TRUE)
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_ARCYNE)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_WIL = 3,
@@ -30,7 +30,7 @@
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_LEGENDARY,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER,
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -632,8 +632,6 @@
 			head =  /obj/item/clothing/head/roguetown/roguehood/nochood
 			cloak = /obj/item/clothing/suit/roguetown/shirt/robe/noc
 			H.adjust_skillrank(/datum/skill/misc/reading, SKILL_LEVEL_JOURNEYMAN, TRUE) // Really good at reading... does this really do anything? No. BUT it's soulful.
-			H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_APPRENTICE, TRUE)
-			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC) // we keep this one since adventuring cleric doesnt get it like the regular acolyte.
 			H.adjust_skillrank(/datum/skill/magic/arcane, SKILL_LEVEL_APPRENTICE, TRUE) // for their arcane spells, very little CDR and cast speed.
 			if(H.mind)
 				H.mind.AddSpell(new /datum/action/cooldown/spell/touch/prestidigitation)
@@ -733,7 +731,7 @@
 		if (/datum/patron/divine/pestra)
 			cloak = /obj/item/clothing/cloak/tabard/devotee/pestra
 			H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
-			H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_JOURNEYMAN, TRUE) //pestrans get jman because medicine goddess
 			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 		if (/datum/patron/divine/ravox)
 			cloak = /obj/item/clothing/cloak/tabard/devotee/ravox
@@ -745,6 +743,11 @@
 			head = /obj/item/clothing/head/roguetown/roguehood
 			H.mind?.AddSpell(new /datum/action/cooldown/spell/minion_order)
 			H.mind?.AddSpell(new /datum/action/cooldown/spell/gravemark)
+		if(/datum/patron/inhumen/matthios)
+			cloak = /obj/item/clothing/suit/roguetown/shirt/robe
+			head = /obj/item/clothing/head/roguetown/roguehood
+			H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_JOURNEYMAN, TRUE) //god of alchemy bestows upon ye, jman alchemy
+			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC) //you get this so you can provide a modicum of plausible deniability about your malchemy stuff while doing a bit, but if it gets even a tiny bit of abuse it should be removed
 		else
 			cloak = /obj/item/clothing/suit/roguetown/shirt/robe //placeholder, anyone who doesn't have cool patron drip sprites just gets generic robes
 			head = /obj/item/clothing/head/roguetown/roguehood

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -250,7 +250,6 @@
 			H.change_stat(STATKEY_CON, -1)
 
 			ADD_TRAIT(H, TRAIT_ARCYNE, TRAIT_GENERIC)
-			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 
 			if(H.mind)
 				H.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 1, "minor" = 2, "utilities" = 4))
@@ -321,6 +320,7 @@
 			H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_APPRENTICE, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/craft/sewing, SKILL_LEVEL_APPRENTICE, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/craft/crafting, SKILL_LEVEL_NOVICE, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, SKILL_LEVEL_JOURNEYMAN, TRUE)
 
 			H.change_stat(STATKEY_INT, 2)
 			H.change_stat(STATKEY_LCK, 1)
@@ -329,7 +329,6 @@
 
 			ADD_TRAIT(H, TRAIT_ARCYNE, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_MEDICINE_EXPERT, TRAIT_GENERIC)
-			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 
 			if(H.mind)
 				var/spells = list("Avant Origin (Acceleration)", "Garde Origin (Divergence)")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -8,7 +8,7 @@
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
 	townie_contract_gate_exempt = TRUE
 	townie_contract_gate_hide_in_list = TRUE
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_ARCYNE)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 2,
@@ -24,7 +24,7 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -21,7 +21,7 @@
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE, 
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN, //jman and the trait so you can potionmax with your cauldron while the sage gravel blasts their problems
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
@@ -167,7 +167,7 @@
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE, //limited at apprentice, they have tools to reduce damage taken and slowing down bleeding
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN, //limited at jman with no trait, they have tools to reduce damage taken and slowing down bleeding
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
@@ -295,7 +295,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/holyblade
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
-	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE)
 	subclass_stats = list(
 			STATKEY_STR = 1,
 			STATKEY_PER = 1,
@@ -310,7 +310,7 @@
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN, //alchemy but no trait so you can make health stuff
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -126,7 +126,7 @@
 	tutorial = "Bombs? You've got them. Plenty of them - and the skills to make more. You've spent years training under skilled alchemists and have found the perfect mix to create some chaos - now go blow something up!"
 	outfit = /datum/outfit/job/roguetown/adventurer/bombadier
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander2.ogg'
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_ALCHEMY_EXPERT, TRAIT_EXPLOSIVE_SUPPLY, TRAIT_BOMBER_EXPERT) // Bombardier get an exception - alchemy is part of the gimmick.
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_EXPLOSIVE_SUPPLY, TRAIT_BOMBER_EXPERT) // Bombardier get an exception - alchemy is part of the gimmick.
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_INT = 2,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -466,7 +466,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/mhunter
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander2.ogg'
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_PURITAN_ADVENTURER, TRAIT_ALCHEMY_EXPERT, TRAIT_EXPERT_HUNTER)
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_PURITAN_ADVENTURER, TRAIT_EXPERT_HUNTER)
 	maximum_possible_slots = 5 //Not a Wretch or Towner, but still conditionally lethal for an Adventurer - especially with steel coverage and round-start access to silver weapons. Adjust the amount of available slots as needed.
 	subclass_stats = list(
 		STATKEY_STR = 2,
@@ -612,6 +612,7 @@
 		switch(discipline_choice)
 			if("Traditionalist - Hauberk & Alchemics (+I INT / -I LCK)")
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+				ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC) //this used to be on the class, now its on the subclass that does alchemy stuff. still gotta grind it tho, homeslice has too much sauce as is
 				ADD_TRAIT(H, TRAIT_SILVER_BLESSED, TRAIT_GENERIC) //'Witcher' archetype. Weaponized alchemy gifts both immunity to nitebeastly curses and a self-suppliable +3 statboost. Well-rounded in almost every facet, but leaves less to chance.
 				H.change_stat(STATKEY_INT, 1)
 				H.change_stat(STATKEY_LCK, -1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfelthand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfelthand.dm
@@ -172,7 +172,7 @@
 	Bound once more to serve in the wake of ruin, you climb towards the Peaks."
 	outfit = /datum/outfit/job/roguetown/heartfelt/hand/advisor
 	category_tags = list(CTAG_HFT_HAND)
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_INTELLECTUAL, TRAIT_SEEPRICES_SHITTY, TRAIT_HEARTFELT, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_ARCYNE, TRAIT_INTELLECTUAL, TRAIT_SEEPRICES_SHITTY, TRAIT_HEARTFELT)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 3,
@@ -196,7 +196,7 @@
 		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltlord.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltlord.dm
@@ -101,7 +101,7 @@
 	outfit = /datum/outfit/job/heartfelt/lord/archmage
 	pickprob = 100
 	class_select_category = CLASS_CAT_HFT_COURT
-	traits_applied = list(TRAIT_NOBLE, TRAIT_ARCYNE, TRAIT_INTELLECTUAL, TRAIT_HEARTFELT, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_NOBLE, TRAIT_ARCYNE, TRAIT_INTELLECTUAL, TRAIT_HEARTFELT)
 
 	subclass_stashed_items = list("Heartfelt Caparison" = /obj/item/caparison/heartfelt)
 	subclass_virtues = list(
@@ -118,7 +118,7 @@
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltmagos.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltmagos.dm
@@ -12,7 +12,7 @@
 	category_tags = list(CTAG_HFT_RETINUE)
 	class_select_category = CLASS_CAT_HFT_COURT
 
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_INTELLECTUAL, TRAIT_ALCHEMY_EXPERT, TRAIT_HEARTFELT)
+	traits_applied = list(TRAIT_ARCYNE, TRAIT_INTELLECTUAL, TRAIT_HEARTFELT)
 	subclass_stats = list(
 		STATKEY_INT = 2,
 		STATKEY_PER = 2,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltprior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltprior.dm
@@ -13,7 +13,7 @@
 
 // HIGH COURT - /ONE SLOT/ Roles that were previously in the Court, but moved here.
 
-	traits_applied = list(TRAIT_CHOSEN, TRAIT_RITUALIST, TRAIT_SOUL_EXAMINE, TRAIT_GRAVEROBBER, TRAIT_HOMESTEAD_EXPERT, TRAIT_MEDICINE_EXPERT, TRAIT_HEARTFELT, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_CHOSEN, TRAIT_RITUALIST, TRAIT_SOUL_EXAMINE, TRAIT_GRAVEROBBER, TRAIT_HOMESTEAD_EXPERT, TRAIT_MEDICINE_EXPERT, TRAIT_HEARTFELT)
 
 	subclass_stats = list(
 		STATKEY_INT = 3,
@@ -32,7 +32,7 @@
 	/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/labor/farming = SKILL_LEVEL_APPRENTICE,
-	/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+	/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
 	/datum/skill/magic/holy = SKILL_LEVEL_MASTER,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
@@ -6,7 +6,6 @@
 	
 	outfit = /datum/outfit/job/roguetown/homesteader
 	traits_applied = list(TRAIT_JACKOFALLTRADES,
-		TRAIT_ALCHEMY_EXPERT,
 		TRAIT_SMITHING_EXPERT,
 		TRAIT_SEWING_EXPERT,
 		TRAIT_SURVIVAL_EXPERT,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -151,6 +151,7 @@
 			H.cmode_music = 'sound/music/combat_matthios.ogg'
 			helmets += list("Decorated Bucket Helmet" = /obj/item/clothing/head/roguetown/helmet/heavy/bucket/gold/cleric,) // This is so stupid. - Just a little, but it does look cool!
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios, SLOT_RING, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 3, TRUE) //jman but no trait bcuz god of alchemy
 			H.change_stat(STATKEY_WIL, 2)
 			H.change_stat(STATKEY_STR, 1)
 		if(/datum/patron/inhumen/baotha)
@@ -211,7 +212,7 @@
 			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 			H.adjust_skillrank_up_to(/datum/skill/misc/medicine, 2, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 2, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 3, TRUE) //jman but no trait bcuz goddess of medicine
 		if(/datum/patron/divine/eora)
 			H.change_stat(STATKEY_INT, 2)
 			H.change_stat(STATKEY_PER, 2)
@@ -225,9 +226,7 @@
 			H.change_stat(STATKEY_PER, 2)
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/noc, SLOT_RING, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/clothing/cloak/tabard/crusader/noc, SLOT_CLOAK, TRUE)
-			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 			H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE) // Really good at reading... does this really do anything? No. BUT it's soulful.
-			H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE)
 			H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 			H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 		if(/datum/patron/divine/ravox)
@@ -426,6 +425,7 @@
 		if(/datum/patron/inhumen/matthios)
 			H.cmode_music = 'sound/music/combat_matthios.ogg'
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios, SLOT_RING, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 3, TRUE) //jman but no trait bcuz god of alchemy
 		if(/datum/patron/inhumen/baotha)
 			H.cmode_music = 'sound/music/combat_baotha.ogg'
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/inhumen/baotha, SLOT_RING, TRUE)
@@ -457,9 +457,8 @@
 		if(/datum/patron/divine/pestra)
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/pestra, SLOT_RING, TRUE)
 			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
-			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 			H.adjust_skillrank_up_to(/datum/skill/misc/medicine, 2, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 2, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 3, TRUE) //jman but no trait bcuz goddess of medicine
 		if(/datum/patron/divine/eora)
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/eora, SLOT_RING, TRUE)
 			ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -7,7 +7,7 @@
 	cmode_music = 'sound/music/combat_heretic.ogg'
 	class_select_category = CLASS_CAT_MAGE
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_ZOMBIE_IMMUNE, TRAIT_NOSTINK, TRAIT_GRAVEROBBER, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT)
+	traits_applied = list(TRAIT_ZOMBIE_IMMUNE, TRAIT_NOSTINK, TRAIT_GRAVEROBBER, TRAIT_ARCYNE, TRAIT_MEDICINE_EXPERT)
 	maximum_possible_slots = 2 // Skeles no longer count vs antag cap, however these are pretty strong mage roles with some inzane potental that can make them a fucking menace to deal with if they work for it. A la-wretch heretics.
 	//Slightly worse spread than rogue mage, trades off with a lot of summoning potental + pretty fucking decent armor choice that's more obvious long-term + player skeles with numbers + traits + medicine skill.
 	subclass_stats = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
@@ -1,4 +1,4 @@
-0/datum/advclass/wretch/pyromaniac
+/datum/advclass/wretch/pyromaniac
 	name = "Pyromaniac"
 	tutorial = "A notorious arsonist with a penchant for fire, you wield your own personal vendetta against the chaotic forces within Azuria. Bring mayhem and destruction with flame and misfortune! Just... try not to hit yourself with your explosives - you aren't fireproof, after all."
 	allowed_sexes = list(MALE, FEMALE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
@@ -1,4 +1,4 @@
-/datum/advclass/wretch/pyromaniac
+0/datum/advclass/wretch/pyromaniac
 	name = "Pyromaniac"
 	tutorial = "A notorious arsonist with a penchant for fire, you wield your own personal vendetta against the chaotic forces within Azuria. Bring mayhem and destruction with flame and misfortune! Just... try not to hit yourself with your explosives - you aren't fireproof, after all."
 	allowed_sexes = list(MALE, FEMALE)
@@ -7,7 +7,7 @@
 	cmode_music = 'sound/music/Iconoclast.ogg'
 	class_select_category = CLASS_CAT_ROGUE
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_ALCHEMY_EXPERT, TRAIT_EXPLOSIVE_SUPPLY)
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_EXPLOSIVE_SUPPLY)
 	subclass_stats = list(
 		STATKEY_WIL = 3,
 		STATKEY_CON = 3,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/roguemage.dm
@@ -8,7 +8,7 @@
 	cmode_music = 'sound/music/cmode/antag/combat_thewall.ogg'
 	class_select_category = CLASS_CAT_MAGE
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_ARCYNE)
 	// Slightly better stat spread from necromancer.
 	subclass_stats = list(
 		STATKEY_INT = 4,
@@ -32,7 +32,7 @@
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT,
 	)
 	subclass_stashed_items = list(

--- a/code/modules/jobs/job_types/roguetown/burghers/crier.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/crier.dm
@@ -31,7 +31,6 @@
 	From your desk in the SCOM atelier, you decide which words will thunder across the realm and which will die in the throats of petitioners who didn't pay enough ratfeed. \
 	In your upstairs studio, you host debates, recite gossip, and spin tales that will ripple through every corner of town. All ears are turned toward you - so speak wisely."
 	outfit = /datum/outfit/job/roguetown/loudmouth/basic
-	traits_applied = list(TRAIT_ALCHEMY_EXPERT)
 	subclass_languages = list(
 		/datum/language/elvish,
 		/datum/language/dwarvish,
@@ -58,7 +57,7 @@
 	age_mod = /datum/class_age_mod/archivist
 	subclass_skills = list(
 		/datum/skill/misc/reading = SKILL_LEVEL_LEGENDARY,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE, //idk why you have this but sure, drink some green so you can keep yapping you podcaster
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,

--- a/code/modules/jobs/job_types/roguetown/burghers/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/guildsman.dm
@@ -111,7 +111,7 @@
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 2, "utilities" = 4, "locked_aspects" = list(/datum/magic_aspect/battlewardry, /datum/magic_aspect/artifice), "post_aspect_spells" = list(/obj/effect/proc_holder/spell/invoked/takeapprentice), "ward" = TRUE)
 
 	category_tags = list(CTAG_GUILDSMEN)
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_ARCYNE)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_WIL = 2,
@@ -131,7 +131,7 @@
 		/datum/skill/craft/blacksmithing = SKILL_LEVEL_APPRENTICE, // Artificer makes for a crappy substitute blacksmith but have the same spread
 		/datum/skill/craft/armorsmithing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,	//For the Alchemical mortar only, which is required for explosives. Feel free to remove if the recipe changes.
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,	//For the Alchemical mortar only, which is required for explosives. Feel free to remove if the recipe changes. Also for ingredient harvesting.
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,

--- a/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
@@ -27,7 +27,6 @@
 	cmode_music = 'sound/music/cmode/nobility/combat_courtmage.ogg'
 	advjob_examine = TRUE // So that Court Magicians can know if they're teachin' a Apprentice or if someone's a bit more advanced of a player. Just makes the title show up as the advjob's name.
 
-	job_traits = list(TRAIT_ALCHEMY_EXPERT)
 	job_subclasses = list(
 		/datum/advclass/wapprentice/associate,
 		/datum/advclass/wapprentice/alchemist,
@@ -106,7 +105,7 @@
 	outfit = /datum/outfit/job/roguetown/wapprentice/alchemist
 
 	category_tags = list(CTAG_WAPPRENTICE)
-	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE)
+	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 3,

--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -246,7 +246,7 @@
 		H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
 	if(H.patron?.type == /datum/patron/divine/pestra) // Medicine and Healing - better surgeons and alchemists
 		H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE) //this makes their skill jman bcuz they already have apprentice
+		H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE) //this makes their skill jman
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/eora) // Beauty and Love - beautiful and can read people pretty well.
 		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -246,7 +246,7 @@
 		H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
 	if(H.patron?.type == /datum/patron/divine/pestra) // Medicine and Healing - better surgeons and alchemists
 		H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE) //this makes their skill jman
+		H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, SKILL_LEVEL_JOURNEYMAN, TRUE) //this makes their skill jman
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/eora) // Beauty and Love - beautiful and can read people pretty well.
 		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -32,7 +32,6 @@
 	outfit = /datum/outfit/job/roguetown/monk/basic
 	subclass_languages = list(/datum/language/grenzelhoftian)
 	category_tags = list(CTAG_ACOLYTE)
-	traits_applied = list(TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_WIL = 2,
@@ -231,7 +230,6 @@
 		H.cmode_music = 'sound/music/cmode/church/combat_astrata.ogg'
 	if(H.patron?.type == /datum/patron/divine/noc) // Arcyne and Knowledge - Probably good at reading and the other arcyne adjacent stuff.
 		H.adjust_skillrank(/datum/skill/misc/reading, SKILL_LEVEL_JOURNEYMAN, TRUE) // Really good at reading... does this really do anything? No. BUT it's soulful.
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_APPRENTICE, TRUE)
 		H.adjust_skillrank(/datum/skill/magic/arcane, SKILL_LEVEL_APPRENTICE, TRUE) // for their arcane spells, very little CDR and cast speed.
 		if(H.mind)
 			H.mind.AddSpell(new /datum/action/cooldown/spell/touch/prestidigitation)
@@ -248,7 +246,7 @@
 		H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
 	if(H.patron?.type == /datum/patron/divine/pestra) // Medicine and Healing - better surgeons and alchemists
 		H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
+		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE) //this makes their skill jman bcuz they already have apprentice
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/eora) // Beauty and Love - beautiful and can read people pretty well.
 		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -38,7 +38,6 @@
 	The forest is the most comfortable place for you, toiling alongside soilsons and soilbrides...although sometimes what lies beyond the gates fills your soul with a feral yearning."
 	outfit = /datum/outfit/job/roguetown/druid/basic
 	category_tags = list(CTAG_DRUID)
-	traits_applied = list(TRAIT_ALCHEMY_EXPERT)
 	subclass_languages = list(/datum/language/beast)
 	subclass_stats = list(
 		STATKEY_INT = 2,
@@ -54,7 +53,7 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/labor/farming = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -49,7 +49,6 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	outfit = /datum/outfit/job/roguetown/priest/basic
 	subclass_languages = list(/datum/language/grenzelhoftian)
 	category_tags = list(CTAG_BISHOP)
-	traits_applied = list(TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
 		STATKEY_INT = 4,
 		STATKEY_WIL = 2,

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -294,9 +294,7 @@
 		H.adjust_skillrank(/datum/skill/misc/climbing, SKILL_LEVEL_NOVICE, TRUE)
 	if(H.patron?.type == /datum/patron/divine/noc)
 		H.adjust_skillrank(/datum/skill/misc/reading, SKILL_LEVEL_JOURNEYMAN, TRUE) // Really good at reading... does this really do anything? No. BUT it's soulful.
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
 		H.adjust_skillrank(/datum/skill/magic/arcane, SKILL_LEVEL_NOVICE, TRUE)
-		ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/abyssor)
 		H.adjust_skillrank(/datum/skill/labor/fishing, SKILL_LEVEL_APPRENTICE, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/swimming, SKILL_LEVEL_NOVICE, TRUE)
@@ -308,8 +306,7 @@
 		H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
 	if(H.patron?.type == /datum/patron/divine/pestra)
 		H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
-		ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
+		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_JOURNEYMAN, TRUE) //sets skill to jman, no leveling without the trait
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/eora)
 		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/templar/templar_guardian.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar/templar_guardian.dm
@@ -252,9 +252,7 @@
 		H.adjust_skillrank(/datum/skill/misc/climbing, SKILL_LEVEL_NOVICE, TRUE)
 	if(H.patron?.type == /datum/patron/divine/noc)
 		H.adjust_skillrank(/datum/skill/misc/reading, SKILL_LEVEL_JOURNEYMAN, TRUE) // Really good at reading... does this really do anything? No. BUT it's soulful.
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
 		H.adjust_skillrank(/datum/skill/magic/arcane, SKILL_LEVEL_NOVICE, TRUE)
-		ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/abyssor)
 		H.adjust_skillrank(/datum/skill/labor/fishing, SKILL_LEVEL_APPRENTICE, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/swimming, SKILL_LEVEL_NOVICE, TRUE)
@@ -266,8 +264,7 @@
 		H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
 	if(H.patron?.type == /datum/patron/divine/pestra)
 		H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
-		ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
+		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_JOURNEYMAN, TRUE) //jman because medicine goddess
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/eora)
 		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/templar/templar_monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar/templar_monk.dm
@@ -172,9 +172,7 @@
 		ADD_TRAIT(H, TRAIT_EXPERT_HUNTER, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/noc)
 		H.adjust_skillrank(/datum/skill/misc/reading, SKILL_LEVEL_JOURNEYMAN, TRUE) // Really good at reading... does this really do anything? No. BUT it's soulful.
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
 		H.adjust_skillrank(/datum/skill/magic/arcane, SKILL_LEVEL_NOVICE, TRUE)
-		ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/abyssor)
 		H.adjust_skillrank(/datum/skill/labor/fishing, SKILL_LEVEL_APPRENTICE, TRUE)
 		ADD_TRAIT(H, TRAIT_WATERBREATHING, TRAIT_GENERIC)
@@ -185,8 +183,7 @@
 		H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
 	if(H.patron?.type == /datum/patron/divine/pestra)
 		H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
-		ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
+		H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_JOURNEYMAN, TRUE) //jman because medicine goddess
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/eora)
 		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -27,7 +27,7 @@
 	// Can't get very far as a magician if you can't chant spells now can you?
 	vice_restrictions = list(/datum/charflaw/mute, /datum/charflaw/wanted)
 
-	job_traits = list(TRAIT_ARCYNE, TRAIT_SEEPRICES, TRAIT_INTELLECTUAL, TRAIT_ALCHEMY_EXPERT)
+	job_traits = list(TRAIT_ARCYNE, TRAIT_SEEPRICES, TRAIT_INTELLECTUAL)
 	job_subclasses = list(
 		/datum/advclass/courtmage
 	)

--- a/code/modules/jobs/job_types/roguetown/courtier/suitor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/suitor.dm
@@ -82,7 +82,7 @@
 	name = "Schemer"
 	tutorial = "You're a silver-tongued snake - master of whispers, poison, and perfectly timed accidents. Why win hearts when you can twist them? With rivals removed and secrets weaponized, they will learn your value."
 	outfit = /datum/outfit/job/roguetown/suitor/schemer
-	traits_applied = list(TRAIT_CICERONE, TRAIT_LIGHT_STEP, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_CICERONE, TRAIT_LIGHT_STEP)
 	category_tags = list(CTAG_CONSORT)
 	subclass_stats = list(
 		STATKEY_SPD = 3,

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -238,7 +238,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	tutorial = "Despite spending your younger years focused on reading and the wonders of the arcyne, it came the time for you to take the throne. Now you rule not only by crown and steel, but by spell and wit, show those who doubted your time buried in books was well spent how wrong they were."
 	outfit = /datum/outfit/job/roguetown/lord/mage
 	category_tags = list(CTAG_LORD)
-	traits_applied = list(TRAIT_NOBLE, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT, TRAIT_DNR)
+	traits_applied = list(TRAIT_NOBLE, TRAIT_ARCYNE, TRAIT_DNR)
 	subclass_stats = list(
 		STATKEY_LCK = 5,
 		STATKEY_INT = 4,
@@ -256,7 +256,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 	)
 
 	subclass_virtues = list(

--- a/code/modules/jobs/job_types/roguetown/nobility/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/prince.dm
@@ -118,7 +118,7 @@
 	name = "Introverted Bookworm"
 	tutorial = "Despite your standing, sociability is not your strong suit, and you have kept mostly to yourself and your books. This hardly makes you a favourite among the lords and ladies of the court, and an exit from your room is often met with amusement from nobility and servants alike. But maybe... just maybe, some of your reading interests may be bearing fruit."
 	outfit = /datum/outfit/job/roguetown/heir/bookworm
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_ARCYNE)
 	category_tags = list(CTAG_HEIR)
 	subclass_stats = list(
 		STATKEY_STR = -1,
@@ -266,7 +266,7 @@
 	name = "Nettlesome Scamp"
 	tutorial = "The stories told to you by your bedside of valiant rogues and thieves with hearts of gold saving the worlds. The misunderstood hero. The clammor of Knights, the dull books of the arcyne and the wise never interested you. So you donned the cloak, and with your plump figure learned the arts of stealth. Surely the populace will be forgiving of your antics."
 	outfit = /datum/outfit/job/roguetown/heir/scamp
-	traits_applied = list(TRAIT_SEEPRICES_SHITTY, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_SEEPRICES_SHITTY)
 	category_tags = list(CTAG_HEIR)
 	//Not standard weighted. Not intended to be considering the stat ceilings. -F
 	subclass_stats = list(

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -273,7 +273,7 @@
 	name = "Vampiric Arsonist"
 	tutorial = "There has been nothing more enchanting in unlyfe than the dance of flames upon an inferno of your alchemical mixes and the taste of blood. Now your master arises once more and your talents shall see use again. Your lord's will be done."
 	outfit = /datum/outfit/job/roguetown/other/vampbomber
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_ALCHEMY_EXPERT, TRAIT_EXPLOSIVE_SUPPLY, TRAIT_MEDIUMARMOR, TRAIT_CIVILIZEDBARBARIAN,  TRAIT_BOMBER_EXPERT)
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_EXPLOSIVE_SUPPLY, TRAIT_MEDIUMARMOR, TRAIT_CIVILIZEDBARBARIAN,  TRAIT_BOMBER_EXPERT)
 	category_tags = list(CTAG_VAMPGUARD)
 	subclass_stats = list(
 		STATKEY_INT = 2,
@@ -291,7 +291,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, //Keeping captives, alive. We're not a lich's army, we have standards.
-		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE, //only needs apprentice for bottle bombs
 		/datum/skill/craft/traps = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/engineering = SKILL_LEVEL_EXPERT, //bombs, bombs and more bombs!
 	)
@@ -409,7 +409,7 @@
 	name = "Vampiric Battlemage"
 	tutorial = "You were a magos of old, ever since the embrace you've never had more time to practice your persuit of arcayne magicks, let alone revel in your taste for blood; now your master arises once more and your arcayne research shall see fruitation. Your lord's will be done."
 	outfit = /datum/outfit/job/roguetown/other/vampseigemage
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_INTELLECTUAL, TRAIT_ALCHEMY_EXPERT, TRAIT_ARCYNE)
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_INTELLECTUAL, TRAIT_ARCYNE)
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 2, "utilities" = 6, "ward" = TRUE)
 	category_tags = list(CTAG_VAMPGUARD)
 	subclass_stats = list(
@@ -422,7 +422,7 @@
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER, //You've had a long, time to practice
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE, //Weaker vs grapples, compared to everyone else
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/anthrax.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/anthrax.dm
@@ -12,7 +12,7 @@
 
 	cmode_music = 'sound/music/combat_delf.ogg'
 
-	traits_applied = list(TRAIT_DARKVISION, TRAIT_MEDIUMARMOR, TRAIT_ANTHRAXI, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_DARKVISION, TRAIT_MEDIUMARMOR, TRAIT_ANTHRAXI)
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_CON = 2,
@@ -32,7 +32,7 @@
 		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/traps = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
@@ -92,7 +92,7 @@
 	category_tags = list(CTAG_MERCENARY)
 	class_select_category = CLASS_CAT_RACIAL
 	cmode_music = 'sound/music/combat_delf.ogg'
-	traits_applied = list(TRAIT_DARKVISION, TRAIT_DODGEEXPERT, TRAIT_ANTHRAXI, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_DARKVISION, TRAIT_DODGEEXPERT, TRAIT_ANTHRAXI)
 	subclass_stats = list(
 		STATKEY_WIL = 2,
 		STATKEY_PER = 2,
@@ -107,7 +107,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_sahir.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_sahir.dm
@@ -8,7 +8,7 @@
 	category_tags = list(CTAG_MERCENARY)
 	cmode_music = 'sound/music/combat_desertrider.ogg'
 	subclass_languages = list(/datum/language/raneshi)
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_ARCYNE)
 	subclass_stats = list(
 		STATKEY_SPD = 1,
 		STATKEY_WIL = 2,
@@ -27,7 +27,7 @@
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
 		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,
 	)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
@@ -221,7 +221,7 @@
 	category_tags = list(CTAG_MERCENARY)
 	cmode_music = 'sound/music/combat_grenzelhoft.ogg'
 	subclass_languages = list(/datum/language/grenzelhoftian)
-	traits_applied = list(TRAIT_INTELLECTUAL, TRAIT_STEELHEARTED, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_INTELLECTUAL, TRAIT_STEELHEARTED)
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 2, "utilities" = 6, "variants" = list(/datum/magic_aspect/pyromancy = "grenzelhoftian"), "post_aspect_spells" = list(/datum/action/cooldown/spell/message, /datum/action/cooldown/spell/magicians_brick), "ward" = TRUE)
 	subclass_stats = list(
 		STATKEY_INT = 3,
@@ -245,7 +245,7 @@
 		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 	)
 
 /datum/outfit/job/roguetown/mercenary/grenzelhoft_mage/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/underdweller.dm
@@ -7,7 +7,7 @@
 	outfit = /datum/outfit/job/roguetown/mercenary/underdweller
 	class_select_category = CLASS_CAT_RACIAL
 	category_tags = list(CTAG_MERCENARY)
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_WEBWALK, TRAIT_EXPLOSIVE_SUPPLY, TRAIT_CAVEDWELLER, TRAIT_ALCHEMY_EXPERT) //No bomb expert, only supply. Axes/mining expert.
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_WEBWALK, TRAIT_EXPLOSIVE_SUPPLY, TRAIT_CAVEDWELLER) //No bomb expert, only supply. Axes/mining expert.
 	subclass_stats = list(
 		STATKEY_CON = 2,
 		STATKEY_WIL = 2,
@@ -25,7 +25,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,	//Gets this for bomb making.
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,	//Gets this for bottle bomb making.
 		/datum/skill/craft/engineering = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -8,7 +8,7 @@
 	class_select_category = CLASS_CAT_NALEDI
 	category_tags = list(CTAG_MERCENARY)
 	cmode_music = 'sound/music/warscholar.ogg'
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT, TRAIT_NALEDI)
+	traits_applied = list(TRAIT_ARCYNE, TRAIT_NALEDI)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_WIL = 2,
@@ -217,7 +217,7 @@
 	class_select_category = CLASS_CAT_NALEDI
 	category_tags = list(CTAG_MERCENARY)
 	cmode_music = 'sound/music/warscholar.ogg'
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT, TRAIT_NALEDI)
+	traits_applied = list(TRAIT_ARCYNE, TRAIT_MEDICINE_EXPERT, TRAIT_NALEDI)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_SPD = 2,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/vagabond/failed_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/vagabond/failed_apprentice.dm
@@ -4,7 +4,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	
 	outfit = /datum/outfit/job/roguetown/vagabond/mage
-	traits_applied = list(TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_ARCYNE)
 	category_tags = list(CTAG_VAGABOND)
 	subclass_stats = list(
 		STATKEY_INT = 2,
@@ -16,6 +16,7 @@
 	subclass_skills = list(
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE
 	)
 	extra_context = "Contains randomized skills and stats."
 
@@ -44,7 +45,6 @@
 
 	if(H.mind)
 		SStreasury.grant_savings(ECONOMIC_DESTITUTE, H)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, rand(1,4), TRUE)
 		H.adjust_skillrank(/datum/skill/magic/arcane, rand(1,4), TRUE)
 		H.STAINT = rand(8, 20)
 		H.STACON = rand(5, 10)

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -98,7 +98,7 @@
 	category = "Table"
 	result = list(/obj/item/alch/transisdust)
 	reqs = list(/obj/item/herbseed/taraxacum = 1, /obj/item/herbseed/hypericum = 1, /obj/item/herbseed/salvia = 1)
-	craftdiff = 3
+	craftdiff = 2
 
 //Hard to craft but feasable, will give ONE vial but that has 10 units so, enough to cure 2 people if they ration it.
 /datum/crafting_recipe/roguetown/alchemy/curerot

--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -602,7 +602,7 @@
 	verbage = "mixes"
 	craftsound = 'sound/foley/scribble.ogg'
 	skillcraft = /datum/skill/craft/alchemy
-	craftdiff = 0
+	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alch/magicdust
 	name = "pure essentia"
@@ -613,4 +613,4 @@
 	verbage = "mixes"
 	craftsound = 'sound/foley/scribble.ogg'
 	skillcraft = /datum/skill/craft/alchemy
-	craftdiff = 0
+	craftdiff = 2

--- a/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
@@ -434,7 +434,7 @@
 		/obj/item/natural/clay = 1,
 	)
 	req_table = TRUE
-	craftdiff = 3
+	craftdiff = 2
 	skillcraft = /datum/skill/craft/alchemy
 	verbage_simple = "prepare"
 	verbage = "prepares"

--- a/code/modules/virtues/crafter.dm
+++ b/code/modules/virtues/crafter.dm
@@ -103,7 +103,7 @@
 				added_skills.Add(list(list(/datum/skill/craft/engineering, 2, 2)))
 				added_skills.Add(list(list(/datum/skill/craft/smelting, 2, 2)))
 				added_skills.Add(list(list(/datum/skill/magic/arcane, 2, 2)))
-				added_traits.Add(TRAIT_ENCHANTING_EXPERT, TRAIT_ALCHEMY_EXPERT, TRAIT_ARCYNE, TRAIT_LEYLINE_ATTUNEMENT)
+				added_traits.Add(TRAIT_ENCHANTING_EXPERT, TRAIT_ARCYNE, TRAIT_LEYLINE_ATTUNEMENT)
 				recipient.mind?.special_items["Pestle"] = /obj/item/pestle
 				recipient.mind?.special_items["Mortar"] = /obj/item/reagent_containers/glass/mortar
 				recipient.mind?.special_items["Chalk"] = /obj/item/chalk

--- a/code/modules/virtues/items.dm
+++ b/code/modules/virtues/items.dm
@@ -2,8 +2,8 @@
 	name = "Arsonist"
 	desc = "I like to watch the world burn, and I've stowed away two powerful firebombs to help me achieve that fact. Every day I can take one bomb from any HERMES."
 	custom_text = "Guaranteed Journeyman for Trapmaking."
-	added_skills = list(list(/datum/skill/craft/alchemy, 1, 6), list(/datum/skill/craft/traps, 3, 3))
-	added_traits = list(TRAIT_ALCHEMY_EXPERT, TRAIT_EXPLOSIVE_SUPPLY) // Kaboom
+	added_skills = list(list(/datum/skill/craft/alchemy, 2, 2), list(/datum/skill/craft/traps, 3, 3))
+	added_traits = list(TRAIT_EXPLOSIVE_SUPPLY) // Kaboom
 	added_stashed_items = list("Firebomb #1" = /obj/item/bomb,
 								"Firebomb #2" = /obj/item/bomb,
 								"Flint" = /obj/item/flint


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Hey y’all, code canary here. Due to a lack of controversial PRs this week, I’ve decided to stir the cauldron myself and hope it doesn't explode :)

Jokes and japes aside, this PR is meant to capitalize on changes made in #6788 by auditing every single alchemy expert having class in the game. All **seventy** of them. And based on criteria I’ve come to a standard for their alchemy skill level, and whether or not a class gets to increase it with the trait. I won’t sugar coat it, this is a broad nerf to a lot of classes but the power level for gearing is getting a bit silly and this should calm things down a bit. Besides, you don’t need potions, and it’s a trivial matter to get them from someone who can make them if you do want them.

To help summarize the changes, I’ve made a spreadsheet with an additional preamble to brief/remind people on how alchemy skill currently works as implemented. Please look at this, I made it for myself and realized it would be helpful for everyone who has to look at this PR. Checking like 50 DM files should just be making sure I didn’t sneak in a blacksteel pan recipe, not the base requirement to comprehend the changes.

[CLICK HERE FOR SPREADSHEET (please, I beg of you, use this resource before commenting, it matches the changes in the PR and I will update it continually)](https://docs.google.com/spreadsheets/d/1wREL1Wv4XGQTG61yHtHb-pbPZyxhREcoj0lyvoMB7-E/edit?usp=sharing)

Also I moved some alchemy recipes around a bit:
- Runic tincture refueling no longer requires alchemy at all as the overlap between "good at bows" and "alchemy" is nonexistent without a virtue cost, so I imagine this really neat feature went largely unused because of that. Expert is still required to make the flask in the first place.
- Sui Dust can now be crafted with only apprentice level alchemy (or novice with 11+ int) instead of using Jman.
- Fire Pot - Apprentice, to match bottle bombs so bomber classes don't need 11+ int or jman alchemy to do their bit if they wanna use a sling too
- Raw Essentia and Feau Dust - Moved from no skill required to Apprentice because you cannot use these for anything without apprentice level alchemy anyways so it seemed pointless to let intermediaries be craftable by someone who can't use them.

## Testing Evidence

I’ve thoroughly checked the code and ensured it compiled on my local instance. So if it fails a CI check because it can’t spawn a mob I didn’t touch then i will cry.

I’ve also double and triple checked the commits for spelling mistakes and anything else that would render something non-functional. I uh, don’t think you really want a video of me spawning in as every class. Otherwise, it’s not an implementation of new mechanics. Just a balance of existing ones.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

There are 70 classes in the game ranging from vagabond to antag who have this trait. After my audit, and creating a standard, the conclusion was that only 25 of them really deserved the trait. There’s also 3 virtues that give it, 2 of which do not even need to anymore. There’s also two other ways to get the trait and a gameplay intended way to raise the skill level without the trait but I’m getting ahead of myself. Those are documented in the spreadsheet too.

### The Standards

For the sake of standardization of power, alchemy is now tiered for access by design. Deviations exist and they’ll be explained later. 

Dedicated miracle casters typically max out at apprentice, with the sole exceptions being Pestrans and Matthios due to patron domains. They instead get Jman and no trait. The reason for this is that miracle healing is already fairly potent and miracle kits already have methods of giving buffs and support. So potions are tertiary at best tbh. Martials may also get apprentice if it fits the soul of the class, but currently that's just one of them. I think more could stand to get apprentice if they lack sauce and it fits, but that's out of scope of this PR.

Mages are, with some exception, being standardized around Jman. The reason for this is that they lack innate healing but damage spells are incredibly strong tools and by far the focus of their kit, not alchemy. This is currently tentative, as I may stratify mages into full casters and support mages to distinguish who gets apprentice and who gets jman. 

Dedicated medics are getting Expert at a minimum, as well as dedicated alchemists. The doctors can get it because they need a proactive part of their kit and stat potions sound pretty reasonable for that niche. Alchemists need it because they’re alchemists and if you were questioning why they need good alchemy skill then you should feel silly.

In general, you only get the alchemy expert trait if you are:
- Not a miracle or mage or martial class that has no focus on alchemy
- A support or crafter class with either a focus on alchemy OR the inclusion of alchemy leveling up to legendary doesn't fundamentally change your performance as a class.

Anything beyond that is special snowflake cases and not standardized. Aka, case by case basis for skills and the trait.

### The Problem Children

Contentious choices I’ve made that I don’t feel adequately fit into the intended balance or would be rightfully controversial, but would sacrifice some sovl or role intention to address in the scope of this PR. May just need squinting at, or I’m huffing paint.

**Matthios Missionary** - Gets alchemist expert despite no other Matthios class getting any alchemy skill before this change. No seriously I checked, its just Hedge Alchemist, which is a special antag, nobody else gets it anywhere (but pestra and noc often did, noc being very ???). So they can have this bit of godly flavor for support if they ever decide to sit down and make/buy a cauldron. Matthios heretic isn’t getting the trait because a plate creachur with a stat weight manipulation miracle and expert weapon skills sounds miserable to fight if they can also add an extra 3-6 to their stat weight on top of that. Ask a malpractioner, take a virtue, ask a fellow freeman who is a potion making class, or rob someone for it. I’ll be honest, I’d rather just kill alchemy skill and traits across all the gods as a blanket standard so it becomes entirely class based and not god based. This is the polite compromise for sovl.

**Witch** - In the sense of the current balance space these are already a ??? But acceptable for now. With this change, they suddenly spike in power level as a town-adjacent-but-only-kinda expert alchemist who has a major aspect or T2 miracles (or T1 and a poke spell) and the ability to hit legendary alchemy. Their sole downside is 0 weapon and defensive skills. This flaunts my current balance intention but I’d rather strip down the magic and miracles before stripping down the alchemy because they’re witches lmao. That kind of change is out of the scope of this PR though, and I do have a plan to sauce up (and lower the power level of) old magick witches in the future but that needs time to develop. And I do have a bandaid idea if it’s critical to address now, because I “main” an old magick witch and know the class intimately that I think I can inject a bit of sauce while still managing a nerf.

**Advisor (Hand)** - Ostensibly they need to be an expert alchemist to advise the crown appropriately (or make them viagra/antidotes/poisons) but they're also a good mage too. So this dual role flaunts the balance equation, but it’s maybe fine since there’s only one. Tentatively, I’m leaving them mostly alone, but a possible class split may be wise if hand players are just spamming stat potions at the power classes instead of their actual duties.

**Heartfelt and migrant roles** - idk what the hell these classes are meant to be. I’ve set them to have parity with whatever already exists in town as far as alchemy is concerned. No offense to those who made or play the classes but some of these appear unfinished or untouched with the general server updates. They likely will need updates to define their purpose better.

**Bishop** - Your class design is lumpy and weird and I have no idea how alchemy is even supposed to fit in here. I’ve made the executive decision to give you jman and take away the trait pending someone reworking this class to have a more cohesive identity. I do not believe the leader of the church *really* needs alchemy but they also have medicine so I think they're supposed to be a super acolyte, not a "duke, but for the church".

**Keeper** - Only church miracle role keeping the trait because they’re not really a church role so… mostly keeping it the same because they do actually use alchemy for some of their mechanics as far as I can tell. And they should hypothetically be working with the apothecaries more than the church in terms of “who benefits who”. So it’s fine, I think. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: removed Alchemy Expert from several classes, altered the alchemy level of several classes, please refer to PR #7757 for a spreadsheet with all classes that were changed.
balance: removed alchemy skill requirement to reload a tincture flask
balance: lowered the skill requirement of fire pots and sui dust
balance: added a skill requirement to feau dust and pure essentia, requires apprentice level alchemy
balance: removed alchemy expert from arsonist and skilled enchanter virtues due to being unnecessary for their intended functions. Alchemy skills granted are retained.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Oh and one more thing
Hi, I'm Tank, I'm from one of the downstreams that follows AP balance almost perfectly and elected to make this one upstream as a little birdy told me that now was a great time to make this change upstream with the current balansjak. I workshopped it first on the downstream with some AP players too, so rest assured this isn't just one crazed lunatic's attempt at balance. I took my time, I was thorough, and I was receptive in feedback I received and adjusted accordingly.

I'm not in the Azure Peak discord, if you want discuss the PR in a way that results in changes made to it, you will have to leave a comment. Or make someone else leave one. Please be SPECIFIC in your feedback if you are giving more than blanket agreement or disagreement (or doing a bit). I don't mind people who are not great at english, but I want you to Get To The Point.