### PR TITLE
Makes deathsight generic message no longer tell you to report to dev,…

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -166,11 +166,11 @@ GLOBAL_LIST_EMPTY(last_words)
 	// this was a player that just died, so do the honors
 	if (client)
 		if (!gibbed && !( (src.mind && src.mind.has_antag_datum(/datum/antagonist/zombie)) || (src.mind && src.mind.has_antag_datum(/datum/antagonist/skeleton)) || HAS_TRAIT(src, TRAIT_SECONDLIFE) )) // because I hate being jumpscared by "OOH SOMEONE DIED IN THE CHURCH" when they're just killing a deadite with burn rot to rez them
-			var/locale = prepare_deathsight_message()
 			for (var/mob/living/player in GLOB.player_list)
-				if (player.stat == DEAD || isbrain(player)) 
+				if (player.stat == DEAD || isbrain(player))
 					continue
 				if (HAS_TRAIT(player, TRAIT_DEATHSIGHT))
+					var/locale = prepare_deathsight_message(player) // observer passed in so the fallback can describe direction/distance relative to them
 					if (HAS_TRAIT(player, TRAIT_CABAL))
 						to_chat(player, span_warning("I feel the faint passage of disjointed life essence as it flees [locale]."))
 					else
@@ -179,10 +179,35 @@ GLOBAL_LIST_EMPTY(last_words)
 
 	return TRUE
 
-/mob/living/proc/prepare_deathsight_message()
+/mob/living/proc/prepare_deathsight_message(mob/observer)
 	var/area/A = get_area(src)
 	if(!A)
 		return "an unknown locale, wreathed in enigmatic fog" // fallback if we can't find the area somehow?? -- This was not clear enough for me ICly that it's somewhere I shouldn't care about, now it should
 	if(!A.deathsight_message)
-		return "[A.name], a place with no deathsight message set. Report this to the devs!"
+		log_game("Deathsight: area [A.type] has no deathsight_message set. Death occurred at [AREACOORD(src)].")
+		return generate_relative_deathsight(observer) // area is misconfigured; give the watcher a rough bearing instead of a broken message
 	return A.deathsight_message
+
+/mob/living/proc/generate_relative_deathsight(mob/observer)
+	var/turf/death_turf = get_turf(src)
+	var/turf/observer_turf = get_turf(observer)
+	if(!death_turf || !observer_turf)
+		return "an unknown locale, wreathed in enigmatic fog"
+
+	var/list/parts = list()
+	var/paces = round(get_dist(observer_turf, death_turf), 20) // nearest 20 paces, so the bearing stays imprecise
+	var/dir_text = dir2text(get_dir(observer_turf, death_turf))
+	if(paces <= 0)
+		parts += "somewhere close at hand"
+	else if(dir_text)
+		parts += "roughly [paces] paces to the [dir_text]"
+	else
+		parts += "roughly [paces] paces away"
+
+	var/zdiff = death_turf.z - observer_turf.z
+	if(zdiff > 0)
+		parts += "[zdiff] level\s above me"
+	else if(zdiff < 0)
+		parts += "[abs(zdiff)] level\s below me"
+
+	return jointext(parts, ", ")


### PR DESCRIPTION
## About The Pull Request
Deathsight generic message no longer tell you to report to dev, since it is useless.

It is now logged in game. And in addition, it give you a rough location of where the death occured. If this becomes a problem I will revert to the generic fallback instead.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="624" height="251" alt="Code_sPnVPbqZGy" src="https://github.com/user-attachments/assets/3a785f83-c69a-4867-94c4-8202481f3142" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I'm tired of reports I cannot action on in game man

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Deathsight generic message no longer tell you to report to dev, since it is useless. It is now logged in game log for future dev investigation. And in addition, it give you a rough location of where the death occured. If this becomes a problem I will revert to the generic fallback instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
