### PR TITLE
Remove Hiding Spot Mechanics, Increase Stealth Reveal penalty from 10 to 30 seconds

### DIFF
--- a/code/datums/status_effects/rogue/roguestatus.dm
+++ b/code/datums/status_effects/rogue/roguestatus.dm
@@ -109,7 +109,7 @@
 /datum/status_effect/stealth_revealed
 	id = "stealthreveal"
 	alert_type = /atom/movable/screen/alert/status_effect/stealth_revealed
-	duration = 10 SECONDS
+	duration = 30 SECONDS
 	status_type = STATUS_EFFECT_REFRESH
 
 /datum/status_effect/stealth_revealed/on_apply()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -13,8 +13,6 @@
 	var/climb_offset = 0 //offset up when climbed
 	var/mob/living/structureclimber
 	var/hammer_repair
-	var/hidingspot = FALSE //safety measures, dw about it
-	var/occupied = FALSE
 //	move_resist = MOVE_FORCE_STRONG
 
 /obj/structure/Initialize()
@@ -69,9 +67,6 @@
 
 
 /obj/structure/Destroy()
-	if(hidingspot) //if I don't do this, it deletes the player too
-		for(var/mob/living/M in src)
-			M.forceMove(get_turf(src))
 	if(isturf(loc))
 		for(var/mob/living/user in loc)
 			if(climb_offset)
@@ -233,14 +228,6 @@
 
 /obj/structure/examine(mob/user)
 	. = ..()
-
-	if(in_range(user, src) && istype(user, /mob/living))
-		if(occupied)
-			var/mob/living/M = locate() in src
-			if(M)
-				M.forceMove(get_turf(src))
-				occupied = FALSE
-
 	if(!(resistance_flags & INDESTRUCTIBLE))
 		if(obj_broken)
 			. += span_notice("It appears to be broken.")

--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -10,12 +10,6 @@
 	sleepy = 0.5
 //	pixel_y = 10
 	layer = OBJ_LAYER
-	hidingspot = TRUE
-	var/mob/living/hiddenguy = null // So we can find them with fixed eye search
-
-/obj/structure/chair/bench/get_mechanics_examine(mob/user)
-	. = ..()
-	. += span_info("Some structures can be used as hiding places. Toggle the 'SNEAK' button on your HUD, then click the structure to hide in it. You can stop hiding by clicking the structure again, or by moving out of it.")
 
 /obj/structure/chair/bench/church
 	icon_state = "church_benchleft"
@@ -39,41 +33,6 @@
 	else
 		layer = OBJ_LAYER
 		plane = GAME_PLANE
-
-/obj/structure/chair/bench/attack_hand(mob/user)
-	if(isliving(user))
-		if(user.m_intent == MOVE_INTENT_SNEAK)
-			hideinside(user)
-			return
-		return ..()
-
-/obj/structure/chair/bench/proc/hideinside(mob/living/user)
-	var/sneak_level = user.get_skill_level(/datum/skill/misc/sneaking) || 0
-	var/sneaktime = max(10, 50 - (sneak_level * 10)) // Hard caps at 1 second at Expert and above.
-	if(user.loc == src)
-		unhide(user)
-		return
-	if(occupied)
-		to_chat(user, span_warning("Someone is already hiding under [src]!"))
-		return
-	if(!do_after(user, sneaktime, src))
-		return
-	user.forceMove(src)
-	occupied = TRUE
-	hiddenguy = user
-	to_chat(user, span_warning("I hide under [src]!"))
-
-/obj/structure/chair/bench/proc/unhide(mob/living/user)
-	var/turf/T = get_turf(src)
-	if(!T) return
-	user.forceMove(T)
-	occupied = FALSE
-	hiddenguy = null
-	to_chat(user, span_warning("I come out from under [src]!"))
-
-/obj/structure/chair/bench/relaymove(mob/user)
-	if(user.loc == src)
-		unhide(user)
 
 /obj/structure/chair/bench/post_buckle_mob(mob/living/M)
 	..()
@@ -376,8 +335,6 @@
 	buckle_lying = 90
 	sleepy = 3
 	debris = list(/obj/item/grown/log/tree/small = 1)
-	hidingspot = TRUE
-	var/mob/living/hiddenguy = null // So we can find them with fixed eye search
 
 /obj/structure/bed/rogue/get_mechanics_examine(mob/user)
 	. = ..()
@@ -388,46 +345,11 @@
 	. += span_info("Sleeping will gradually heal most wounds and damages, over time. This can be further enhanced by sleeping next to a lit campfire or fireplace. To begin waking back up, click the arrows that border the HUD's eye once again. If you can see the eye, that means you'll wake up soon.")
 	. += span_info("Once awake, hit the 'RESIST' hotkey or left-click the bed to 'unbuckle' yourself. Once unbuckled, pressing the 'V' key will allow you to fully rise up.")
 	. += span_info("Note that you can still sleep anywhere you wish, even without a bed, by simply laying down and closing your eyes. While this can work in a pinch to stave off tiredness or bolster your characters to survive a critical wound, it's much less ideal.")
-	. += span_info("Some structures can be used as hiding places. Toggle the 'SNEAK' button on your HUD, then click the structure to hide in it. You can stop hiding by clicking the structure again, or by moving out of it.")
 
 /obj/structure/bed/rogue/OnCrafted(dirin)
 	dirin = turn(dirin, 180)
 	. = ..(dirin)
 	update_icon()
-
-/obj/structure/bed/rogue/attack_hand(mob/living/user)
-	if(user.m_intent == MOVE_INTENT_SNEAK)
-		hideinside(user)
-		return
-	return ..()
-
-/obj/structure/bed/rogue/proc/hideinside(mob/living/user)
-	var/sneak_level = user.get_skill_level(/datum/skill/misc/sneaking) || 0
-	var/sneaktime = max(10, 50 - (sneak_level * 10)) // Hard caps at 1 second at Expert and above.
-	if(user.loc == src)
-		unhide(user)
-		return
-	if(occupied)
-		to_chat(user, span_warning("Someone is already hiding under [src]!"))
-		return
-	if(!do_after(user, sneaktime, src))
-		return
-	user.forceMove(src)
-	occupied = TRUE
-	hiddenguy = user
-	to_chat(user, span_warning("I hide under [src]!"))
-
-/obj/structure/bed/rogue/proc/unhide(mob/living/user)
-	var/turf/T = get_turf(src)
-	if(!T) return
-	user.forceMove(T)
-	occupied = FALSE
-	hiddenguy = null
-	to_chat(user, span_warning("I come out from under [src]!"))
-
-/obj/structure/bed/rogue/relaymove(mob/user)
-	if(user.loc == src)
-		unhide(user)
 
 /obj/structure/bed/rogue/attack_right(mob/user)
 	var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -231,50 +231,10 @@
 	static_debris = list(/obj/item/grown/log/tree = 1)
 	climb_offset = 14
 	stump_type = FALSE
-	hidingspot = TRUE
-	var/mob/living/hiddenguy = null // So we can find them with fixed eye search
 
 /obj/structure/flora/roguetree/stump/log/Initialize()
 	. = ..()
 	icon_state = "log[rand(1,2)]"
-
-/obj/structure/flora/roguetree/stump/log/get_mechanics_examine(mob/user)
-	. = ..()
-	. += span_info("Some structures can be used as hiding places. Toggle the 'SNEAK' button on your HUD, then click the structure to hide in it. You can stop hiding by clicking the structure again, or by moving out of it.")
-
-/obj/structure/flora/roguetree/stump/log/attack_hand(mob/user)
-	if(isliving(user))
-		if(user.m_intent == MOVE_INTENT_SNEAK)
-			hideinside(user)
-			return
-
-/obj/structure/flora/roguetree/stump/log/proc/hideinside(mob/living/user)
-	var/sneak_level = user.get_skill_level(/datum/skill/misc/sneaking) || 0
-	var/sneaktime = max(10, 50 - (sneak_level * 10)) // Hard caps at 1 second at Expert and above.
-	if(user.loc == src)
-		unhide(user)
-		return
-	if(occupied)
-		to_chat(user, span_warning("Someone is already hiding inside [src]!"))
-		return
-	if(!do_after(user, sneaktime, src))
-		return
-	user.forceMove(src)
-	occupied = TRUE
-	hiddenguy = user
-	to_chat(user, span_warning("I hide inside [src]!"))
-
-/obj/structure/flora/roguetree/stump/log/proc/unhide(mob/living/user)
-	var/turf/T = get_turf(src)
-	if(!T) return
-	user.forceMove(T)
-	occupied = FALSE
-	hiddenguy = null
-	to_chat(user, span_warning("I come out from inside [src]!"))
-
-/obj/structure/flora/roguetree/stump/log/relaymove(mob/user)
-	if(user.loc == src)
-		unhide(user)
 
 //newbushes
 
@@ -294,7 +254,6 @@
 	. += span_info("Grass, bushes, and most kinds of foliage can be sliced away by hitting them with the 'CUT', 'CHOP', or 'REND' intents on bladed weapons. Using a torch or lamptern on foliage can burn it away, as well.")
 	. += span_info("Left-clicking a bush allows you to forage through it. Most common bushes are rife with thorns, fibers, and jackberries; others can hold unique herbs and flowers, perfect for alchemists and bleeding hearts alike.")
 	. += span_info("Moving through foliage has a chance to attract an ambush. The farther you're away from civilization, the more dangerous that these ambushes can become. Most ambushes can be avoided by toggling the 'SNEAK' button on your HUD, before moving through the foliage.")
-	. += span_info("Some structures can be used as hiding places. Toggle the 'SNEAK' button on your HUD, then click the structure to hide in it. You can stop hiding by clicking the structure again, or by moving out of it.")
 
 /obj/structure/flora/roguegrass/spark_act()
 	fire_act()
@@ -359,8 +318,6 @@
 	climbable = FALSE
 	dir = SOUTH
 	debris = list(/obj/item/natural/fibers = 1, /obj/item/grown/log/tree/stick = 1)
-	hidingspot = TRUE
-	var/mob/living/hiddenguy = null // So we can find them with fixed eye search
 	var/list/looty = list()
 	var/bushtype
 
@@ -410,9 +367,6 @@
 		var/mob/living/L = user
 		user.changeNext_move(CLICK_CD_INTENTCAP)
 		playsound(src.loc, "plantcross", 50, FALSE, -1)
-		if(user.m_intent == MOVE_INTENT_SNEAK)
-			hideinside(user)
-			return
 		if(do_after(L, SEARCHTIME, target = src))
 			if(!looty.len && (world.time > res_replenish))
 				loot_replenish()
@@ -435,40 +389,10 @@
 			if(!looty.len)
 				to_chat(user, span_warning("Picked clean... I should try later."))
 
-/obj/structure/flora/roguegrass/bush/proc/hideinside(mob/living/user)
-	var/sneak_level = user.get_skill_level(/datum/skill/misc/sneaking) || 0
-	var/sneaktime = max(10, 50 - (sneak_level * 10)) // Hard caps at 1 second at Expert and above.
-	if(user.loc == src)
-		unhide(user)
-		return
-	if(occupied)
-		to_chat(user, span_warning("Someone is already hiding in [src]!"))
-		return
-	if(!do_after(user, sneaktime, src))
-		return
-	user.forceMove(src)
-	occupied = TRUE
-	hiddenguy = user
-	to_chat(user, span_warning("I hide in [src]!"))
-
-/obj/structure/flora/roguegrass/bush/proc/unhide(mob/living/user)
-	var/turf/T = get_turf(src)
-	if(!T) return
-	user.forceMove(T)
-	occupied = FALSE
-	hiddenguy = null
-	to_chat(user, span_warning("I come out from [src]!"))
-
-/obj/structure/flora/roguegrass/bush/relaymove(mob/user)
-	if(user.loc == src)
-		unhide(user)
-
 /obj/structure/flora/roguegrass/bush/update_icon()
 	icon_state = "bush[rand(2, 4)]"
 
 /obj/structure/flora/roguegrass/bush/CanAStarPass(ID, travel_dir, caller)
-	if(occupied)
-		return FALSE
 	if(ismovableatom(caller))
 		var/atom/movable/mover = caller
 		if(mover.pass_flags & PASSGRILLE)
@@ -478,8 +402,6 @@
 	return ..()
 
 /obj/structure/flora/roguegrass/bush/CanPass(atom/movable/mover, turf/target)
-	if(occupied)
-		return 0
 	if(istype(mover) && (mover.pass_flags & PASSGRILLE))
 		return 1
 	if(get_dir(loc, target) == dir)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -36,12 +36,6 @@
 	attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
 	blade_dulling = DULLING_BASHCHOP
 	debris = list(/obj/item/grown/log/tree/small = 1)
-	hidingspot = TRUE
-	var/mob/living/hiddenguy = null // So we can find them with fixed eye search
-
-/obj/structure/table/get_mechanics_examine(mob/user)
-	. = ..()
-	. += span_info("Some structures can be used as hiding places. Toggle the 'SNEAK' button on your HUD, then click the structure to hide in it. You can stop hiding by clicking the structure again, or by moving out of it.")
 
 /obj/structure/table/examine(mob/user)
 	. = ..()
@@ -64,17 +58,6 @@
 	return attack_hand(user)
 
 /obj/structure/table/attack_hand(mob/living/user)
-	if(user.m_intent == MOVE_INTENT_SNEAK)
-		var/turf/T = get_turf(src)
-		for(var/obj/structure/bars/B in T)
-			to_chat(user, span_warning("I can't fit down there with the bars in the way!"))
-			return
-		for(var/obj/structure/mineral_door/wood/deadbolt/shutter/b in T)
-			if(!b.door_opened)
-				to_chat(user, span_warning("I can't fit down there with the shutter in the way!"))
-				return
-		hideinside(user)
-		return
 	if(Adjacent(user) && user.pulling)
 		if(isliving(user.pulling))
 			var/mob/living/pushed_mob = user.pulling
@@ -118,34 +101,6 @@
 		if(peel.unload_onto_table(src, user))
 			return TRUE
 	return ..()
-
-/obj/structure/table/proc/hideinside(mob/living/user)
-	var/sneak_level = user.get_skill_level(/datum/skill/misc/sneaking) || 0
-	var/sneaktime = max(10, 50 - (sneak_level * 10)) // Hard caps at 1 second at Expert and above.
-	if(user.loc == src)
-		unhide(user)
-		return
-	if(occupied)
-		to_chat(user, span_warning("Someone is already hiding under [src]!"))
-		return
-	if(!do_after(user, sneaktime, src))
-		return
-	user.forceMove(src)
-	occupied = TRUE
-	hiddenguy = user
-	to_chat(user, span_warning("I hide under [src]!"))
-
-/obj/structure/table/proc/unhide(mob/living/user)
-	var/turf/T = get_turf(src)
-	if(!T) return
-	user.forceMove(T)
-	occupied = FALSE
-	hiddenguy = null
-	to_chat(user, span_warning("I come out from under [src]!"))
-
-/obj/structure/table/relaymove(mob/user)
-	if(user.loc == src)
-		unhide(user)
 
 /obj/structure/table/attack_tk()
 	return FALSE

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -12,15 +12,9 @@
 	attacked_sound = "woodimpact"
 	var/state = 0
 	var/list/allowed_books = list(/obj/item/book, /obj/item/storage/book, /obj/item/recipe_book, /obj/item/skillbook) //Things allowed in the bookcase
-	hidingspot = TRUE
-	var/mob/living/hiddenguy = null // So we can find them with fixed eye search
 
 /obj/structure/bookcase/examine(mob/user)
 	. = ..()
-
-/obj/structure/bookcase/get_mechanics_examine(mob/user)
-	. = ..()
-	. += span_info("Some structures can be used as hiding places. Toggle the 'SNEAK' button on your HUD, then click the structure to hide in it. You can stop hiding by clicking the structure again, or by moving out of it.")
 
 /obj/structure/bookcase/Initialize(mapload)
 	. = ..()
@@ -55,9 +49,6 @@
 
 /obj/structure/bookcase/attack_hand(mob/living/user)
 	. = ..()
-	if(user.m_intent == MOVE_INTENT_SNEAK)
-		hideinside(user)
-		return
 	if(.)
 		return
 	if(user.cmode)
@@ -75,34 +66,6 @@
 			else
 				choice.forceMove(drop_location())
 			update_icon()
-
-/obj/structure/bookcase/proc/hideinside(mob/living/user)
-	var/sneak_level = user.get_skill_level(/datum/skill/misc/sneaking) || 0
-	var/sneaktime = max(10, 50 - (sneak_level * 10)) // Hard caps at 1 second at Expert and above.
-	if(user.loc == src)
-		unhide(user)
-		return
-	if(occupied)
-		to_chat(user, span_warning("Someone is already hiding behind [src]!"))
-		return
-	if(!do_after(user, sneaktime, src))
-		return
-	user.forceMove(src)
-	occupied = TRUE
-	hiddenguy = user
-	to_chat(user, span_warning("I hide behind [src]!"))
-
-/obj/structure/bookcase/proc/unhide(mob/living/user)
-	var/turf/T = get_turf(src)
-	if(!T) return
-	user.forceMove(T)
-	occupied = FALSE
-	hiddenguy = null
-	to_chat(user, span_warning("I come out from behind [src]!"))
-
-/obj/structure/bookcase/relaymove(mob/user)
-	if(user.loc == src)
-		unhide(user)
 
 /obj/structure/bookcase/deconstruct(disassembled = TRUE)
 	for(var/obj/item/book/B in contents)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2157,13 +2157,6 @@
 						found_ping(get_turf(M), client, "hidden")
 
 		for(var/obj/O in view(7,src))
-			if("hiddenguy" in O.vars)
-				var/mob/living/M = O.vars["hiddenguy"]
-				if(M)
-					var/sneak = M.get_skill_level(/datum/skill/misc/sneaking)
-					var/effective_sneak = 8 + (sneak * 2)
-					if(STAPER >= effective_sneak) // skewed towards the hiding player because there's already a separate, guaranteed way to find hiders.
-						found_ping(get_turf(O), client, "hidden")
 			if(istype(O, /obj/item/restraints/legcuffs/beartrap))
 				var/obj/item/restraints/legcuffs/beartrap/M = O
 				if(isturf(M.loc) && M.armed)

--- a/code/modules/spells/roguetown/acolyte/eora/eora_bed.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_bed.dm
@@ -5,7 +5,6 @@
 	debris = null
 	max_integrity = 50
 	icon_state = "eora"
-	hidingspot = FALSE
 	var/list/occupants = list()
 	var/next_heal_time = 0
 	var/heal_cooldown = 10 SECONDS


### PR DESCRIPTION
## About The Pull Request
This removes the hiding spot mechanics from https://github.com/Azure-Peak/Azure-Peak/pull/6622 and keep the rest of the PR's changes intact.
- Remove the hiding spot mechanics
- Stealth reveal penalty increased from 10 to 30 seconds

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1334" height="1031" alt="dreamseeker_f7i7l2Qyg1" src="https://github.com/user-attachments/assets/209f2eed-b2f1-4f23-80cc-68831b155f6f" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
**Stealth Reveal Timer:** it is fun to be the skyrim stealth archer / mage, shooting at someone from the dark and then disappearing. It is absolutely no fun to be on the receiving end of it. Especially when it is stacked with light steps and you have complete freedom in the forest not triggering ambush and the opponents must chase you and somehow predict where you have went. With the new timer, at least you have far more time before they can disappear from middle of combat.

**Hiding Spots:**
The rest of the PR's stealth changes are pretty good, but I take major issues with hiding spot. In exchange for dragging your sprite onto any item, you can just **disappear** forever without a trace, unless someone's taken tracking / sleuth (As we all know, without sleuth tracking is functionally useless). 

At the highest skill level, you can simply disappear into a bush or whatever item under one second, completely throwing off your pursuer without the need to physically hide yourself inside a container, pixelshift, or remove them from line of sight. I think that is very fun for the thief and very unfun for anyone else. Anyone pursuing a thief have to spam right click and most of the time they will not find you - 5 + minutes of efforts to rules out you might've hidden under a bush or a table or whatever underneath. 

I am against asymmetrical mechanics that is very fun for the player but horrible to counter, so I am removing it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Increased stealth reveal timer from 10s to 30s to nerf stealth archery / magery / whatever
del: Remove hiding spots mechanics because it is too hard to counter and too unfair for anyone dealing WITH it. It is also a cause of a few voidspace bugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
