### PR TITLE
Savefile Exporting

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -275,6 +275,25 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			key_bindings -= key
 	// End
 
+/client/verb/export_savefile()
+	set name = "Export Preferences"
+	set desc = "Export your preferences to a file."
+	set category = "OOC"
+	if(!prefs.path)
+		return
+
+	if(alert("Are you sure you want to export your preferences? This will create a file on your computer that contains your preferences.", "Export Preferences", "Yes", "No") == "No")
+		return
+
+	if(!fexists(prefs.path))
+		to_chat(src, span_warning("No savefile, what?!"))
+		return
+
+	var/file_name = "[ckey].sav"
+	var/exportable_file = file(prefs.path)
+
+	DIRECT_OUTPUT(src, ftp(exportable_file, file_name))
+
 /datum/preferences/proc/save_preferences()
 	if(!path)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

port of https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1982 (by meeee)

you can now export your savefile, containing all your characters and preferences.
it will be downloaded as a file on your computer.

there is no way to import savefiles yourself. it would have to be done by someone with access to the server box.

you can, however, use these savefiles when localhosting.

## Testing Evidence

<img width="579" height="424" alt="image" src="https://github.com/user-attachments/assets/6e877642-5c6a-4955-9c5c-e0e3d1123417" />
<img width="364" height="400" alt="image" src="https://github.com/user-attachments/assets/c5701794-08ea-4188-ae1b-966b9be6f5b3" />


## Why It's Good For The Game

makes it easier for people to maintain ownership over their characters.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: You can export your preferences/characters using the "Export Preferences" verb in the "OOC" panel. It will be saved as a file on your computer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
