### PR TITLE
[FIX] - Wrestle Bugfix

### DIFF
--- a/code/modules/spells/spell_types/wrestling/chokeslam.dm
+++ b/code/modules/spells/spell_types/wrestling/chokeslam.dm
@@ -49,7 +49,7 @@
 	animate(target, pixel_z = original_target_pixel_z + 16, time = 5)
 	
 	// Then drop back down after a short delay
-	var/drop_timer = addtimer(CALLBACK(src, PROC_REF(drop_target), target, original_target_pixel_z), 5)
+	var/drop_timer = addtimer(CALLBACK(src, PROC_REF(drop_target), target, original_target_pixel_z), 5, TIMER_STOPPABLE)
 
 
 

--- a/code/modules/spells/spell_types/wrestling/headbutt.dm
+++ b/code/modules/spells/spell_types/wrestling/headbutt.dm
@@ -37,10 +37,8 @@
 
 	var/original_user_pixel_x = user.pixel_x
 	var/original_user_pixel_y = user.pixel_y
-	var/original_user_transform = user.transform
 	var/original_target_pixel_x = target.pixel_x
 	var/original_target_pixel_y = target.pixel_y
-	var/original_target_transform = target.transform
 
 	to_chat(user, span_notice("You line up with [target]!"))
 	to_chat(target, span_userdanger("[user] winds up for a headbutt!"))
@@ -115,16 +113,16 @@
 		tracker.channeling_throw = FALSE
 		user.stop_pulling(TRUE)
 		to_chat(user, span_notice("I'm interupted!"))
-		animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, transform = original_user_transform, time = 1 SECONDS) // reset animation
-		animate(target, pixel_x = original_target_pixel_x, pixel_y = original_target_pixel_y, transform = original_target_transform, time = 1 SECONDS) // reset animation
+		animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, time = 1 SECONDS) // reset animation
+		animate(target, pixel_x = original_target_pixel_x, pixel_y = original_target_pixel_y, time = 1 SECONDS) // reset animation
 		revert_cast()
 
 		return FALSE
 
 	if(!do_after(user, channel_time, target = target)) //saftey check
 		tracker.channeling_throw = FALSE
-		animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, transform = original_user_transform, time = 1 SECONDS) // reset animation
-		animate(target, pixel_x = original_target_pixel_x, pixel_y = original_target_pixel_y, transform = original_target_transform, time = 1 SECONDS) // reset animation
+		animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, time = 1 SECONDS) // reset animation
+		animate(target, pixel_x = original_target_pixel_x, pixel_y = original_target_pixel_y, time = 1 SECONDS) // reset animation
 		revert_cast()
 
 		return FALSE

--- a/code/modules/spells/spell_types/wrestling/stunner.dm
+++ b/code/modules/spells/spell_types/wrestling/stunner.dm
@@ -68,9 +68,7 @@
 	var/original_user_pixel_x = user.pixel_x
 	var/original_user_pixel_y = user.pixel_y
 	var/original_user_pixel_z = user.pixel_z
-	var/original_user_transform = user.transform
 	var/original_target_pixel_z = target.pixel_z
-	var/original_target_transform = target.transform
 	
 	
 	// lifting both user and target upwards
@@ -81,7 +79,7 @@
 	animate(target, pixel_z = original_target_pixel_z + 11, time = 5) // we shouldnt animate people on the floor because they break. so you body slam them or w/e
 	
 	//  drop back down after a short delay
-	var/drop_timer = addtimer(CALLBACK(src, PROC_REF(drop_both), user, target, original_user_pixel_z, original_target_pixel_z, original_user_transform, original_target_transform), 5)
+	var/drop_timer = addtimer(CALLBACK(src, PROC_REF(drop_both), user, target, original_user_pixel_z, original_target_pixel_z), 5, TIMER_STOPPABLE)
 
 
 
@@ -90,8 +88,8 @@
 		user.stop_pulling(TRUE)
 		to_chat(user, span_notice("I'm interupted!"))
 		deltimer(drop_timer)
-		animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, pixel_z = original_user_pixel_z, transform = original_user_transform, time = 1 SECONDS) // reset animation
-		animate(target, pixel_z = original_target_pixel_z, transform = original_target_transform, time = 1 SECONDS) // reset animation
+		animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, pixel_z = original_user_pixel_z, time = 1 SECONDS) // reset animation
+		animate(target, pixel_z = original_target_pixel_z, time = 1 SECONDS) // reset animation
 		revert_cast()
 
 		return FALSE
@@ -99,8 +97,8 @@
 	if(!do_after(user, channel_time, target = target)) //saftey check
 		tracker.channeling_throw = FALSE
 		deltimer(drop_timer)
-		animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, pixel_z = original_user_pixel_z, transform = original_user_transform, time = 1 SECONDS) // reset animation
-		animate(target, pixel_z = original_target_pixel_z, transform = original_target_transform, time = 1 SECONDS) // reset animation
+		animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, pixel_z = original_user_pixel_z, time = 1 SECONDS) // reset animation
+		animate(target, pixel_z = original_target_pixel_z, time = 1 SECONDS) // reset animation
 		revert_cast()
 
 		return FALSE
@@ -141,9 +139,9 @@
 	tracker.channeling_throw = FALSE
 	return TRUE
 
-/obj/effect/proc_holder/spell/invoked/stunner/proc/drop_both(mob/living/user, mob/living/target, original_user_pixel_x, original_user_pixel_y, original_user_pixel_z, original_target_pixel_z, original_user_transform, original_target_transform)
-	animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, pixel_z = original_user_pixel_z, transform = original_user_transform, time = 5)
-	animate(target, pixel_z = original_target_pixel_z, transform = original_target_transform, time = 5)
+/obj/effect/proc_holder/spell/invoked/stunner/proc/drop_both(mob/living/user, mob/living/target, original_user_pixel_x, original_user_pixel_y, original_user_pixel_z, original_target_pixel_z)
+	animate(user, pixel_x = original_user_pixel_x, pixel_y = original_user_pixel_y, pixel_z = original_user_pixel_z, time = 5)
+	animate(target, pixel_z = original_target_pixel_z, time = 5)
 
 /datum/component/wrestle_combat_tracker // keeps track of if were channeling or not, used for all wrestling spells
 	channeling_throw = FALSE


### PR DESCRIPTION
Removes Runtime from lack of Timer_Stoppable flag on timers when interrupted

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Hello there!

Downstream porting up some fixes we applied to the wrestling moves
- Added the TIMER_STOPPABLE flag to the timer checks to prevent runtime if interrupted by actions or cancels
- removed the .transform checks - These always seemed to revert sprite height and pixel size for us downstream. We removed them from the wrestling moves and have not noticed any consequences in terms of performance or maneuvers.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="403" height="95" alt="image" src="https://github.com/user-attachments/assets/0ae87b26-6719-4f2b-89e6-cd4551266cae" />
<img width="214" height="194" alt="image" src="https://github.com/user-attachments/assets/97677f70-d8d6-4468-8dad-99d6c15085bd" />
<img width="653" height="451" alt="image" src="https://github.com/user-attachments/assets/99168ad5-12a7-4b95-9266-30ef16fc68ed" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Fixes bugs, polishes the code of fun stuff, cuts down on runtime.
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Removed .transform check in wrestling spells to prevent sprite scale corruption
fix: fixed runtime on interrupted timers in wrestling spells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
