### PR TITLE
Spellfist Yak

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
@@ -19,14 +19,12 @@
 		TRAIT_INQUISITION
 	)
 	subclass_stats = list(
-		STATKEY_STR = 1,
-		STATKEY_SPD = 1,
+		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
-		STATKEY_PER = 2,
-		STATKEY_CON = 1
+		STATKEY_CON = 3
 	)
 	subclass_skills = list(
-		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
@@ -37,7 +35,7 @@
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 	)
-	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 4)
+	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 4, ward = TRUE, "locked_aspects" = list(/datum/magic_aspect/autowardry))
 	subclass_stashed_items = list(
 		"The Book" = /obj/item/book/rogue/bibble/psy
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -286,15 +286,14 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/spellfist
 	traits_applied = list(TRAIT_CIVILIZEDBARBARIAN, TRAIT_ARCYNE)
 	subclass_stats = list(
-		STATKEY_SPD = 1,
-		STATKEY_WIL = 2,
-		STATKEY_PER = 2,
-		STATKEY_CON = 1
+		STATKEY_STR = 2,
+		STATKEY_WIL = 1,
+		STATKEY_CON = 2
 	)
-	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 4)
+	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 4, ward = TRUE)
 	subclass_skills = list(
-		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
@@ -313,10 +312,10 @@
 /datum/outfit/job/roguetown/adventurer/spellfist/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/headband/monk
-	shoes = /obj/item/clothing/shoes/roguetown/sandals
-	pants = /obj/item/clothing/under/roguetown/tights/black
-	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/black
-	armor = /obj/item/clothing/suit/roguetown/armor/gambeson
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shirt =  /obj/item/clothing/suit/roguetown/armor/gambeson
+	armor =	/obj/item/clothing/suit/roguetown/armor/leather/heavy
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	neck = /obj/item/clothing/neck/roguetown/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/cloth/monk
@@ -340,9 +339,9 @@
 
 	if(H.mind)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/fist_of_psydon)
-		H.mind.AddSpell(new /datum/action/cooldown/spell/grasp_of_psydon())
-		H.mind.AddSpell(new /datum/action/cooldown/spell/blink)
-		H.mind.AddSpell(new /datum/action/cooldown/spell/storm_of_psydon())
+		H.mind.AddSpell(new /datum/action/cooldown/spell/grasp_of_psydon)
+		H.mind.AddSpell(new /datum/action/cooldown/spell/blink/shadowstep)
+		H.mind.AddSpell(new /datum/action/cooldown/spell/storm_of_psydon)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/empower_weapon)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/mending)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellfist.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellfist.dm
@@ -11,13 +11,11 @@
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_CIVILIZEDBARBARIAN, TRAIT_ARCYNE)
 	subclass_stats = list(
-		STATKEY_STR = 1,
-		STATKEY_SPD = 1,
+		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
-		STATKEY_PER = 1,
-		STATKEY_CON = 1
+		STATKEY_CON = 3
 	)
-	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 4)
+	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 4, ward = TRUE, "locked_aspects" = list(/datum/magic_aspect/autowardry))
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
@@ -67,9 +65,9 @@
 
 	if(H.mind)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/fist_of_psydon)
-		H.mind.AddSpell(new /datum/action/cooldown/spell/grasp_of_psydon())
-		H.mind.AddSpell(new /datum/action/cooldown/spell/blink)
-		H.mind.AddSpell(new /datum/action/cooldown/spell/storm_of_psydon())
+		H.mind.AddSpell(new /datum/action/cooldown/spell/grasp_of_psydon)
+		H.mind.AddSpell(new /datum/action/cooldown/spell/blink/shadowstep)
+		H.mind.AddSpell(new /datum/action/cooldown/spell/storm_of_psydon)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/empower_weapon)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/mending)
 

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -98,16 +98,13 @@
 	category_tags = list(CTAG_MERCENARY)
 	cmode_music = 'sound/music/warscholar.ogg'
 	traits_applied = list(TRAIT_CIVILIZEDBARBARIAN, TRAIT_ARCYNE, TRAIT_NALEDI)
-	// Previous budget was kinda lopsided with negative per and con on a melee class (??) to give them a lot of str and speed. I took 6 points off and shifted it to wil and perception instead.
 	subclass_stats = list(
-		STATKEY_STR = 1,
-		STATKEY_SPD = 1,
+		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
-		STATKEY_PER = 2,
-		STATKEY_CON = 1
+		STATKEY_CON = 3
 	)
 	subclass_skills = list(
-		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
@@ -119,7 +116,7 @@
 		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,
 	)
-	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 4)
+	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 4, ward = TRUE, "locked_aspects" = list(/datum/magic_aspect/autowardry))
 
 /datum/outfit/job/roguetown/mercenary/warscholar_pontifex
 	var/detailcolor


### PR DESCRIPTION
## About The Pull Request
So I observed a fight with the new Naledi Adventurer Pontifex class and got very angry at Borneblood for an unarmed class with Expert and Spells and Thick Blooded and Minor Aspects and Lesser Augmentation. It was way too cracked for an adventurer and probably ABOVE pontifex in power (not HFist). 

But players said it was fun, and I've known for over 1 - 2 months that Spellfist is in a very dire state and needed some changes. So I decided to settle for a midway solution, inspired by what Borneblood did. 

Does this mean we'll see a return of the ward to Spellblade? Unsure, I am unlikely to pull that trigger. I am generally fine with supplementary armor now that the ward stacking bug is fixed. 

The changes:
- All spellfists now have ward access (again), helping cover up shortage on places where they start with lackluster armor
- Heretic and Pontifex now have access to 1 locked minor aspect - Autowardry. No lesser augmentation / blink / self buff BS. This means their ward is significantly better than Adventurer. I cannot afford to give them more than 9 statweight (This will set a very bad precedent), or minmax by deducting speed and then increasing str / con (bad precedent) or Master (that'd be crazy), so I figured I would adjust the lever of their defensive stats
- Adventurer Spellfist have significantly better starting armor, somewhat mirroring that of Spellblade
- Adventurer Spellfist now have Expert skills.
- Adventurer Spellfist and H SFist now have access to shadowstep. I CBA gatekeeping them when the remaining 3 traits are Psydon coded in the first place.
- After receiving feedback that the speed / perception oriented statblock didn't work, I swapped it out for a STR / CON oriented statblock.
- Adv. Spellfist: 2 Str, 1 Wil, 2 Con
- Pontifex / HFist: 2 Str, 2 Wil, 3 Con
- Also applied the same treatment to Sojourner.
- Also shot their wrestling from Jman to Apprentice. Punching good, grappling bad.
- 

Yes, I asked Kunai to gun down Pontifex.

No, they DO NOT HAVE THICKBLOODED. I have read many many dev-general threads about how people just do not die when they are killed and I think proliferating thick blooded would be a grave mistake on top of assigning them con.

This PR should hopefully go toward fulfilling a big strong spellfist that is tanky (for a hybrid) fantasy. I'll see the results and think on how to adjust SBlade.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1315" height="1123" alt="dreamseeker_V8zf9ZSHij" src="https://github.com/user-attachments/assets/2c8f20ea-df20-4ee4-a40d-5a207f7c0a43" />
<img width="1305" height="1140" alt="dreamseeker_yU6tZYyqaB" src="https://github.com/user-attachments/assets/aae6aacb-0cc1-476b-837f-ca24efca3b0a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Rationale explained above

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: All spellfists now have ward access (again), helping cover up shortage on places where they start with lackluster armor
add: Heretic Spellfist / Sojourner / Pontifex now have access to 1 locked minor aspect - Autowardry. No lesser augmentation / blink / self buff BS. This means their ward is significantly better than Adventurer. I cannot afford to give them more than 9 statweight (This will set a very bad precedent), or minmax by deducting speed and then increasing str / con (bad precedent) or Master (that'd be crazy), so I figured I would adjust the lever of their defensive stats
balance: Adventurer Spellfist have significantly better starting armor, somewhat mirroring that of Spellblade
balance: Adventurer Spellfist now have Expert skills.
balance: Adventurer Spellfist and H SFist now have access to shadowstep. I CBA gatekeeping them when the remaining 3 traits are Psydon coded in the first place.
balance: After receiving feedback that the speed / perception oriented statblock didn't work, I swapped it out for a STR / CON oriented statblock. Adv. Spellfist: 2 Str, 1 Wil, 2 Con. Pontifex / HFist / Soj: 2 Str, 2 Wil, 3 Con
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
