### PR TITLE
[TM] Rotational tweaks, AKA we need to run more people over (AKA I broke stuff and now we're fixing it)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_turf.dm
+++ b/code/__DEFINES/dcs/signals/signals_turf.dm
@@ -6,3 +6,8 @@
 	#define COMPONENT_TURF_DENY_MOVEMENT  (1<<1)
 #define COMSIG_TURF_ENTERED "turf_entered"
 #define COMSIG_TURF_EXITED "turf_exited"
+
+///from /datum/element/footstep/prepare_step(): (list/steps)
+#define COMSIG_TURF_PREPARE_STEP_SOUND "turf_prepare_step_sound"
+	//stops element/footstep/proc/prepare_step() from returning null if the turf itself has no sound
+	#define FOOTSTEP_OVERRIDEN (1<<0)

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -92,6 +92,9 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 /// When moving, will Bump()/Cross() everything, but won't be stopped.
 #define UNSTOPPABLE		(1<<4)
 
+#define MOVETYPES_NOT_TOUCHING_GROUND (FLOATING | FLYING)
+#define MOVETYPES_FLOATING_ANIMATION (FLOATING | FLYING)
+
 //Fire and Acid stuff, for resistance_flags
 #define LAVA_PROOF		(1<<0)
 /// 100% immune to fire damage (but not necessarily to lava or heat)

--- a/code/__DEFINES/footsteps.dm
+++ b/code/__DEFINES/footsteps.dm
@@ -28,6 +28,16 @@
 #define FOOTSTEP_MOB_HUMAN 5 //Warning: Only works on /mob/living/carbon/human
 #define FOOTSTEP_MOB_SLIME 6
 
+//priority defines for the footstep_override element
+#define STEP_SOUND_NO_PRIORITY 0
+#define STEP_SOUND_CONVEYOR_PRIORITY 1
+#define STEP_SOUND_TABLE_PRIORITY 2
+
+///the key to a list of override sounds to replace with. Same format as the global lists.
+#define STEP_SOUND_SHOE_OVERRIDE "step_sound_shoe_override"
+
+///the name of the index key for priority
+#define STEP_SOUND_PRIORITY "step_sound_priority"
 /*
 
 id = list(

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -39,3 +39,5 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 */
 ///Do we not use the priority system?
 #define MOVEMENT_LOOP_IGNORE_PRIORITY (1<<1)
+///Is the loop moving the movable outside its control, like it's an external force? e.g. footsteps won't play if enabled.
+#define MOVEMENT_LOOP_OUTSIDE_CONTROL (1<<4)

--- a/code/datums/components/conveyor_movement.dm
+++ b/code/datums/components/conveyor_movement.dm
@@ -1,0 +1,54 @@
+//Make a component to do things like gravity/flying checks
+///Manages the loop caused by being on a conveyor belt
+///Prevents movement while you're floating, etc
+///Takes the direction to move, delay between steps, and time before starting to move as arguments
+/datum/component/convey
+	var/living_parent = FALSE
+	var/speed
+	var/move_loop_flags = MOVEMENT_LOOP_IGNORE_PRIORITY|MOVEMENT_LOOP_OUTSIDE_CONTROL
+	var/movement_flags_skip = MOVETYPES_FLOATING_ANIMATION
+
+/datum/component/convey/Initialize(direction, speed, start_delay)
+	if(!ismovable(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	living_parent = isliving(parent)
+	src.speed = speed
+	if(!isnum(start_delay))
+		start_delay = speed
+	var/atom/movable/moving_parent = parent
+	var/datum/move_loop/loop = SSmove_manager.move(moving_parent, direction, delay = start_delay, subsystem = SSconveyors, flags = move_loop_flags)
+	RegisterSignal(loop, COMSIG_MOVELOOP_PREPROCESS_CHECK, PROC_REF(should_move))
+	RegisterSignal(loop, COMSIG_QDELETING, PROC_REF(loop_ended))
+
+/datum/component/convey/proc/should_move(datum/move_loop/source)
+	SIGNAL_HANDLER
+	source.delay = speed //We use the default delay
+	if(living_parent)
+		var/mob/living/moving_mob = parent
+		if((moving_mob.movement_type & movement_flags_skip) && !moving_mob.stat)
+			return MOVELOOP_SKIP_STEP
+	var/atom/movable/moving_parent = parent
+	if(moving_parent.anchored)
+		return MOVELOOP_SKIP_STEP
+
+/datum/component/convey/proc/loop_ended(datum/source)
+	SIGNAL_HANDLER
+	if(QDELETED(src))
+		return
+	qdel(src)
+
+/datum/component/convey/current
+	move_loop_flags = MOVEMENT_LOOP_IGNORE_PRIORITY
+	movement_flags_skip = MOVETYPES_NOT_TOUCHING_GROUND
+
+/datum/component/convey/current/should_move(datum/move_loop/source)
+	source.delay = speed //We use the default delay
+	/*
+	var/atom/movable/moving_parent = parent
+	if(!HAS_TRAIT(moving_parent, TRAIT_IMMERSED))
+		return MOVELOOP_SKIP_STEP
+	if(HAS_TRAIT(moving_parent, TRAIT_SWIMMER)) // more time to swim against the current
+		source.delay *= 2
+	*/
+	return ..()

--- a/code/datums/rotation_network_data.dm
+++ b/code/datums/rotation_network_data.dm
@@ -2,9 +2,8 @@
 	var/total_stress = 0
 	var/used_stress = 0
 	var/overstressed = FALSE
-	var/rebuilding = FALSE
-
-	var/list/connected = list()
+	var/list/obj/structure/connected = list()
+	var/list/datum/rotation_segment/segments = list()
 
 /datum/rotation_network/proc/add_connection(obj/structure/incoming)
 	connected |= incoming
@@ -25,8 +24,6 @@
 	outgoing.update_animation_effect()
 
 /datum/rotation_network/proc/check_stress()
-	if(rebuilding)
-		return
 	if(total_stress > 0 && total_stress < used_stress)
 		breakdown()
 	else if(overstressed)
@@ -48,47 +45,248 @@
 	for(var/obj/structure/child in connected)
 		child.update_animation_effect()
 
-/// Reset all non stress generators. Re-propagate from stress generators.
+/datum/rotation_network/proc/build_segments()
+	// Clear existing segments
+	for(var/datum/rotation_segment/seg in segments)
+		qdel(seg)
+	segments = list()
+
+	var/list/assigned = list() // node -> segment
+
+	for(var/obj/structure/node in connected)
+		if(assigned[node])
+			continue
+
+		// BFS to find all shaft-connected nodes with same rpm/dir
+		var/datum/rotation_segment/seg = new()
+		seg.network = src
+		segments += seg
+
+		var/list/to_visit = list(node)
+		assigned[node] = seg
+
+		while(length(to_visit))
+			var/obj/structure/current = to_visit[1]
+			to_visit.Cut(1, 2)
+			seg.members += current
+			current.segment = seg
+
+			for(var/direction in GLOB.cardinals_multiz)
+				var/edge_dir = direction
+				if(!(edge_dir & current.dpdir))
+					continue
+				var/turf/T = get_step_multiz(current, direction)
+				if(!T)
+					continue
+				for(var/obj/structure/neighbor in T.contents)
+					if(assigned[neighbor])
+						continue
+					if(!(neighbor in connected))
+						continue
+					if(!(REVERSE_DIR(direction) & neighbor.dpdir))
+						continue
+					// Same segment if same rpm and direction (shaft connection)
+					assigned[neighbor] = seg
+					to_visit += neighbor
+
+	// Now find segment boundary connections (cog sideways)
+	for(var/datum/rotation_segment/seg in segments)
+		for(var/obj/structure/node in seg.members)
+			if(!istype(node, /obj/structure/rotation_piece/cog))
+				continue
+			for(var/direction in GLOB.cardinals)
+				if(direction & node.dpdir)
+					continue // shaft direction, not a cog sideways connection
+				var/turf/T = get_step(node, direction)
+				if(!T)
+					continue
+				for(var/obj/structure/neighbor in T.contents)
+					if(!(neighbor in connected))
+						continue
+					if(!istype(neighbor, /obj/structure/rotation_piece/cog))
+						continue
+					if(neighbor.dir != node.dir && neighbor.dir != REVERSE_DIR(node.dir))
+						continue
+					var/datum/rotation_segment/neighbor_seg = assigned[neighbor]
+					if(!neighbor_seg || neighbor_seg == seg)
+						continue
+					// Check not already connected
+					var/already_connected = FALSE
+					for(var/datum/segment_connection/conn in seg.connections)
+						if(conn.other == neighbor_seg)
+							already_connected = TRUE
+							break
+					if(already_connected)
+						continue
+					var/datum/segment_connection/conn = new()
+					conn.our_node = node
+					conn.their_node = neighbor
+					conn.other = neighbor_seg
+					conn.flips_direction = TRUE
+					if(istype(node, /obj/structure/rotation_piece/cog))
+						var/obj/structure/rotation_piece/cog/cog = node
+						conn.speed_ratio = istype(neighbor, /obj/structure/rotation_piece/cog) ? (cog.cog_size / neighbor.cog_size) : 1
+					else
+						conn.speed_ratio = 1
+					seg.connections += conn
+
+					var/datum/segment_connection/reverse_conn = new()
+					reverse_conn.our_node = neighbor
+					reverse_conn.their_node = node
+					reverse_conn.other = seg
+					reverse_conn.flips_direction = TRUE
+					if(istype(neighbor, /obj/structure/rotation_piece/cog))
+						var/obj/structure/rotation_piece/cog/cog = neighbor
+						reverse_conn.speed_ratio = istype(node, /obj/structure/rotation_piece/cog) ? (cog.cog_size / node.cog_size) : 1
+					else
+						reverse_conn.speed_ratio = 1
+					neighbor_seg.connections += reverse_conn
+
+/datum/rotation_network/proc/propagate_from_generators()
+	// Find all generator segments and BFS through segment graph
+	var/list/datum/rotation_segment/visited_segs = list()
+	var/list/datum/rotation_segment/to_visit = list()
+
+	for(var/datum/rotation_segment/seg in segments)
+		for(var/obj/structure/node in seg.members)
+			if(!node.stress_generator)
+				continue
+			if(visited_segs[seg])
+				continue
+			visited_segs[seg] = TRUE
+			seg.rotation_direction = node.rotation_direction
+			seg.rotations_per_minute = node.rotations_per_minute
+			to_visit += seg
+			break
+
+	while(length(to_visit))
+		var/datum/rotation_segment/current_seg = to_visit[1]
+		to_visit.Cut(1, 2)
+
+		// Apply rpm/dir to all members
+		for(var/obj/structure/node in current_seg.members)
+			node.rotation_direction = current_seg.rotation_direction
+			if(!node.stress_generator)
+				node.set_rotations_per_minute(current_seg.rotations_per_minute)
+
+		// Propagate to connected segments
+		for(var/datum/segment_connection/conn in current_seg.connections)
+			if(visited_segs[conn.other])
+				continue
+			var/obj/structure/neighbor_seg = conn.other
+			neighbor_seg.rotation_direction = conn.flips_direction ? REVERSE_DIR(current_seg.rotation_direction) : current_seg.rotation_direction
+			neighbor_seg.rotations_per_minute = current_seg.rotations_per_minute * conn.speed_ratio
+			visited_segs[neighbor_seg] = TRUE
+			to_visit += neighbor_seg
+
 /datum/rotation_network/proc/rebuild_group()
-	rebuilding = TRUE
-	var/list/producers = list()
+	// Reset all non-generators
 	for(var/obj/structure/child in connected)
 		if(!child.stress_generator)
 			child.rotation_direction = null
 			child.set_rotations_per_minute(0)
 			var/old_stress_use = child.stress_use
-			child.set_stress_use(0)
+			child.set_stress_use(0, check_network = FALSE)
 			child.set_stress_use(old_stress_use, check_network = FALSE)
-			continue
-		producers |= child
 
-	for(var/obj/structure/producer in producers)
-		producer.find_and_propagate(list(), TRUE)
-	rebuilding = FALSE
+	build_segments()
+	propagate_from_generators()
 	check_stress()
+	update_animation_effect()
 
 /datum/rotation_network/proc/reassess_group(obj/structure/deleted)
-	var/list/returned_nearbys = deleted.return_surrounding_rotation(src)
-	var/list/connected_copy = connected.Copy()
-
-	for(var/obj/structure/near in returned_nearbys)
-		var/list/returned = near.return_connected(deleted, list(), src)
-		connected_copy -= deleted
-		if(length(connected_copy) == length(returned))
-			rebuild_group()
-			return
-		var/datum/rotation_network/new_network = new
-		for(var/obj/structure/returned_object in returned)
-			remove_connection(returned_object)
-			new_network.add_connection(returned_object)
-			if(returned_object.stress_use) // remove_connection resets last_stress_added
-				returned_object.set_stress_use(returned_object.stress_use, check_network = FALSE)
-			if(returned_object.stress_generator)
-				new_network.total_stress += returned_object.last_stress_generation // this is undone in set_stress_generation
-				returned_object.set_stress_generation(returned_object.last_stress_generation, check_network = FALSE)
-		new_network.rebuild_group()
+	connected -= deleted
 
 	if(!length(connected))
 		qdel(src)
 		return
+
+	// BFS to find all nodes still reachable from any remaining node
+	// using both shaft and cog connections
+	var/obj/structure/start = connected[1]
+	var/list/reachable = list()
+	reachable[start] = TRUE
+	var/list/to_visit = list(start)
+
+	while(length(to_visit))
+		var/obj/structure/current = to_visit[1]
+		to_visit.Cut(1, 2)
+
+		// Shaft connections
+		for(var/direction in GLOB.cardinals_multiz)
+			var/turf/T = get_step_multiz(current, direction)
+			if(!T)
+				continue
+			for(var/obj/structure/neighbor in T.contents)
+				if(reachable[neighbor])
+					continue
+				if(!(neighbor in connected))
+					continue
+				if(!(direction & current.dpdir))
+					continue
+				if(!(REVERSE_DIR(direction) & neighbor.dpdir))
+					continue
+				reachable[neighbor] = TRUE
+				to_visit += neighbor
+
+		// Cog sideways connections
+		if(istype(current, /obj/structure/rotation_piece/cog))
+			for(var/direction in GLOB.cardinals)
+				if(direction & current.dpdir)
+					continue
+				var/turf/T = get_step(current, direction)
+				if(!T)
+					continue
+				for(var/obj/structure/neighbor in T.contents)
+					if(reachable[neighbor])
+						continue
+					if(!(neighbor in connected))
+						continue
+					if(!istype(neighbor, /obj/structure/rotation_piece/cog))
+						continue
+					if(neighbor.dir != current.dir && neighbor.dir != REVERSE_DIR(current.dir))
+						continue
+					reachable[neighbor] = TRUE
+					to_visit += neighbor
+
+	if(length(reachable) == length(connected))
+		rebuild_group()
+		return
+
+	// Split unreachable nodes into a new network
+	var/datum/rotation_network/new_network = new
+	for(var/obj/structure/child in connected)
+		if(reachable[child])
+			continue
+		remove_connection(child)
+		new_network.add_connection(child)
+		if(child.stress_use)
+			child.set_stress_use(child.stress_use, check_network = FALSE)
+		if(child.stress_generator)
+			new_network.total_stress += child.last_stress_generation
+			child.set_stress_generation(child.last_stress_generation, check_network = FALSE)
+
+	new_network.rebuild_group()
 	rebuild_group()
+
+/datum/rotation_segment
+	var/datum/rotation_network/network
+	var/rotation_direction
+	var/rotations_per_minute
+	var/list/obj/structure/members = list()
+	var/list/datum/segment_connection/connections = list()
+
+/datum/rotation_segment/Destroy()
+	for(var/obj/structure/node in members)
+		node.segment = null
+	members = list()
+	connections = list()
+	network = null
+	return ..()
+
+/datum/segment_connection
+	var/datum/rotation_segment/other
+	var/obj/structure/our_node
+	var/obj/structure/their_node
+	var/flips_direction = FALSE
+	var/speed_ratio = 1

--- a/code/game/objects/minecart_system/minecart.dm
+++ b/code/game/objects/minecart_system/minecart.dm
@@ -86,7 +86,7 @@
 /obj/structure/closet/crate/miningcar/proc/smack(mob/living/smacked, damage_mod = 1, momentum_mod = 1.5)
 	ASSERT(momentum_mod >= 1)
 	var/cartdamage = damage_mod * momentum //we calculate the damage mod * the speed we're going
-	cartdamage = CLAMP(cartdamage, 0, 50) //we max the damage at 50
+	cartdamage = CLAMP(cartdamage, 0, 100) //we max the damage at 100
 	if(!smacked.apply_damage(cartdamage, BRUTE, BODY_ZONE_CHEST))
 		return
 	if(obj_integrity <= max_integrity * 0.05)
@@ -359,7 +359,7 @@
 			momentum = 0
 			return
 		check_powered()
-		momentum -= 1
+		momentum -= 0.25 //this controls the momentum decay rate. 
 
 	// No more momentum = STOP
 	if(momentum <= 0)

--- a/code/game/objects/minecart_system/minecart_rail.dm
+++ b/code/game/objects/minecart_system/minecart_rail.dm
@@ -152,7 +152,8 @@
 				if(!structure.try_network_merge(src))
 					rotation_break()
 			else
-				if(!structure.try_connect(src))
+				var/result = structure.try_connect(src)
+				if(result == FALSE)
 					rotation_break()
 
 	if(!rotation_network)
@@ -166,13 +167,10 @@
 		return list()
 	. = ..()
 
-/obj/structure/minecart_rail/find_and_propagate(list/checked, first = FALSE)
-	if(!length(checked))
-		checked = list()
-	checked |= src
+/obj/structure/minecart_rail/propagate_rotation_to_network(new_direction, new_rpm)
 	if(ISDIAGONALDIR(dir))
-		return checked
-	. = ..()
+		return
+	..()
 
 /obj/structure/minecart_rail/set_rotations_per_minute(speed)
 	. = ..()

--- a/code/game/rotational_objects/item_rotation_contraption.dm
+++ b/code/game/rotational_objects/item_rotation_contraption.dm
@@ -76,7 +76,7 @@
 			return
 
 	visible_message("[user] starts placing down [src].", "You start to place [src].")
-	if(!do_after(user, 1.2 SECONDS - user?.get_skill_level(/datum/skill/craft/engineering), T))
+	if(!do_after(user, 1 SECONDS - user?.get_skill_level(/datum/skill/craft/engineering), T))
 		return
 	if(QDELETED(stack_target) && ispath(placed_type, /obj/structure/rotation_piece))
 		stack_target = locate(placed_type) in T

--- a/code/game/rotational_objects/roller.dm
+++ b/code/game/rotational_objects/roller.dm
@@ -46,7 +46,7 @@
 	layer = BELOW_OPEN_DOOR_LAYER
 	rotation_structure = TRUE
 	stress_use = 0
-	initialize_dirs = CONN_DIR_LEFT | CONN_DIR_RIGHT | CONN_DIR_FORWARD | CONN_DIR_FLIP
+	initialize_dirs = CONN_DIR_LEFT | CONN_DIR_RIGHT //| CONN_DIR_FORWARD | CONN_DIR_FLIP
 
 	var/operating = FALSE
 	var/movedir

--- a/code/game/rotational_objects/roller.dm
+++ b/code/game/rotational_objects/roller.dm
@@ -1,41 +1,3 @@
-//Make a component to do things like gravity/flying checks
-///Manages the loop caused by being on a conveyor belt
-///Prevents movement while you're floating, etc
-///Takes the direction to move, delay between steps, and time before starting to move as arguments
-/datum/component/convey
-	var/living_parent = FALSE
-	var/speed
-
-/datum/component/convey/Initialize(direction, speed, start_delay)
-	if(!ismovable(parent))
-		return COMPONENT_INCOMPATIBLE
-
-	living_parent = isliving(parent)
-	src.speed = speed
-	if(!start_delay)
-		start_delay = speed
-	var/atom/movable/moving_parent = parent
-	var/datum/move_loop/loop = SSmove_manager.move(moving_parent, direction, delay = start_delay, subsystem = SSconveyors, flags=MOVEMENT_LOOP_IGNORE_PRIORITY)
-	RegisterSignal(loop, COMSIG_MOVELOOP_PREPROCESS_CHECK, PROC_REF(should_move))
-	RegisterSignal(loop, COMSIG_PARENT_QDELETING, PROC_REF(loop_ended))
-
-/datum/component/convey/proc/should_move(datum/move_loop/source)
-	SIGNAL_HANDLER
-	source.delay = speed //We use the default delay
-	if(living_parent)
-		var/mob/living/moving_mob = parent
-		if((moving_mob.movement_type & FLYING) && !moving_mob.stat)
-			return MOVELOOP_SKIP_STEP
-	var/atom/movable/moving_parent = parent
-	if(moving_parent.anchored)
-		return MOVELOOP_SKIP_STEP
-
-/datum/component/convey/proc/loop_ended(datum/source)
-	SIGNAL_HANDLER
-	if(QDELETED(src))
-		return
-	qdel(src)
-
 /obj/structure/roller
 	name = "roller"
 	desc = "A rotating roller that moves items in one direction. Can be powered by rotation from the sides."
@@ -58,8 +20,9 @@
 	movedir = dir
 
 	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
-		COMSIG_ATOM_EXIT = PROC_REF(roller_exit),
+		COMSIG_ATOM_EXITED = PROC_REF(conveyable_exit),
+		COMSIG_ATOM_ENTERED = PROC_REF(conveyable_enter),
+		COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON = PROC_REF(conveyable_enter)
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
@@ -67,9 +30,13 @@
 
 /obj/structure/roller/LateInitialize()
 	. = ..()
+	movedir = dir
 	set_connection_dir()
 	find_rotation_network()
 	build_roller_chain()
+
+/obj/structure/roller/set_connection_dir()
+	dpdir = turn(dir, 90) | turn(dir, -90) | movedir | REVERSE_DIR(movedir)
 
 /obj/structure/roller/Destroy()
 	for(var/obj/structure/roller/connected in connected_rollers)
@@ -133,24 +100,14 @@
 /obj/structure/roller/set_rotations_per_minute(rpm)
 	if(rotations_per_minute == rpm)
 		return FALSE
-
-	rotations_per_minute = rpm
-
-	if(rpm > 0)
-		operating = TRUE
-	else
-		operating = FALSE
+	rotations_per_minute = min(rpm, 32)
+	operating = rotations_per_minute > 0
+	if(!operating)
 		for(var/atom/movable/movable in loc)
 			stop_conveying(movable)
 
 	vand_update_appearance()
-	propagate_rotation()
 	return TRUE
-
-/obj/structure/roller/proc/propagate_rotation()
-	for(var/obj/structure/roller/connected in connected_rollers)
-		if(connected.rotations_per_minute != rotations_per_minute)
-			connected.set_rotations_per_minute(rotations_per_minute)
 
 /obj/structure/roller/proc/build_roller_chain()
 	var/turf/forward_turf = get_step(src, movedir)
@@ -166,52 +123,51 @@
 	var/clamprpm = clamp(rotations_per_minute,0,32) //limiting RPM down
 	return max(1, (10 / (clamprpm / 16))) // Returns deciseconds
 
-/obj/structure/roller/proc/on_entered(datum/source, atom/movable/entering_atom)
+/obj/structure/roller/proc/conveyable_enter(datum/source, atom/movable/entering_atom)
 	SIGNAL_HANDLER
+	if(entering_atom.loc != loc) // If we are not on the same turf (order of operations memes) go to hell
+		return
 
 	if(!operating || !rotations_per_minute)
-		return
-
-	if(!ismovable(entering_atom))
-		return
-
-	var/static/list/unconveyables = typecacheof(list(/obj/effect, /mob/dead))
-	if(is_type_in_typecache(entering_atom, unconveyables))
-		return
-
-	if(entering_atom.anchored || entering_atom == src)
+		stop_conveying(entering_atom)
 		return
 
 	start_conveying(entering_atom)
 
 /obj/structure/roller/proc/start_conveying(atom/movable/moving)
-	if(QDELETED(moving))
-		return
+    if(QDELETED(moving))
+        return
 
-	var/datum/move_loop/move/existing_loop = SSmove_manager.processing_on(moving, SSconveyors)
-	if(existing_loop)
-		existing_loop.direction = movedir
-		existing_loop.delay = get_move_delay()
-		return
+    var/static/list/unconveyables = typecacheof(list(/obj/effect, /mob/dead))
+    if(!istype(moving) || is_type_in_typecache(moving, unconveyables) || moving.anchored || moving == src)
+        return
 
-	moving.AddComponent(/datum/component/convey, movedir, get_move_delay())
+    SSmove_manager.stop_looping(moving, SSconveyors)
+
+    moving.AddComponent(/datum/component/convey, movedir, get_move_delay())
 
 /obj/structure/roller/proc/stop_conveying(atom/movable/thing)
 	if(!ismovable(thing))
 		return
 	SSmove_manager.stop_looping(thing, SSconveyors)
 
-/obj/structure/roller/proc/roller_exit(datum/source, atom/movable/exiting_atom, turf/exit_turf)
-	SIGNAL_HANDLER
+/obj/structure/roller/proc/conveyable_exit(datum/source, atom/convayable, direction)
+    SIGNAL_HANDLER
+    if(!ismovable(convayable))
+        return
 
-	if(!ismovable(exiting_atom))
-		return
+    var/obj/structure/roller/next_roller = locate(/obj/structure/roller) in get_step(src, direction)
+    var/chained_handoff = next_roller && next_roller.operating && \
+                          (direction == movedir) && (next_roller.movedir == movedir)
 
-	var/obj/structure/roller/next_roller = locate(/obj/structure/roller) in exit_turf
+    if(chained_handoff)
+        return 
 
-	// Stop conveying if no operating roller in exit direction
-	if(!next_roller || !next_roller.operating)
-		stop_conveying(exiting_atom)
+    if(convayable.z != z || !isturf(convayable.loc))
+        stop_conveying(convayable)
+        return
+
+    stop_conveying(convayable)
 
 /obj/structure/roller/wrench_act(mob/living/user, obj/item/tool)
 	tool.play_tool_sound(src, 50)
@@ -250,4 +206,3 @@
 		return
 	rotate_roller(user)
 	return TRUE
-

--- a/code/game/rotational_objects/rotation_shaft.dm
+++ b/code/game/rotational_objects/rotation_shaft.dm
@@ -110,7 +110,8 @@
 				if(!structure.try_network_merge(src))
 					rotation_break()
 			else
-				if(!structure.try_connect(src))
+				var/result = structure.try_connect(src)
+				if(result == FALSE)
 					rotation_break()
 
 	if(!rotation_network)
@@ -165,50 +166,6 @@
 		animate(icon_state = "2", time = frame_stage)
 		animate(icon_state = "1", time = frame_stage)
 
-/obj/structure/rotation_piece/cog/find_and_propagate(list/checked, first = FALSE)
-	if(!length(checked))
-		checked = list()
-	checked |= src
-
-	for(var/direction in GLOB.cardinals)
-		var/turf/step_back = get_step(src, direction)
-		if(!step_back)
-			continue
-		for(var/obj/structure/structure in step_back.contents)
-			if(structure in checked)
-				continue
-			if(!(direction & dpdir))  // not in dpdir, check for cog structures
-				if(!istype(structure, /obj/structure/rotation_piece/cog))
-					continue
-			else if(!(REVERSE_DIR(direction) & structure.dpdir))
-				continue
-			if(!(structure in rotation_network.connected))
-				continue
-			propagate_rotation_change(structure, checked, TRUE)
-	if(first && rotation_network)
-		rotation_network.update_animation_effect()
-
-/obj/structure/rotation_piece/cog/propagate_rotation_change(obj/structure/connector, list/checked, first = FALSE)
-	if(!length(checked))
-		checked = list()
-	checked |= src
-
-	var/direction = get_dir(src, connector)
-	if(direction != dir && direction != REVERSE_DIR(dir))
-		if(istype(connector, /obj/structure/rotation_piece/cog))
-			connector.rotation_direction = REVERSE_DIR(rotation_direction)
-			connector.set_rotations_per_minute(get_speed_mod(connector))
-	else
-		if(connector.stress_generator && connector.rotation_direction && rotation_direction && (connector.rotation_direction != rotation_direction))
-			rotation_break()
-			return
-		connector.rotation_direction = rotation_direction
-		if(!connector.stress_generator)
-			connector.set_rotations_per_minute(rotations_per_minute)
-
-	connector.find_and_propagate(checked, FALSE)
-	if(first)
-		rotation_network.update_animation_effect()
 
 /obj/structure/rotation_piece/cog/proc/get_speed_mod(obj/structure/connector)
 	var/obj/structure/rotation_piece/cog = connector

--- a/code/game/rotational_objects/rotational_speed_data.dm
+++ b/code/game/rotational_objects/rotational_speed_data.dm
@@ -13,6 +13,7 @@
 	/// Bitflags of relative directional SHAFT connections. See \code\_DEFINES\rotation_defines.dm
 	var/initialize_dirs
 	var/datum/rotation_network/rotation_network
+	var/datum/rotation_segment/segment
 
 /obj/structure/Initialize()
 	. = ..()
@@ -147,7 +148,8 @@
 				if(!structure.try_network_merge(src))
 					rotation_break()
 			else
-				if(!structure.try_connect(src))
+				var/result = structure.try_connect(src)
+				if(result == FALSE)
 					rotation_break()
 
 	if(!rotation_network)
@@ -159,15 +161,11 @@
 /obj/structure/proc/set_rotational_direction_and_speed(direction, speed)
 	set_rotations_per_minute(speed)
 	rotation_direction = direction
-	find_and_propagate(first = TRUE)
-	rotation_network.check_stress()
-	rotation_network.update_animation_effect()
+	rotation_network.rebuild_group()
 
 /obj/structure/proc/set_rotational_speed(speed)
 	set_rotations_per_minute(speed)
-	find_and_propagate(first = TRUE)
-	rotation_network.check_stress()
-	rotation_network.update_animation_effect()
+	rotation_network.rebuild_group()
 
 // DOES NOT UPDATE NETWORK ANIMATION
 /obj/structure/proc/set_stress_generation(amount, check_network = TRUE)
@@ -187,95 +185,116 @@
 		rotation_network?.check_stress()
 
 /obj/structure/proc/try_connect(obj/structure/connector)
-	if(can_connect(connector))
-		rotation_network.add_connection(connector)
-		pass_rotation_data(connector)
-		if(connector.stress_use)
-			connector.set_stress_use(connector.stress_use)
-		return TRUE
-	return FALSE
+	if(can_connect(connector) == FALSE)
+		return FALSE
+	if(connector.can_connect(src) == FALSE)
+		return null
+	rotation_network.add_connection(connector)
+	if(connector.stress_use)
+		connector.set_stress_use(connector.stress_use, check_network = FALSE)
+	rotation_network.rebuild_group()
+	return TRUE
 
 /obj/structure/proc/can_connect(obj/structure/connector)
 	if(connector.rotation_direction && rotation_direction && (connector.rotation_direction != rotation_direction))
 		if(connector.rotations_per_minute && rotations_per_minute)
-			return FALSE
-	return TRUE
+			return FALSE // direction conflict
+	return TRUE // compatible
 
 /obj/structure/proc/try_network_merge(obj/structure/connector)
-	if(!can_connect(connector))
+	if(can_connect(connector) == FALSE)
+		return FALSE
+	if(connector.can_connect(src) == FALSE)
 		return FALSE
 	if(!rotation_network)
 		return FALSE
 	if(src in connector.rotation_network.connected)
 		return FALSE
-	var/connector_stress = connector.rotation_network.total_stress
-	for(var/obj/structure/child in connector.rotation_network.connected)
+	var/list/to_migrate = connector.rotation_network.connected.Copy()
+	for(var/obj/structure/child in to_migrate)
 		if(src == child)
 			return FALSE
 		connector.rotation_network.remove_connection(child)
 		rotation_network.add_connection(child)
-		if(child.stress_use) // remove_connection resets last_stress_added
+		if(child.stress_use)
 			child.set_stress_use(child.stress_use, check_network = FALSE)
 		if(child.stress_generator)
-			rotation_network.total_stress += child.last_stress_generation // this is undone in set_stress_generation
+			rotation_network.total_stress += child.last_stress_generation
 			child.set_stress_generation(child.last_stress_generation, check_network = FALSE)
-	if(!connector_stress)
-		propagate_rotation_change(connector)
-	rotation_network.rebuild_group() // <=-- this is dumb as hell but for some reason if you perform a fucking dark ritual or someshit you can trick the game into lobotomizing itself.
+	rotation_network.rebuild_group()
 	return TRUE
 
-/obj/structure/proc/propagate_rotation_change(obj/structure/connector, list/checked, first = FALSE)
-	if(!length(checked))
-		checked = list()
-	checked |= src
-
-	if(connector.last_stress_generation && connector.rotation_direction && rotation_direction && (connector.rotation_direction != rotation_direction))
-		rotation_break()
+/obj/structure/proc/propagate_rotation_to_network(new_direction, new_rpm)
+	if(!rotation_network)
 		return
-	connector.rotation_direction = rotation_direction
-	if(!connector.stress_generator)
-		connector.set_rotations_per_minute(rotations_per_minute)
+	var/list/to_visit = list(src)
+	var/list/visited = list()
+	visited[src] = TRUE
+	var/list/node_direction = list()
+	var/list/node_rpm = list()
+	node_direction[src] = new_direction
+	node_rpm[src] = new_rpm
 
-	connector.find_and_propagate(checked, FALSE)
-	if(first)
-		connector.update_animation_effect()
+	while(length(to_visit))
+		var/obj/structure/current = to_visit[1]
+		to_visit.Cut(1, 2)
+		var/cur_dir = node_direction[current]
+		var/cur_rpm = node_rpm[current]
 
-/obj/structure/proc/find_and_propagate(list/checked, first = FALSE)
-	if(!length(checked))
-		checked = list()
-	checked |= src
-
-	for(var/direction in GLOB.cardinals_multiz)
-		if(!(direction & dpdir))
-			continue
-		var/turf/step_forward = get_step_multiz(src, direction)
-		if(step_forward)
-			for(var/obj/structure/structure in step_forward.contents)
-				if(structure in checked)
+		for(var/direction in GLOB.cardinals_multiz)
+			var/turf/T = get_step_multiz(current, direction)
+			if(!T)
+				continue
+			for(var/obj/structure/neighbor in T.contents)
+				if(visited[neighbor])
 					continue
-				if(!structure.rotation_network || !structure.dpdir)
+				if(!(neighbor in rotation_network.connected))
 					continue
-				if(!(structure in rotation_network.connected))
+
+				var/neighbor_dir
+				var/neighbor_rpm
+				var/edge_dir = get_dir(current, neighbor)
+				var/is_shaft_connection = (edge_dir & current.dpdir) && (REVERSE_DIR(edge_dir) & neighbor.dpdir)
+				var/is_cog_connection = !is_shaft_connection && \
+					(istype(neighbor, /obj/structure/rotation_piece/cog)) && \
+					(neighbor.dir == current.dir || neighbor.dir == REVERSE_DIR(current.dir))
+
+				if(!is_shaft_connection && !is_cog_connection)
 					continue
-				if(!(REVERSE_DIR(direction) & structure.dpdir))
-					continue
-				propagate_rotation_change(structure, checked, FALSE)
 
-	if(first)
-		rotation_network?.update_animation_effect()
+				if(is_cog_connection)
+					neighbor_dir = REVERSE_DIR(cur_dir)
+					if(istype(current, /obj/structure/rotation_piece/cog))
+						var/obj/structure/rotation_piece/cog/cog = current
+						neighbor_rpm = istype(neighbor, /obj/structure/rotation_piece/cog) ? cog.get_speed_mod(neighbor) : cur_rpm
+					else
+						neighbor_rpm = cur_rpm
+				else
+					if(neighbor.stress_generator && neighbor.rotation_direction && cur_dir && neighbor.rotation_direction != cur_dir)
+						rotation_break()
+						return
+					neighbor_dir = cur_dir
+					neighbor_rpm = cur_rpm
 
-/obj/structure/proc/pass_rotation_data(obj/structure/connector, list/checked)
-	if(!length(checked))
-		checked = list()
-	checked |= src
+				visited[neighbor] = TRUE
+				node_direction[neighbor] = neighbor_dir
+				node_rpm[neighbor] = neighbor_rpm
+				to_visit += neighbor
 
+	for(var/obj/structure/node in visited)
+		node.rotation_direction = node_direction[node]
+		if(!node.stress_generator)
+			node.set_rotations_per_minute(node_rpm[node])
+	rotation_network?.update_animation_effect()
+
+/obj/structure/proc/pass_rotation_data(obj/structure/connector)
 	if(connector.rotations_per_minute == rotations_per_minute)
 		return
-
+	// Just pick the authoritative source and do one BFS from it
 	if(connector.rotations_per_minute > rotations_per_minute)
-		connector.propagate_rotation_change(src, first = TRUE)
+		connector.propagate_rotation_to_network(connector.rotation_direction, connector.rotations_per_minute)
 	else
-		propagate_rotation_change(connector, checked, TRUE)
+		propagate_rotation_to_network(rotation_direction, rotations_per_minute)
 
 /obj/structure/proc/rotation_break()
 	visible_message(span_warning("[src] breaks apart from the opposing directions!"))

--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -756,10 +756,12 @@
 	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/engineering/cog
-	name = "wooden cogwheel(4x)"
+	name = "wooden cogwheel(6x)"
 	category = "Rotational"
 	display_category = ITEM_CAT_ENG_MACHINERY
 	result = list(
+		/obj/item/rotation_contraption/cog,
+		/obj/item/rotation_contraption/cog,
 		/obj/item/rotation_contraption/cog,
 		/obj/item/rotation_contraption/cog,
 		/obj/item/rotation_contraption/cog,
@@ -796,10 +798,11 @@
 	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/engineering/large_cog
-	name = "large wooden cogwheel (2x)"
+	name = "large wooden cogwheel (3x)"
 	category = "Rotational"
 	display_category = ITEM_CAT_ENG_MACHINERY
 	result = list(
+		/obj/item/rotation_contraption/large_cog,
 		/obj/item/rotation_contraption/large_cog,
 		/obj/item/rotation_contraption/large_cog,
 	)
@@ -851,10 +854,15 @@
 	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/engineering/rails
-	name = "minecart rails (20x)"
+	name = "minecart rails (25x)"
 	category = "Minecarts"
 	display_category = ITEM_CAT_ENG_CONSTRUCTION
 	result = list(
+		/obj/item/rotation_contraption/minecart_rail,
+		/obj/item/rotation_contraption/minecart_rail,
+		/obj/item/rotation_contraption/minecart_rail,
+		/obj/item/rotation_contraption/minecart_rail,
+		/obj/item/rotation_contraption/minecart_rail,
 		/obj/item/rotation_contraption/minecart_rail,
 		/obj/item/rotation_contraption/minecart_rail,
 		/obj/item/rotation_contraption/minecart_rail,
@@ -926,10 +934,12 @@
 	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/engineering/roller
-	name = "rollers (2x)"
+	name = "rollers (4x)"
 	category = "Minecarts"
 	display_category = ITEM_CAT_ENG_CONSTRUCTION
 	result = list(
+		/obj/item/rotation_contraption/roller,
+		/obj/item/rotation_contraption/roller,
 		/obj/item/rotation_contraption/roller,
 		/obj/item/rotation_contraption/roller,
 	)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -754,6 +754,7 @@
 #include "code\datums\components\caltrop.dm"
 #include "code\datums\components\combat_vocalizer.dm"
 #include "code\datums\components\construction.dm"
+#include "code\datums\components\conveyor_movement.dm"
 #include "code\datums\components\creamed.dm"
 #include "code\datums\components\cursed_item.dm"
 #include "code\datums\components\deadchat_control.dm"


### PR DESCRIPTION
## About The Pull Request
We're down on minecart accidents, and we have a quota to reach! This PR tweaks some in-game values, so making long tracks and interesting roller builds should be more consistent. 

In this update
- Reduced the momentum lost for mincarts from 1 per tick to .25 a tick, the speed isn't increased but the decay should be 25% of what it had and require fewer boosts to get to places. 
- The damage cap for minecarts has been increased from 50 to 100. This does not double the damage, just the cap.
- Placement time of rotational items is down from 1.2 seconds to 1 second, and is still reduced by engineering skills
- Rollers can only be powered from the sides to allow better consistency in their setup
- Roller recipe increased from 2 to 4
- Minetrack recipe has been increased from 20 to 25
- Large cogs recipe has been increased from 2 to 3
- Small cogs recipe has been increased from 4 to 6

The increase in crafting items is to encourage more tracks and to make up on roller builds now taking more resources, but the designs will be less finicky. 

## Testing Evidence

<img width="530" height="196" alt="image" src="https://github.com/user-attachments/assets/78e4ee76-672a-4f46-840b-30ff7f501ff7" />


https://github.com/user-attachments/assets/dd5e30ed-f290-424a-9006-26624b16dfce

## Why It's Good For The Game

mor running people over, more consistent builds, and faster builds

## Changelog

:cl:
qol: easier to make rotational items
balance: increased recipe values to help make up for roller changes and encourage more builds
balance: less decay on minecart tracks
balance: upped damage cap on minecarts
fix: made rollers more consistent being powered on the side
/:cl:
