### PR TITLE
Potions with the same effect no longer stack.

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -345,6 +345,29 @@
 							if(istype(R, A))
 								A.addiction_stage = -15 // you're satisfied for a good while.
 				need_mob_update += R.on_mob_life(C)
+				// Anti-stacking: while this reagent is active, rapidly purge any
+				// other reagents it conflicts with so their effects can't combine.
+				// Self is always excluded so a reagent never purges itself - this is
+				// important when a conflict entry is a parent type of the reagent
+				// (e.g. /datum/reagent/buff listing /datum/reagent/buff to block
+				// stacking different stat buffs without nuking itself).
+				// We collect matches first and purge after scanning, to avoid
+				// mutating the list we are iterating over (cached_reagents).
+				if(R.conflicting_reagent_types)
+					var/list/_to_purge = null
+					for(var/_other in cached_reagents)
+						var/datum/reagent/CR = _other
+						if(CR == R)
+							continue
+						for(var/_ctype in R.conflicting_reagent_types)
+							if(istype(CR, _ctype))
+								if(!_to_purge)
+									_to_purge = list()
+								_to_purge += CR.type
+								break // one purge per reagent per tick is enough
+					if(_to_purge)
+						for(var/_purge_type in _to_purge)
+							remove_reagent(_purge_type, 10) // Matches the rate the old buff system used.
 
 	if(can_overdose)
 		if(addiction_tick == 6)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -367,7 +367,7 @@
 								break // one purge per reagent per tick is enough
 					if(_to_purge)
 						for(var/_purge_type in _to_purge)
-							remove_reagent(_purge_type, 10) // Matches the rate the old buff system used.
+							remove_reagent(_purge_type, 10) 
 
 	if(can_overdose)
 		if(addiction_tick == 6)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -345,29 +345,6 @@
 							if(istype(R, A))
 								A.addiction_stage = -15 // you're satisfied for a good while.
 				need_mob_update += R.on_mob_life(C)
-				// Anti-stacking: while this reagent is active, rapidly purge any
-				// other reagents it conflicts with so their effects can't combine.
-				// Self is always excluded so a reagent never purges itself - this is
-				// important when a conflict entry is a parent type of the reagent
-				// (e.g. /datum/reagent/buff listing /datum/reagent/buff to block
-				// stacking different stat buffs without nuking itself).
-				// We collect matches first and purge after scanning, to avoid
-				// mutating the list we are iterating over (cached_reagents).
-				if(R.conflicting_reagent_types)
-					var/list/_to_purge = null
-					for(var/_other in cached_reagents)
-						var/datum/reagent/CR = _other
-						if(CR == R)
-							continue
-						for(var/_ctype in R.conflicting_reagent_types)
-							if(istype(CR, _ctype))
-								if(!_to_purge)
-									_to_purge = list()
-								_to_purge += CR.type
-								break // one purge per reagent per tick is enough
-					if(_to_purge)
-						for(var/_purge_type in _to_purge)
-							remove_reagent(_purge_type, 10) 
 
 	if(can_overdose)
 		if(addiction_tick == 6)
@@ -428,7 +405,64 @@
 		R.on_update (A)
 	update_total()
 
+/// Anti-stacking: if a reagent and one of its declared conflicts are both
+/// present, they neutralize 1:1 into /datum/reagent/ruined_potion. 
+///
+/// Self never conflicts with itself (matters when a conflict entry is a parent
+/// type, e.g. /datum/reagent/buff).
+/datum/reagents/proc/handle_conflicting_reagents()
+	var/list/drain_amounts = find_conflicting_reagent_amounts()
+	if(!drain_amounts)
+		return
+
+	var/ruined_volume = 0
+	for(var/reagent_type in drain_amounts)
+		var/to_remove = drain_amounts[reagent_type]
+		remove_reagent(reagent_type, to_remove, safety = 1)
+		ruined_volume += to_remove
+	add_reagent(/datum/reagent/ruined_potion, ruined_volume, no_react = 1)
+
+	if(my_atom)
+		my_atom.on_reagent_change(REACT_REAGENTS)
+		if(!ismob(my_atom))
+			var/list/seen = viewers(4, get_turf(my_atom))
+			var/iconhtml = icon2html(my_atom, seen)
+			for(var/mob/M in seen)
+				to_chat(M, span_notice("[iconhtml] The mixture curdles into a foul, useless sludge."))
+	update_total()
+
+/datum/reagents/proc/find_conflicting_reagent_amounts()
+	var/list/drain_amounts = null
+
+	for(var/i in 1 to length(reagent_list))
+		var/datum/reagent/A = reagent_list[i]
+		if(!A.conflicting_reagent_types)
+			continue
+		for(var/j in (i + 1) to length(reagent_list))
+			var/datum/reagent/B = reagent_list[j]
+			if(!reagents_conflict(A, B))
+				continue
+			var/a_remaining = A.volume - (drain_amounts ? (drain_amounts[A.type] || 0) : 0)
+			var/b_remaining = B.volume - (drain_amounts ? (drain_amounts[B.type] || 0) : 0)
+			var/neutralize = min(a_remaining, b_remaining)
+			if(neutralize <= 0)
+				continue
+			if(!drain_amounts)
+				drain_amounts = list()
+			drain_amounts[A.type] = (drain_amounts[A.type] || 0) + neutralize
+			drain_amounts[B.type] = (drain_amounts[B.type] || 0) + neutralize
+
+	return drain_amounts
+
+/datum/reagents/proc/reagents_conflict(datum/reagent/A, datum/reagent/B)
+	if(A == B)
+		return FALSE
+	return is_type_in_list(B, A.conflicting_reagent_types) || is_type_in_list(A, B.conflicting_reagent_types)
+
 /datum/reagents/proc/handle_reactions()
+	// Anti-stacking check, runs before NO_REACT so it works on kegs too.
+	handle_conflicting_reagents()
+
 	if(flags & NO_REACT)
 		return //Yup, no reactions here. No siree.
 

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -41,6 +41,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/reagent_weight = 1 //affects how far it travels when sprayed
 	var/metabolizing = FALSE
 	var/harmful = FALSE //is it bad for you? Currently only used for borghypo. C2s and Toxins have it TRUE by default.
+	/// Reagents that cannot be active at the same time as this one (e.g. weak + strong potions of the same family).
+	var/list/conflicting_reagent_types = null
 
 /datum/reagent/Destroy() // This should only be called by the holder, so it's already handled clearing its references
 	. = ..()

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -9,6 +9,7 @@
 	overdose_threshold = 0
 	metabolization_rate = REAGENTS_METABOLISM
 	alpha = 173
+	conflicting_reagent_types = list(/datum/reagent/medicine/stronghealth, /datum/reagent/medicine/restoration)
 
 /datum/reagent/medicine/healthpot/on_mob_life(mob/living/carbon/M)
 	if(volume >= 60)
@@ -70,6 +71,7 @@
 	taste_description = "rich lifeblood"
 	scent_description = "metal"
 	metabolization_rate = REAGENTS_METABOLISM * 2
+	conflicting_reagent_types = list(/datum/reagent/medicine/healthpot, /datum/reagent/medicine/restoration)
 
 /datum/reagent/medicine/stronghealth/on_mob_life(mob/living/carbon/M)
 	if(volume >= 60)
@@ -97,6 +99,7 @@
 	overdose_threshold = 0
 	metabolization_rate = REAGENTS_METABOLISM
 	alpha = 173
+	conflicting_reagent_types = list(/datum/reagent/medicine/strongmana, /datum/reagent/medicine/restoration)
 
 /datum/reagent/medicine/manapot/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_INFINITE_STAMINA))
@@ -110,6 +113,7 @@
 	taste_description = "raw power"
 	scent_description = "berries"
 	metabolization_rate = REAGENTS_METABOLISM * 3
+	conflicting_reagent_types = list(/datum/reagent/medicine/manapot, /datum/reagent/medicine/restoration)
 
 /datum/reagent/medicine/strongmana/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_INFINITE_STAMINA))
@@ -123,6 +127,8 @@
 	taste_description = "reinvigorative creaminess"
 	scent_description = "strawberries in liqour"
 	metabolization_rate = REAGENTS_METABOLISM * 2
+	// Restoration is a hybrid of the health and mana families, so it conflicts with both.
+	conflicting_reagent_types = list(/datum/reagent/medicine/healthpot, /datum/reagent/medicine/stronghealth, /datum/reagent/medicine/manapot, /datum/reagent/medicine/strongmana)
 
 /datum/reagent/medicine/restoration/on_mob_life(mob/living/carbon/M)
 	if(volume >= 60)
@@ -151,6 +157,7 @@
 	overdose_threshold = 0
 	metabolization_rate = REAGENTS_METABOLISM
 	alpha = 173
+	conflicting_reagent_types = list(/datum/reagent/medicine/strongstam)
 
 /datum/reagent/medicine/stampot/on_mob_life(mob/living/carbon/M)
 	if(volume >= 60)
@@ -167,6 +174,7 @@
 	taste_description = "sparkly static"
 	scent_description = "grass"
 	metabolization_rate = REAGENTS_METABOLISM
+	conflicting_reagent_types = list(/datum/reagent/medicine/stampot)
 
 /datum/reagent/medicine/strongstam/on_mob_life(mob/living/carbon/M)
 	if(volume >= 60)
@@ -190,6 +198,7 @@
 	taste_description = "sickly sweet"
 	scent_description = "medicine"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+	conflicting_reagent_types = list(/datum/reagent/medicine/strong_antidote)
 
 /datum/reagent/medicine/antidote/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.99)
@@ -210,6 +219,7 @@
 	taste_description = "dirt"
 	scent_description = "medicine"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+	conflicting_reagent_types = list(/datum/reagent/medicine/antidote)
 
 /datum/reagent/medicine/strong_antidote/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.99)
@@ -235,19 +245,15 @@
 	reagent_state = LIQUID
 	metabolization_rate = REAGENTS_METABOLISM * 0.1
 	overdose_threshold = 33
+	// All stat buffs conflict with each other: only one buff potion's effect can be active at a time.
+	// (Self is excluded by the purge logic, so a buff never purges itself despite matching its own parent type.)
+	conflicting_reagent_types = list(/datum/reagent/buff)
 
 /datum/reagent/buff/overdose_process(mob/living/carbon/M)
 	. = ..()
 	M.Jitter(2)
 	if(!HAS_TRAIT(M, TRAIT_CRACKHEAD)) // Baothan get to stack more of one potion in their body, but not multiple
 		M.adjustToxLoss(3)
-
-/datum/reagent/buff/on_mob_life(mob/living/carbon/M)
-	for(var/datum/reagent/R in M.reagents.reagent_list)
-		if(istype(R, /datum/reagent/buff) && R != src)
-			holder.remove_reagent(R.type, 10)
-			// Rapidly purge stacking buffs
-	..()
 
 /datum/reagent/buff/strength
 	name = STATKEY_STR

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -327,6 +327,26 @@
 	M.apply_status_effect(/datum/status_effect/buff/alch/fortunepot)
 	return ..()
 
+/* Ruined Potion
+	When two conflicting potions end up in the same container (or the same body),
+	they neutralize each other into this useless sludge.
+*/
+/datum/reagent/ruined_potion
+	name = "Odd water"
+	description = "A foul mess of conflicting alchemical essences that tried to push nature too far. Utterly useless."
+	reagent_state = LIQUID
+	color = "#6b5d4f" // muddy brownish-green
+	taste_description = "bitter failure"
+	scent_description = "rancid alchemical waste"
+	metabolization_rate = REAGENTS_METABOLISM
+	overdose_threshold = 0
+	can_synth = FALSE 
+
+/datum/reagent/ruined_potion/on_mob_life(mob/living/carbon/M)
+	if(volume > 0.99)
+		M.add_nausea(2) // Drinking ruined potions is unpleasant but not dangerous.
+	return ..()
+
 //Poisons
 /* Tested this quite a bit. Heres the deal. Metabolism REAGENTS_SLOW_METABOLISM is 0.1 and needs to be that so poison isnt too fast working but
 still is dangerous. Toxloss of 3 at metabolism 0.1 puts you in dying early stage then stops for reference of these values.


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Extends the purging system already used by stat potions to all potions in general. Reagent datum gets a conflicting_reagent_types list where you can input which reagents are incompatible with it per reagent so it can be changed as required. Right now I'm restricting weaker potions compounding with stronger ones (they get purged at 10u's per tick).

The purging is represented as the reagents turning into an useless odd water.

## Testing Evidence

VV'd my char after drinking conflicting potions, the purging works as expected, stops when the conflicting reagent is fully purged. No runtimes were detected during testing.


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

prevents stacking potion with the same effect but different potency. Ideally there should be only one potion type and another var should handle its potency, like purity for example. This is an intermediate solution meanwhile.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: potions with the same effect now react turning into odd water.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
