### PR TITLE
Changes (SomeTM) things about the keep

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -8839,18 +8839,49 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/underdark/north)
 "bOt" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/natural/bundle/stick{
-	pixel_y = -6
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl";
+	sellprice = 30
 	},
-/obj/item/natural/bundle/stick{
-	pixel_y = -6
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl";
+	sellprice = 30
 	},
-/obj/item/natural/bundle/stick{
-	pixel_y = -6
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl";
+	sellprice = 30
 	},
-/obj/item/natural/bundle/stick{
-	pixel_y = -6
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl";
+	sellprice = 30
+	},
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter/pewter,
+/obj/item/cooking/platter/pewter,
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/gold,
+/obj/item/reagent_containers/glass/bowl/gold,
+/obj/item/reagent_containers/glass/bowl/gold,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy{
+	pixel_x = -1;
+	pixel_y = 7
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -22163,6 +22194,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/inq/basement)
+"euU" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/basement/keep)
 "euV" = (
 /obj/machinery/light/roguestreet,
 /turf/open/floor/rogue/cobblerock,
@@ -30668,49 +30703,18 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
 "geE" = (
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
+/obj/structure/closet/crate/chest/crate,
+/obj/item/natural/bundle/stick{
+	pixel_y = -6
 	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
+/obj/item/natural/bundle/stick{
+	pixel_y = -6
 	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
+/obj/item/natural/bundle/stick{
+	pixel_y = -6
 	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter/pewter,
-/obj/item/cooking/platter/pewter,
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy{
-	pixel_x = -1;
-	pixel_y = 7
+/obj/item/natural/bundle/stick{
+	pixel_y = -6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
@@ -35322,6 +35326,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/inq/basement)
+"haC" = (
+/obj/structure/fluff/statue/knight/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "haH" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
@@ -55233,6 +55241,7 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/royal,
 /obj/item/storage/backpack/rogue/satchel,
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/steward,
+/obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "kNT" = (
@@ -65890,8 +65899,13 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
 "mLY" = (
-/obj/machinery/light/rogue/candle/r,
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/structure/table/wood/poor,
+/obj/item/roguebin/water,
+/obj/item/natural/cloth{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "mMt" = (
 /obj/structure/bars/pipe,
@@ -95104,7 +95118,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "suH" = (
-/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/machinery/light/rogue/candle/r{
+	pixel_x = 32;
+	pixel_y = -11
+	},
 /turf/open/transparent/openspace,
 /area/rogue/under/town/basement/keep)
 "suQ" = (
@@ -108585,10 +108605,12 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/inq/embassy)
 "vaU" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/mirror/fancy{
+	pixel_y = 0;
+	pixel_x = -32
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "vaW" = (
 /obj/structure/fluff/psycross/astrata/golden,
@@ -111047,6 +111069,9 @@
 	},
 /obj/structure/fluff/railing/border{
 	dir = 5
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
@@ -123802,11 +123827,8 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/underdark)
 "ybK" = (
-/obj/structure/stairs{
-	dir = 8
-	},
 /obj/structure/fluff/railing/border{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
@@ -194444,7 +194466,7 @@ iIF
 cPO
 iad
 iad
-iad
+cPO
 cPO
 iad
 qcz
@@ -194896,7 +194918,7 @@ wVM
 sEH
 iad
 mii
-vaU
+cPO
 cPO
 iad
 mEr
@@ -195801,7 +195823,7 @@ iad
 iad
 cPO
 cPO
-cPO
+haC
 iad
 iad
 iad
@@ -308349,8 +308371,8 @@ iad
 iad
 mdt
 aal
-aal
-qJZ
+vaU
+mLY
 iad
 reQ
 hFg
@@ -308801,7 +308823,7 @@ iad
 iad
 mdt
 aal
-aal
+qJZ
 aOv
 iad
 mEr
@@ -309252,7 +309274,7 @@ iad
 iad
 iad
 iad
-aal
+euU
 aal
 iad
 iad
@@ -310157,7 +310179,7 @@ iad
 iad
 iad
 vAo
-suH
+asJ
 xgW
 tUV
 wCC
@@ -310607,9 +310629,9 @@ rEF
 rTY
 iad
 iad
-mLY
-vAo
+iad
 suH
+asJ
 xgW
 wCC
 kYL

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -4803,6 +4803,10 @@
 	pixel_x = 8;
 	pixel_y = 5
 	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = -5;
+	pixel_y = 16
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "aZL" = (
@@ -7071,6 +7075,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/scarymaze)
+"bwL" = (
+/obj/structure/fluff/walldeco/bigpainting{
+	pixel_x = 0
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/manor)
 "bwN" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -9745,6 +9755,23 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
+"bYm" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = -5;
+	pixel_y = 16
+	},
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = -14;
+	pixel_y = 24
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "bYr" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road,
@@ -10090,6 +10117,16 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/his_vault)
+"ccT" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/machinery/light/rogue/candle/r{
+	pixel_x = 32;
+	pixel_y = -11
+	},
+/turf/open/transparent/openspace,
+/area/rogue/under/town/basement/keep)
 "ccU" = (
 /obj/structure/table/church,
 /turf/open/floor/rogue/churchbrick,
@@ -16886,6 +16923,7 @@
 /obj/structure/roguemachine/scomm/r{
 	scom_tag = "Manor - Heir's Appartment II"
 	},
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "dtw" = (
@@ -19064,6 +19102,7 @@
 /area/rogue/outdoors/beach/forest/north)
 "dPn" = (
 /obj/structure/table/wood/fancy/black,
+/obj/item/bouquet/salvia,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "dPo" = (
@@ -22194,10 +22233,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/inq/basement)
-"euU" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
 "euV" = (
 /obj/machinery/light/roguestreet,
 /turf/open/floor/rogue/cobblerock,
@@ -35326,10 +35361,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/inq/basement)
-"haC" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
 "haH" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
@@ -43358,6 +43389,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
+"iBT" = (
+/obj/structure/curtain/red,
+/obj/structure/roguewindow/harem3,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/manor)
 "iBX" = (
 /obj/effect/decal/mossy{
 	dir = 4
@@ -49275,7 +49311,7 @@
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
 "jHD" = (
-/obj/structure/chair/stool/rogue,
+/obj/structure/chair/bench/couch,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "jHE" = (
@@ -58496,6 +58532,14 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach/forest/south)
+"lqN" = (
+/obj/structure/chair/bench/couch/r,
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = -17;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "lqO" = (
 /obj/structure/fluff/railing/border/north,
 /obj/structure/fluff/railing/border/east,
@@ -59004,6 +59048,14 @@
 /obj/item/kitchen/fork/silver{
 	pixel_x = -9;
 	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 9;
+	pixel_y = 17
+	},
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = -13;
+	pixel_y = 24
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
@@ -59724,6 +59776,23 @@
 /obj/machinery/light/rogue/smelter/hiron,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
+"lCV" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = -9;
+	pixel_x = -7
+	},
+/obj/item/kitchen/fork/silver{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 9;
+	pixel_y = 17
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "lCW" = (
 /obj/structure/closet/crate/roguecloset/inn/chest,
 /obj/item/rogueweapon/huntingknife/idagger/navaja,
@@ -61795,6 +61864,9 @@
 /obj/structure/roguemachine/scomm/r{
 	scom_tag = "Manor - Heir's Appartment I"
 	},
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "lWk" = (
@@ -62496,6 +62568,14 @@
 /area/rogue/indoors/town/magician)
 "mcQ" = (
 /obj/structure/table/wood/long_table,
+/obj/item/cooking/platter/silver{
+	pixel_x = 15;
+	pixel_y = 4
+	},
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = -6;
+	pixel_y = 9
+	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "mcU" = (
@@ -64863,6 +64943,15 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
+"mAn" = (
+/obj/structure/table/wood/poor,
+/obj/item/roguebin/water,
+/obj/item/natural/cloth{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/town/basement/keep)
 "mAo" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/naturalstone,
@@ -65899,14 +65988,10 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
 "mLY" = (
-/obj/structure/table/wood/poor,
-/obj/item/roguebin/water,
-/obj/item/natural/cloth{
-	pixel_y = 5;
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/structure/curtain/blue,
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "mMt" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -68465,6 +68550,18 @@
 /area/rogue/under/cave/mazedungeon)
 "noj" = (
 /obj/structure/table/wood/long_table/right,
+/obj/item/flowercrown/matricaria{
+	pixel_x = -16;
+	pixel_y = 6
+	},
+/obj/item/alch/matricaria{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/alch/matricaria{
+	pixel_x = 1;
+	pixel_y = -5
+	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "non" = (
@@ -86499,25 +86596,9 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
 "qJY" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/gold{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_x = 17;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 10;
-	pixel_y = 19
-	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = -11;
-	pixel_y = 8
-	},
+/obj/structure/fluff/statue/knight/r,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/area/rogue/under/town/basement/keep)
 "qJZ" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
@@ -90931,6 +91012,10 @@
 /obj/item/clothing/head/roguetown/wizhat/black,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/magician)
+"rDQ" = (
+/obj/structure/fluff/statue/gargoyle/moss/candles,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "rDS" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/spoon/bronze{
@@ -91399,6 +91484,20 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/orcdungeon)
+"rIT" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 9;
+	pixel_y = 17
+	},
+/obj/item/candle/candlestick/silver/lit,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "rIW" = (
 /obj/item/reagent_containers/glass/cup/ceramic/fancy,
 /obj/structure/table/wood/poor,
@@ -91502,7 +91601,16 @@
 /turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/tavern)
 "rKa" = (
-/obj/machinery/gear_painter,
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 9;
+	pixel_y = 17
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "rKb" = (
@@ -91545,6 +91653,14 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
+"rKD" = (
+/obj/structure/mirror/fancy{
+	pixel_y = 0;
+	pixel_x = -32
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/town/basement/keep)
 "rKG" = (
 /obj/structure/table/wood/long_table,
 /obj/item/reagent_containers/glass/bottle/rogue/wine{
@@ -92741,6 +92857,11 @@
 "rWq" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon1/gethsmane)
+"rWs" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/bouquet/matricaria,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "rWt" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -95118,15 +95239,22 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "suH" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = 8;
+	pixel_y = 5
 	},
-/obj/machinery/light/rogue/candle/r{
-	pixel_x = 32;
-	pixel_y = -11
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = -5;
+	pixel_y = 16
 	},
-/turf/open/transparent/openspace,
-/area/rogue/under/town/basement/keep)
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = 14;
+	pixel_y = 24
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "suQ" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -98913,6 +99041,14 @@
 /obj/item/reagent_containers/glass/cup/silver,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"tgX" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/candle/candlestick/gold/lit{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "tha" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/structure/fluff/walldeco/customflag{
@@ -108367,6 +108503,10 @@
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"uYL" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/basement/keep)
 "uYM" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -108511,8 +108651,8 @@
 /area/rogue/under/cave/dukecourt)
 "vak" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_x = 7;
+/obj/item/candle/candlestick/gold/lit{
+	pixel_x = 0;
 	pixel_y = 15
 	},
 /turf/open/floor/rogue/wood/herringbone,
@@ -108605,13 +108745,22 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/inq/embassy)
 "vaU" = (
-/obj/structure/mirror/fancy{
-	pixel_y = 0;
-	pixel_x = -32
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = -9;
+	pixel_y = 5
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 9;
+	pixel_y = 17
+	},
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = 15;
+	pixel_y = 25
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "vaW" = (
 /obj/structure/fluff/psycross/astrata/golden,
 /turf/open/floor/rogue/churchrough,
@@ -111017,6 +111166,7 @@
 /obj/effect/landmark/start/prince{
 	dir = 8
 	},
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "vzj" = (
@@ -117627,6 +117777,19 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"wOi" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = 14;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = -5;
+	pixel_y = 16
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "wOj" = (
 /obj/structure/fluff/railing/corner/south_east,
 /obj/structure/fluff/railing/corner/south_west,
@@ -119813,6 +119976,18 @@
 "xna" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/cooking/platter/silver,
+/obj/item/candle/candlestick/silver/lit{
+	pixel_x = 12;
+	pixel_y = -14
+	},
+/obj/item/kitchen/fork/silver{
+	pixel_x = 14;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = -5;
+	pixel_y = 16
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "xnc" = (
@@ -195823,7 +195998,7 @@ iad
 iad
 cPO
 cPO
-haC
+qJY
 iad
 iad
 iad
@@ -291193,7 +291368,7 @@ fCL
 fCL
 fCL
 msn
-bDo
+rDQ
 mJD
 nkA
 jya
@@ -308371,8 +308546,8 @@ iad
 iad
 mdt
 aal
-vaU
-mLY
+rKD
+mAn
 iad
 reQ
 hFg
@@ -309274,7 +309449,7 @@ iad
 iad
 iad
 iad
-euU
+uYL
 aal
 iad
 iad
@@ -310630,7 +310805,7 @@ rTY
 iad
 iad
 iad
-suH
+ccT
 asJ
 xgW
 wCC
@@ -420003,7 +420178,7 @@ rLl
 dir
 qXR
 aZJ
-lvE
+vaU
 lLP
 tCI
 vxe
@@ -420455,7 +420630,7 @@ ibw
 xsF
 qXR
 aZJ
-lvE
+rIT
 lLP
 dir
 tCI
@@ -420899,7 +421074,7 @@ eIk
 nVW
 lRg
 lRg
-dPn
+rWs
 sSy
 tCI
 jxs
@@ -421355,7 +421530,7 @@ etj
 wRu
 dir
 xna
-xna
+wOi
 tCI
 dir
 ibw
@@ -421368,7 +421543,7 @@ vxe
 gKo
 ygR
 hmU
-qxS
+lqN
 kLi
 qxS
 vxe
@@ -424066,8 +424241,8 @@ lRg
 ugJ
 pNB
 ruD
-xna
-xna
+lCV
+rKa
 xwF
 ruD
 ibw
@@ -424522,8 +424697,8 @@ dPu
 jxL
 ruD
 qXR
-lvE
-aZJ
+rKa
+suH
 lLP
 xwF
 ruD
@@ -424974,7 +425149,7 @@ wWq
 ibw
 eOA
 qXR
-lvE
+rKa
 aZJ
 lLP
 ruD
@@ -425419,15 +425594,15 @@ vxe
 lsP
 lRg
 ezn
-qJY
+ohQ
 sSy
 xwF
 ibw
 kMx
 ruD
 qXR
-lvE
-aZJ
+rKa
+bYm
 lLP
 xwF
 vxe
@@ -425867,11 +426042,11 @@ aDs
 hNP
 lOO
 tWS
-eIk
+iBT
 wfS
 lRg
 lRg
-dPn
+tgX
 sSy
 ruD
 xHQ
@@ -527578,10 +527753,10 @@ fAA
 wYV
 vxe
 vxe
+bwL
 gZs
 gZs
-gZs
-gZs
+itD
 gZs
 gZs
 gZs
@@ -528037,7 +528212,7 @@ gZs
 gZs
 gZs
 gZs
-uIk
+mLY
 sLn
 sLn
 dzz
@@ -531199,7 +531374,7 @@ vxe
 qHk
 fAA
 fAA
-rKa
+fAA
 sLn
 kys
 rnm

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -18,6 +18,10 @@
 /obj/item/fishingrod,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"aaj" = (
+/obj/structure/bobcatpelt,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "aal" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
@@ -1104,6 +1108,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach/north)
+"aly" = (
+/obj/structure/foxpelt{
+	pixel_y = -18;
+	pixel_x = -2
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "alB" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
@@ -6472,15 +6483,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
-"bqN" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w";
-	pixel_x = -1
-	},
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
 "brc" = (
 /obj/structure/bars/steel,
 /turf/open/transparent/openspace,
@@ -7717,14 +7719,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
-"bCB" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread";
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "bCD" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -9610,6 +9604,11 @@
 "bWg" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/woods)
+"bWh" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "bWn" = (
 /mob/living/carbon/human/species/elf/dark/drowraider,
 /turf/open/floor/rogue/blocks,
@@ -11864,6 +11863,18 @@
 "ctG" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/inq)
+"ctH" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = -7;
+	pixel_x = -4
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "ctI" = (
 /obj/structure/mineral_door/wood/donjon{
 	desc = "a large door. It seems big enough to fit a mount.";
@@ -20635,6 +20646,13 @@
 "efo" = (
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
+"efp" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32;
+	pixel_x = 16
+	},
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/manor)
 "efr" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grass,
@@ -29895,18 +29913,6 @@
 "fWp" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/cave/mazedungeon)
-"fWv" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = -7;
-	pixel_x = -4
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "fWw" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/wood,
@@ -46399,13 +46405,6 @@
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
-"jhd" = (
-/obj/structure/foxpelt{
-	pixel_y = -18;
-	pixel_x = -2
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
 "jhh" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/edge{
@@ -61022,10 +61021,6 @@
 /obj/item/rogueweapon/scabbard/gwstrap,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
-"lNE" = (
-/obj/structure/bobcatpelt,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "lNG" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/cave/east)
@@ -62761,11 +62756,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
-"meJ" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "meN" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -66319,6 +66309,7 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "mQz" = (
+/obj/structure/fluff/railing/wood/east,
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 4
 	},
@@ -82911,12 +82902,6 @@
 "qaH" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
-"qaI" = (
-/obj/structure/mirror/fancy{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "qaQ" = (
 /obj/structure/stairs{
 	dir = 4
@@ -90620,11 +90605,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
 "rAK" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32;
-	pixel_x = 16
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread";
+	pixel_y = -6
 	},
-/turf/closed/wall/mineral/rogue/stonebrick,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "rAP" = (
 /obj/item/roguecoin/gold{
@@ -90993,9 +90979,11 @@
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/magician)
 "rDQ" = (
-/obj/structure/fluff/statue/gargoyle/moss/candles,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep/unbuildable)
+/obj/structure/mirror/fancy{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "rDS" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/spoon/bronze{
@@ -101736,6 +101724,18 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/exposed/magiciantower)
+"tIW" = (
+/obj/structure/closet/crate/drawer/random{
+	pixel_y = 0
+	},
+/obj/item/clothing/ring/gold,
+/obj/item/rogueweapon/huntingknife/scissors/steel,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32;
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "tIZ" = (
 /obj/structure/table/church/m,
 /obj/item/candle/eora{
@@ -120175,18 +120175,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
-"xoy" = (
-/obj/structure/closet/crate/drawer/random{
-	pixel_y = 0
-	},
-/obj/item/clothing/ring/gold,
-/obj/item/rogueweapon/huntingknife/scissors/steel,
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32;
-	pixel_x = 16
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "xoB" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -124780,10 +124768,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "yiR" = (
-/obj/structure/fluff/railing/wood/east,
-/obj/structure/fluff/railing/wood/north,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep/unbuildable)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w";
+	pixel_x = -1
+	},
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "yiU" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/effect/decal/cleanable/roguerune/god/psydon,
@@ -176100,7 +176092,7 @@ tsN
 tsN
 tsN
 uvk
-bhJ
+tsN
 ehs
 ehs
 ehs
@@ -290908,14 +290900,14 @@ cqx
 fCL
 fCL
 mQz
-exD
-exD
-njB
-jiQ
-njB
-pWT
-pWT
-wMX
+fCL
+fCL
+fCL
+fCL
+fCL
+fCL
+msn
+bDo
 ikO
 aFv
 aFv
@@ -291359,15 +291351,15 @@ khy
 khy
 khy
 khy
-yiR
-fCL
-fCL
-fCL
-fCL
-fCL
-fCL
-msn
-rDQ
+khy
+khy
+khy
+khy
+khy
+khy
+khy
+khy
+mJD
 mJD
 nkA
 jya
@@ -406169,14 +406161,14 @@ khy
 khy
 khy
 khy
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+khy
+khy
+khy
+khy
+khy
+khy
+khy
+khy
 bGf
 bGf
 bGf
@@ -524140,8 +524132,8 @@ fHc
 fHc
 jVV
 vxe
-xoy
-lNE
+tIW
+aaj
 fAA
 pZc
 vxe
@@ -525499,7 +525491,7 @@ rdi
 keM
 tFv
 xZf
-qaI
+rDQ
 vxe
 wOi
 prJ
@@ -525951,12 +525943,12 @@ vxe
 rIe
 ejC
 eOt
-bqN
+yiR
 vxe
-meJ
+bWh
 cjc
 aLr
-fWv
+ctH
 hsd
 jHJ
 vmi
@@ -526407,7 +526399,7 @@ rpv
 vxe
 gHS
 eFX
-bCB
+rAK
 xZf
 hsd
 jHJ
@@ -526853,7 +526845,7 @@ lRg
 nBg
 vxe
 gFd
-jhd
+aly
 lWi
 vxe
 vxe
@@ -529115,7 +529107,7 @@ vxe
 kia
 kia
 vxe
-rAK
+efp
 pSr
 fHc
 vxe

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -106,10 +106,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "abi" = (
-/obj/structure/fluff/railing/corner,
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric_double{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "abn" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woods/north)
@@ -327,8 +331,15 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach)
 "adt" = (
-/obj/item/clothing/head/peaceflower,
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/fluff/statue/femalestatue1{
+	pixel_y = 6;
+	pixel_x = -18
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "adw" = (
 /obj/effect/decal/cobbleedge{
@@ -1483,6 +1494,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dukecourt)
+"aoN" = (
+/obj/effect/lily_petal/two,
+/turf/open/water/bath,
+/area/rogue/indoors/town/manor)
 "aoO" = (
 /obj/effect/decal/edge_corner{
 	color = "#3f3f3f";
@@ -2253,23 +2268,6 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
-"ayb" = (
-/obj/effect/decal/carpet/kover_black{
-	pixel_w = 0;
-	pixel_x = -15;
-	pixel_y = -25;
-	pixel_z = 0
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine{
-	pixel_x = 7;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "ayf" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
@@ -2449,7 +2447,10 @@
 /area/rogue/indoors/town/church/chapel)
 "aAq" = (
 /obj/structure/fluff/railing/corner/north_east,
-/obj/structure/fluff/railing/corner,
+/obj/structure/roguemachine/scomm{
+	scom_tag = "Manor - Kitchen"
+	},
+/obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "aAw" = (
@@ -3539,13 +3540,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woods/southeast)
 "aLr" = (
-/obj/structure/stairs/fancy/l{
-	dir = 1
-	},
-/turf/open/floor/rogue/carpet/lord{
-	icon_state = "carpet_l"
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/carpet/red,
+/area/rogue/under/town/basement/keep)
 "aLs" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/effect/decal/cleanable/blood/drip{
@@ -3674,12 +3671,6 @@
 /obj/effect/landmark/chimeric_calyx_spawner/thirty,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest/hamlet)
-"aMK" = (
-/obj/structure/fluff/railing/corner/north_east,
-/obj/structure/flora/roguegrass,
-/obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "aMW" = (
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/concrete,
@@ -4070,14 +4061,16 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "aRN" = (
-/obj/structure/fluff/railing/corner/south_east,
-/obj/structure/fluff/railing/corner/south_west,
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border/north{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
+	},
+/area/rogue/indoors/town/manor)
 "aRP" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/fluff/railing/border/north,
@@ -4113,11 +4106,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
 "aSd" = (
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
-	},
-/obj/machinery/light/rogue/campfire/fireplace,
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/obj/structure/fluff/walldeco/bigpainting/lake,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "aSg" = (
 /obj/structure/mirror,
@@ -4371,10 +4361,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "aUM" = (
-/obj/structure/fluff/railing/border/east,
-/obj/structure/fluff/railing/border/west,
-/obj/machinery/light/rogue/candle/l,
-/turf/open/transparent/openspace,
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8;
+	pixel_y = 17
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
+	},
 /area/rogue/indoors/town/manor)
 "aUO" = (
 /turf/open/floor/rogue/wood,
@@ -4464,17 +4457,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"aVJ" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/tunic,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
-/obj/item/clothing/suit/roguetown/armor/silkcoat,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/dress/royal/princess,
-/obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "aVK" = (
 /obj/structure/rack/rogue,
 /obj/item/natural/bundle/stick{
@@ -4817,15 +4799,11 @@
 "aZJ" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/cooking/platter/silver,
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 16;
-	pixel_x = -7
-	},
 /obj/item/kitchen/fork/silver{
 	pixel_x = 8;
 	pixel_y = 5
 	},
-/turf/open/floor/rogue/tile/masonic,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "aZL" = (
 /obj/structure/table/wood/poor,
@@ -5147,6 +5125,15 @@
 /obj/machinery/light/rogue/campfire/fireplace,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
+"bcp" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "bcr" = (
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
 /turf/open/floor/rogue/cobble,
@@ -5529,25 +5516,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "bgH" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/natural/bundle/stick{
-	pixel_y = -6
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = -6
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = -6
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = -6
-	},
 /obj/structure/fluff/railing/border/east,
-/obj/structure/roguemachine/scomm{
-	scom_tag = "Manor - Kitchen"
-	},
-/obj/structure/fluff/railing/corner/south_west,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "bgJ" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -6038,21 +6008,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest/north)
 "bmd" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 5;
-	pixel_x = 9
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/obj/structure/fluff/statue/knight/interior/r,
+/turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
 "bmg" = (
 /obj/item/reagent_containers/food/snacks/egg,
@@ -6237,19 +6194,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
-"bnK" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/standingbell{
-	name = "servantry service bell";
-	specific_location = "Throne Room"
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
-/area/rogue/indoors/town/manor)
 "bnL" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/forest/north)
@@ -7014,14 +6958,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/inq/embassy)
 "bvB" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "bvC" = (
 /obj/structure/ladder,
@@ -7266,6 +7210,22 @@
 "byb" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -1;
+	pixel_y = -5
+	},
+/obj/item/natural/cloth{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/food/snacks/rogue/veg/potato_sliced{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue{
+	pixel_x = 0;
+	pixel_y = -5
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
@@ -7917,10 +7877,6 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/cave/dukecourt)
-"bEL" = (
-/obj/structure/chair/bench/couch/r,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "bEM" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/naturalstone,
@@ -8883,13 +8839,21 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/underdark/north)
 "bOt" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/closet/crate/chest/crate,
+/obj/item/natural/bundle/stick{
+	pixel_y = -6
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/item/natural/bundle/stick{
+	pixel_y = -6
 	},
-/area/rogue/indoors/town/manor)
+/obj/item/natural/bundle/stick{
+	pixel_y = -6
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement/keep)
 "bOu" = (
 /obj/effect/landmark/mapGenerator/rogue/mountain{
 	endTurfY = 450
@@ -9166,16 +9130,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
-"bRj" = (
-/obj/structure/table/wood/long_table,
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "bRl" = (
 /obj/machinery/light/rogue/candle/blue,
 /obj/structure/rack/rogue/shelf/big,
@@ -9559,10 +9513,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
-"bVl" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/manor)
 "bVn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -10342,7 +10292,6 @@
 	icon_state = "cobbleedge-w";
 	pixel_y = -7
 	},
-/obj/machinery/loom,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "cfJ" = (
@@ -10549,10 +10498,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "chn" = (
-/obj/structure/stairs,
-/obj/structure/fluff/railing/border/west,
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/cobble,
+/obj/structure/table/wood,
+/obj/structure/standingbell{
+	name = "servantry service bell";
+	specific_location = "Throne Room"
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "chp" = (
 /obj/structure/fluff/railing/border/north,
@@ -10697,6 +10648,10 @@
 /obj/structure/closet/crate/coffin/royal/keylock/psydon,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault/four)
+"cjc" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "cje" = (
 /obj/structure/stairs/stone,
 /obj/machinery/light/rogue/candle/blue/r,
@@ -11797,9 +11752,14 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "cte" = (
-/obj/structure/chair/wood/rogue/fancy,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/candle,
+/obj/structure/roguemachine/mail{
+	mailtag = "Manor Lower Vestibule";
+	pixel_x = -30;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "ctf" = (
 /obj/structure/fluff/railing/border/east,
 /obj/effect/decal/edge_corner{
@@ -11970,11 +11930,11 @@
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/beach/forest/north)
 "cuS" = (
-/obj/machinery/light/rogue/candle/l,
-/obj/structure/mannequin/male/decorative/training_dummy_style,
-/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted,
-/obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "cuZ" = (
 /obj/structure/chair/wood/rogue{
@@ -12749,6 +12709,19 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
+"cCL" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/cooking/platter/gold,
+/obj/item/kitchen/fork/gold{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 4;
+	pixel_y = 15
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "cCQ" = (
 /obj/structure/table/wood/poor/alt_alt,
 /obj/structure/bars/shop/bronze,
@@ -14715,9 +14688,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest/hamlet)
 "cWR" = (
-/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/tile/masonic{
-	dir = 8
+	dir = 4
 	},
 /area/rogue/indoors/town/manor)
 "cWT" = (
@@ -15271,11 +15244,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "ddf" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/table/wood,
+/obj/item/mini_flagpole/duke,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 10;
+	pixel_y = 19
 	},
-/turf/open/floor/rogue/tile/masonic/inverted,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "ddl" = (
 /obj/structure/mineral_door/bars{
@@ -15789,6 +15764,12 @@
 "diN" = (
 /turf/closed/wall/mineral/rogue/wooddark/end/east,
 /area/rogue/indoors/shelter/woods)
+"diO" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "diU" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/corner/north_east,
@@ -16003,6 +15984,14 @@
 "dll" = (
 /turf/closed/wall/mineral/rogue/pipe/corners/eight,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"dls" = (
+/obj/structure/fluff/railing/corner/north_east,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "dlt" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/effect/spawner/lootdrop/general_loot_mid,
@@ -16115,6 +16104,17 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"dmv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w";
+	pixel_x = -1
+	},
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "dmw" = (
 /obj/structure/flora/hotspring_rocks,
 /turf/open/floor/rogue/grasscold,
@@ -16193,8 +16193,10 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/scarymaze)
 "dnA" = (
-/obj/structure/fluff/walldeco/painting/queen,
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "dnD" = (
 /obj/machinery/light/rogue/campfire{
@@ -16849,6 +16851,12 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
+"dtm" = (
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Manor - Heir's Appartment II"
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "dtw" = (
 /obj/structure/fluff/walldeco/artificerflag{
 	name = "Crafter's Guild"
@@ -17707,6 +17715,13 @@
 /obj/machinery/light/rogue/campfire/fireplace,
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"dBw" = (
+/obj/machinery/light/rogue/candle/floorcandle{
+	pixel_y = -14;
+	pixel_x = 0
+	},
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/manor)
 "dBy" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/naturalstone,
@@ -19018,22 +19033,6 @@
 /area/rogue/outdoors/beach/forest/north)
 "dPn" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/gold{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 10;
-	pixel_y = 19
-	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_x = -17;
-	pixel_y = 11
-	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "dPo" = (
@@ -19058,9 +19057,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "dPx" = (
+/obj/structure/fluff/railing/border/east,
 /obj/structure/stairs,
-/obj/structure/fluff/railing/border/west,
-/obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "dPA" = (
@@ -19174,10 +19172,6 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
-"dQD" = (
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "dQF" = (
 /obj/structure/fluff/railing/border/east,
 /obj/structure/fermentation_keg,
@@ -19258,6 +19252,12 @@
 /obj/item/flint,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"dRb" = (
+/obj/structure/chair/wood/rogue/chair5{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "dRm" = (
 /obj/structure/table/church/end,
 /obj/effect/spawner/lootdrop/valuable_candle_spawner,
@@ -19411,11 +19411,10 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
 "dTb" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
+/obj/structure/stairs/fancy/l{
+	dir = 1
 	},
-/obj/structure/fluff/statue/knight/interior/r,
-/turf/open/floor/rogue/tile/masonic/single,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "dTd" = (
 /obj/structure/fluff/psycross/zizocross,
@@ -19676,8 +19675,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark/north)
 "dVY" = (
-/obj/structure/fluff/railing/corner/north_east,
 /obj/structure/flora/roguegrass/herb/random,
+/obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "dWd" = (
@@ -19723,12 +19722,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach)
 "dWM" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "dWO" = (
 /obj/structure/fluff/railing/wood/east,
 /obj/structure/fluff/railing/wood/north,
@@ -20118,15 +20114,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "eaD" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
+/obj/structure/fluff/walldeco/bigpainting/lake{
+	pixel_y = -32
 	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "eaG" = (
 /obj/structure/flora/rogueshroom{
@@ -20355,18 +20346,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog/north)
-"ecv" = (
-/obj/structure/table/wood/long_table/east,
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/obj/item/rogueweapon/huntingknife/scissors/steel{
-	pixel_x = -7;
-	pixel_y = -5;
-	sellprice = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "ecB" = (
 /obj/machinery/light/rogue/candle/l,
 /obj/structure/standingbell{
@@ -20553,12 +20532,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "eeh" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/obj/structure/fluff/railing/border/north,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "eei" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -20633,6 +20611,11 @@
 "efo" = (
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
+"efr" = (
+/turf/open/water/bath{
+	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
+	},
+/area/rogue/indoors/town/manor)
 "efw" = (
 /mob/living/carbon/human/species/skeleton/npc/medium,
 /turf/open/floor/rogue/dirt/road,
@@ -21005,6 +20988,17 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
+"ejC" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w";
+	pixel_x = -1
+	},
+/obj/structure/chair/wood/rogue/chair5{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "ejG" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/west)
@@ -21062,8 +21056,14 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
 "eki" = (
-/obj/structure/chair/wood/rogue/throne,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border/north,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
+	},
 /area/rogue/indoors/town/manor)
 "ekj" = (
 /obj/effect/decal/cobbleedge{
@@ -21162,12 +21162,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/mountains/decap)
 "elk" = (
-/obj/structure/table/wood/poor,
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "ell" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 1;
@@ -21564,7 +21561,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cavewet/bogcaves/south)
 "eoS" = (
-/obj/structure/fluff/railing/wood/west,
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/exposed/town/keep/unbuildable)
 "eoU" = (
@@ -21809,8 +21808,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "ere" = (
-/obj/structure/chair/bench/couch/r,
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/table/wood/long_table,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "erp" = (
 /obj/structure/fluff/walldeco/customflag,
@@ -21829,15 +21828,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "erB" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
+/obj/structure/mineral_door/wood/fancywood{
+	lockid = "heir2";
+	name = "Heir's Apartment II";
+	locked = 1
 	},
-/obj/structure/standingbell{
-	name = "servantry service bell";
-	specific_location = "Heir's Apartment I";
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "erC" = (
 /obj/structure/fluff/railing/wood/west,
@@ -21984,30 +21980,15 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/cave/peace)
 "etj" = (
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver/pewter,
-/obj/item/reagent_containers/glass/cup/silver/pewter,
-/obj/item/reagent_containers/glass/cup,
-/obj/item/reagent_containers/glass/cup,
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border/north{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
+	},
 /area/rogue/indoors/town/manor)
 "etk" = (
 /obj/effect/decal/cleanable/debris/woody,
@@ -22272,14 +22253,6 @@
 /obj/structure/fluff/railing/wood/west,
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/under/town/basement/keep)
-"ewt" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border/east,
-/obj/structure/curtain/blue,
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/manor)
 "ewv" = (
 /obj/structure/fluff/railing/wood/north,
 /turf/open/floor/rogue/woodturned,
@@ -22305,13 +22278,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/church)
 "ewz" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/fluff/walldeco/bigpainting{
+	pixel_x = -32;
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "ewA" = (
 /obj/structure/spider/stickyweb,
@@ -22869,7 +22841,6 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/south)
 "eBB" = (
-/obj/structure/fluff/railing/corner,
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -23192,6 +23163,12 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
+"eFX" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/turf/open/water/bath{
+	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
+	},
+/area/rogue/indoors/town/manor)
 "eGa" = (
 /obj/structure/table/wood/poor,
 /obj/item/natural/bundle/stick{
@@ -23440,17 +23417,9 @@
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/under/cave/scarymaze)
 "eIk" = (
-/obj/structure/fluff/railing/corner/south_east,
-/obj/structure/fluff/railing/corner/south_west,
-/obj/item/natural/poo{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/natural/poo/cow{
-	pixel_x = -1;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/curtain/red,
+/obj/structure/roguewindow/harem3,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "eIn" = (
 /obj/structure/spider/stickyweb,
@@ -23947,24 +23916,25 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
+"eOt" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w";
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "eOy" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter)
 "eOA" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver{
-	pixel_y = 5
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 21
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 5;
-	pixel_x = 9
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
 	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "eOB" = (
 /obj/machinery/light/rogue/cauldron,
@@ -24931,15 +24901,15 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs/keep)
 "eYJ" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "heir2";
-	name = "Heir's Apartment II";
-	locked = 1
+/obj/effect/decal/carpet/kover_purple{
+	dir = 4;
+	pixel_x = -13;
+	pixel_y = -13
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/town/roofs/keep)
 "eYM" = (
-/obj/structure/fluff/railing/wood/west,
+/obj/structure/fermentation_keg/water,
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/exposed/town/keep/unbuildable)
@@ -25528,15 +25498,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "fdR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/landmark/events/testportal{
-	aportalloc = "manor"
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "fdU" = (
 /obj/effect/decal/carpet/square/black,
 /turf/open/floor/rogue/cobblerock,
@@ -26229,10 +26193,10 @@
 /area/rogue/indoors/town)
 "fkj" = (
 /obj/structure/table/wood/long_table/right,
-/obj/item/rogueweapon/huntingknife/scissors,
 /obj/structure/mirror/fancy{
 	pixel_y = -32
 	},
+/obj/item/paper/scroll,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/manor)
 "fkk" = (
@@ -26501,7 +26465,7 @@
 	pixel_x = -12;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
+/obj/item/reagent_containers/glass/cup/golden/small{
 	pixel_x = 8;
 	pixel_y = 7
 	},
@@ -27380,17 +27344,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
 "fwe" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 16;
-	pixel_x = -7
+/obj/structure/stairs/fancy/c{
+	dir = 1
 	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/tile/masonic/single,
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "fwn" = (
 /obj/machinery/light/rogue/candle/l,
@@ -27710,12 +27667,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/inq/basement)
 "fzW" = (
-/obj/structure/fluff/railing/border/east,
-/obj/structure/roguemachine/mail{
-	mailtag = "Manor Lower Vestibule"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "fzX" = (
 /turf/closed/wall/mineral/rogue/decostone/long/east_west,
 /area/rogue/under/cave/dukecourt)
@@ -27984,9 +27937,10 @@
 	},
 /area/rogue/under/cave/taricheamanor)
 "fCC" = (
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
+/obj/structure/roguewindow,
+/obj/structure/curtain/red,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "fCD" = (
 /obj/effect/decal/mossy{
 	dir = 4
@@ -28504,8 +28458,9 @@
 /area/rogue/indoors)
 "fIa" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
+	pixel_x = 32
 	},
+/obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "fIv" = (
@@ -28516,10 +28471,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault)
 "fIB" = (
-/obj/effect/landmark/start/prince{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "fIC" = (
 /obj/structure/mirror,
@@ -28944,10 +28899,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods/south)
 "fLY" = (
-/obj/structure/fluff/railing/wood/north,
-/obj/structure/fluff/railing/wood/west,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/exposed/town/keep/unbuildable)
+/obj/structure/fluff/pillow/red{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/rogue/outdoors/town)
 "fMd" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/wood,
@@ -29566,15 +29522,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"fTj" = (
-/obj/structure/bed/rogue/inn/double{
-	dir = 1
-	},
-/obj/item/bedsheet/rogue/fabric_double{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "fTl" = (
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/metal,
@@ -29811,6 +29758,20 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"fVk" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
+/obj/item/clothing/suit/roguetown/shirt/dress/royal/princess,
+/obj/item/clothing/shoes/roguetown/simpleshoes/heels,
+/obj/item/clothing/shoes/roguetown/boots,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/steward,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
+/obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "fVm" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/south)
@@ -30154,11 +30115,12 @@
 /turf/closed/wall/mineral/rogue/wooddark/end/north,
 /area/rogue/indoors/cave)
 "fYI" = (
-/obj/structure/rack/rogue/shelf/biggest{
-	pixel_y = 24
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/statue/knight/interior,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "fYN" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/ocean,
@@ -30189,11 +30151,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter)
 "fZc" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/obj/structure/fluff/statue/knight/interior,
-/turf/open/floor/rogue/tile/masonic/inverted,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
 /area/rogue/indoors/town/manor)
 "fZe" = (
 /obj/structure/roguemachine/scomm{
@@ -30577,14 +30540,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/inq/chapel)
-"gdy" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border/west,
-/obj/structure/curtain/blue,
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/manor)
 "gdA" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/cobble,
@@ -30713,16 +30668,49 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
 "geE" = (
-/obj/structure/table/wood/poor,
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 8;
-	pixel_y = 20
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl";
+	sellprice = 30
 	},
-/obj/item/cooking/platter/silver{
-	pixel_y = -6
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl";
+	sellprice = 30
 	},
-/obj/item/cooking/platter/silver{
-	pixel_y = -3
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl";
+	sellprice = 30
+	},
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl";
+	sellprice = 30
+	},
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter/pewter,
+/obj/item/cooking/platter/pewter,
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/gold,
+/obj/item/reagent_containers/glass/bowl/gold,
+/obj/item/reagent_containers/glass/bowl/gold,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy{
+	pixel_x = -1;
+	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
@@ -30776,6 +30764,12 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/beach/forest/south)
+"gfb" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "gfd" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newbranch/leafless{
@@ -30813,6 +30807,13 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter)
+"gfN" = (
+/obj/structure/curtain/red,
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "gfS" = (
 /obj/structure/table/wood/poor,
 /obj/machinery/light/rogue/candle/l,
@@ -32607,9 +32608,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"gxR" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "gxV" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f"
@@ -33147,6 +33145,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/forest/north)
+"gFd" = (
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "gFh" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -33172,11 +33174,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
-"gFm" = (
-/mob/living/simple_animal/butterfly,
-/obj/structure/fluff/railing/border/north,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "gFn" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/cobblerock,
@@ -33256,15 +33253,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave/dukecourt)
 "gGv" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/obj/structure/chair/wood/rogue{
+/obj/structure/stairs{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/obj/structure/fluff/railing/border,
+/obj/structure/curtain/blue,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "gGA" = (
 /obj/structure/chair/stool/rogue,
@@ -33435,6 +33429,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
+"gHS" = (
+/obj/structure/roguemachine/scomm{
+	scom_tag = "Manor - Heir's Lounge"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "gHU" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road,
@@ -33897,6 +33901,12 @@
 "gNh" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/forest/north)
+"gNj" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = -16
+	},
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "gNl" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
@@ -34488,10 +34498,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "gTe" = (
-/obj/structure/fluff/railing/border/north,
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w";
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
 "gTh" = (
 /obj/effect/particle_effect/smoke{
 	lifetime = 14400
@@ -35126,9 +35139,13 @@
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors/shelter/mountains/decap)
 "gYO" = (
-/obj/structure/fluff/railing/corner/north_east,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/structure/bookcase/random,
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = 14;
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "gYQ" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/trash/applecore,
@@ -35699,6 +35716,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dukecourt)
+"hfm" = (
+/obj/structure/fluff/railing/corner/south_east,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "hfq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -36269,19 +36291,12 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/manor)
 "hkp" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/standingbell{
-	dir = 1;
-	name = "servantry service bell";
-	specific_location = "Throne Room"
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border/east,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town/roofs/keep)
 "hku" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -36558,8 +36573,9 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/shelter)
 "hmU" = (
-/obj/structure/fluff/statue/knight/interior,
-/obj/machinery/light/rogue/candle/l,
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/manor)
 "hmZ" = (
@@ -37042,9 +37058,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/druidsgrove)
 "hsd" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/grass,
+/obj/structure/roguewindow/harem3,
+/obj/structure/curtain/blue,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "hse" = (
 /obj/structure/fermentation_keg/water,
@@ -37849,31 +37865,11 @@
 /obj/structure/fluff/railing/corner/south_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"hAu" = (
-/obj/structure/roguemachine/mail/r{
-	mailtag = "Meeting Room"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "hAv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/troll/bog,
 /obj/effect/spawner/lootdrop/general_loot_mid,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
-"hAy" = (
-/obj/structure/table/wood/long_table/right,
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	pixel_x = 3;
-	pixel_y = 5;
-	sellprice = 30
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "hAG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -40028,8 +40024,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dukecourt)
 "hVX" = (
-/obj/structure/fluff/railing/border/north,
-/obj/structure/closet/crate/roguecloset/inn,
+/obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "hWa" = (
@@ -40980,6 +40975,12 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
+"ieA" = (
+/obj/structure/roguemachine/scomm/l{
+	scom_tag = "Manor - Lobby"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "ieC" = (
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/wood,
@@ -41172,12 +41173,12 @@
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "igK" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/standingbell{
+	name = "servantry service bell";
+	specific_location = "Meeting Room";
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/manor)
 "igO" = (
 /obj/structure/bed/rogue/shit,
@@ -41492,11 +41493,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "ijM" = (
-/obj/structure/standingbell{
-	name = "servantry service bell";
-	specific_location = "Meeting Room"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/fluff/railing/border/north{
+	dir = 4
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
 /area/rogue/indoors/town/manor)
 "ijN" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -41691,10 +41696,6 @@
 /obj/structure/fluff/railing/wood/east,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
-"ilp" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "ils" = (
 /obj/structure/bars/grille,
 /turf/open/transparent/openspace,
@@ -42518,11 +42519,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
-"itj" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "itm" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/blocks,
@@ -42795,14 +42791,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
-"iwi" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border/north,
-/obj/structure/curtain/blue,
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/manor)
 "iwl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -42940,12 +42928,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/inq/basement)
-"ixa" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Manor - Heir's Apartment - I"
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "ixh" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road,
@@ -43076,9 +43058,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
 "iys" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "iyu" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/cave)
@@ -43757,7 +43739,10 @@
 /area/rogue/indoors/town/church/chapel)
 "iGh" = (
 /obj/structure/table/wood/long_table,
-/obj/item/natural/fur/wolf,
+/obj/item/candle/gold/lit{
+	pixel_y = 6;
+	pixel_x = 3
+	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/manor)
 "iGi" = (
@@ -44889,6 +44874,10 @@
 /obj/effect/falling_sakura,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
+"iRl" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "iRm" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -45485,6 +45474,13 @@
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"iXo" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border/north,
+/turf/open/floor/carpet/red,
+/area/rogue/under/town/basement/keep)
 "iXq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -48223,10 +48219,15 @@
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/shop)
 "jxL" = (
-/obj/structure/mirror,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8;
+	pixel_y = 17
+	},
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "jxM" = (
 /obj/structure/fluff/railing/border/east,
 /obj/item/roguebin/water,
@@ -48260,21 +48261,9 @@
 	smooth = 0
 	},
 /area/rogue/outdoors/town)
-"jxZ" = (
-/obj/structure/table/wood/fancy/red,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "jya" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep/unbuildable)
-"jyc" = (
-/obj/machinery/light/rogue/candle,
-/obj/structure/fluff/statue/femalestatue2{
-	pixel_y = 0;
-	pixel_x = -15
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "jyd" = (
 /obj/item/natural/stone,
 /obj/structure/vine{
@@ -49278,10 +49267,8 @@
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
 "jHD" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "jHE" = (
 /obj/effect/decal/cobbleedge{
@@ -50213,59 +50200,14 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "jQJ" = (
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter/pewter,
-/obj/item/cooking/platter/pewter,
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/manor)
-"jQL" = (
-/obj/structure/stairs{
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/structure/fluff/railing/border,
-/obj/structure/curtain/blue,
-/turf/open/floor/rogue/tile/harem,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "jQM" = (
 /obj/structure/flora/roguegrass/bush/wall,
@@ -50381,11 +50323,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/north)
-"jRJ" = (
-/obj/structure/fluff/railing/border/north,
-/obj/structure/fluff/railing/border/west,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "jSe" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -50800,6 +50737,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"jVV" = (
+/obj/structure/closet/crate/drawer/random{
+	pixel_y = 0
+	},
+/obj/item/clothing/ring/gold,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "jVX" = (
 /obj/structure/bed/rogue/shit,
 /obj/structure/fluff/walldeco/chains{
@@ -51290,6 +51234,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/under/cave/dukecourt)
+"kas" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/curtain/blue,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "kat" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -51746,12 +51700,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
-"key" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/manor)
 "kez" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -51781,6 +51729,10 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods/south)
+"keM" = (
+/obj/item/clothing/head/peaceflower,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/manor)
 "keN" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt/road,
@@ -52435,11 +52387,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
-"klB" = (
-/obj/structure/fluff/railing/border/east,
-/obj/structure/fluff/railing/border,
-/turf/open/transparent/openspace,
-/area/rogue/under/town/basement/keep)
 "klM" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
@@ -52712,6 +52659,12 @@
 /obj/effect/landmark/start/servant,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
+"koZ" = (
+/obj/item/soap/bath,
+/turf/open/water/bath{
+	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
+	},
+/area/rogue/indoors/town/manor)
 "kpb" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -53331,10 +53284,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "kvn" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Throne Room"
-	},
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/chair/bench/couch,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "kvr" = (
 /obj/structure/table/wood/poor,
@@ -53367,17 +53318,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/steward)
-"kvx" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/obj/structure/closet/crate/drawer/random{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/item/book/rogue/tales3,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "kvy" = (
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/hexstone,
@@ -53904,14 +53844,6 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
-"kAv" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
-/area/rogue/indoors/town/manor)
 "kAx" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
@@ -54992,8 +54924,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/exposed/town/keep)
 "kLi" = (
-/obj/structure/table/wood/long_table,
-/turf/open/floor/rogue/tile/harem,
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = -16;
+	pixel_y = 13
+	},
+/obj/structure/table/wood/long_table/right,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "kLk" = (
 /obj/structure/bed/rogue/inn/double,
@@ -55004,11 +54940,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach/central)
-"kLp" = (
-/obj/structure/fluff/railing/border/north,
-/obj/structure/fluff/railing/border/east,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manor)
 "kLs" = (
 /obj/structure/chair/bench/couch/r,
 /obj/structure/rogue/trophy/deer,
@@ -55109,7 +55040,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest/south)
 "kMx" = (
-/turf/open/floor/rogue/tile/masonic/single,
+/obj/structure/fermentation_keg/water,
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = -17;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
+	},
 /area/rogue/indoors/town/manor)
 "kME" = (
 /obj/effect/decal/edge{
@@ -55294,6 +55232,7 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/random,
 /obj/item/clothing/suit/roguetown/shirt/dress/royal,
 /obj/item/storage/backpack/rogue/satchel,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/steward,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "kNT" = (
@@ -55711,23 +55650,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/water/ocean,
 /area/rogue/outdoors/beach/central)
-"kSd" = (
-/obj/structure/table/wood/long_table/mid/alt,
-/obj/item/cooking/platter/silver{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/obj/item/kitchen/spoon/gold{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "kSh" = (
 /obj/machinery/light/rogue/candle/off/r,
 /mob/living/carbon/human/species/goblin/npc/hell,
@@ -55738,9 +55660,31 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/underdark/south)
 "kSj" = (
-/obj/structure/fluff/walldeco/painting/seraphina,
-/turf/closed/wall/mineral/rogue/decostone/cand,
-/area/rogue/indoors/town/manor)
+/obj/item/kitchen/spoon/iron,
+/obj/item/kitchen/spoon/iron,
+/obj/item/kitchen/spoon/iron,
+/obj/item/kitchen/spoon/iron,
+/obj/item/kitchen/spoon/iron,
+/obj/item/kitchen/spoon/iron,
+/obj/item/kitchen/fork/iron,
+/obj/item/kitchen/fork/iron,
+/obj/item/kitchen/fork/iron,
+/obj/item/kitchen/fork/iron,
+/obj/item/kitchen/fork/iron,
+/obj/item/kitchen/fork/iron,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver/pewter,
+/obj/item/reagent_containers/glass/cup/silver/pewter,
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup,
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/basement/keep)
 "kSo" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt/road,
@@ -56132,6 +56076,15 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods/southwest)
+"kVR" = (
+/obj/structure/curtain/blue,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/shoes/roguetown/sandals,
+/obj/item/clothing/shoes/roguetown/sandals,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/manor)
 "kVU" = (
 /obj/structure/stairs{
 	dir = 8
@@ -56192,8 +56145,16 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
 "kWx" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
+/obj/structure/table/wood,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = -14;
+	pixel_y = 7
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
@@ -56367,11 +56328,6 @@
 /obj/item/roguemachine/mastermail,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
-"kXU" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "kXY" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -57515,14 +57471,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"liH" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
-/area/rogue/indoors/town/manor)
 "liI" = (
 /obj/structure/fluff/railing/border/north,
 /turf/open/transparent/openspace,
@@ -58394,17 +58342,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/magiciantower)
 "lpr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/corner/south_west,
+/obj/structure/fluff/railing/corner/north_east,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/exposed/town/keep)
 "lpu" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -58416,15 +58357,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/under/underdark/north)
-"lpD" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "lpG" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -58813,23 +58745,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement/keep)
 "lsP" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/gold{
-	pixel_x = -2;
-	pixel_y = 5
+/obj/structure/fluff/walldeco/bigpainting/lake{
+	pixel_x = -32
 	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 10;
-	pixel_y = 19
-	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_x = 11;
-	pixel_y = 11
-	},
+/obj/structure/bookcase/random,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "lsR" = (
@@ -59071,12 +58990,13 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/north)
 "lvE" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = -9;
+	pixel_y = 5
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "lvI" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
@@ -59582,18 +59502,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement/keep)
-"lAj" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
-	},
-/obj/structure/rogue/trophy/deer,
-/obj/structure/closet/crate/drawer/random{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "lAl" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -59878,6 +59786,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"lDA" = (
+/obj/structure/standingbell{
+	name = "servantry service bell";
+	specific_location = "Heir's Apartment II";
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "lDB" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/indoors)
@@ -61168,11 +61084,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"lOn" = (
-/obj/structure/fluff/railing/corner/south_east,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "lOv" = (
 /obj/effect/particle_effect/smoke{
 	lifetime = 14400
@@ -61715,10 +61626,12 @@
 	},
 /area/rogue/under/cave/dungeon1/gethsmane)
 "lUs" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/bookcase/random,
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = 16;
+	pixel_y = -5
 	},
-/turf/open/floor/rogue/tile/masonic,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "lUx" = (
 /obj/structure/fluff/walldeco/psybanner/red,
@@ -61869,6 +61782,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"lWi" = (
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Manor - Heir's Appartment I"
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "lWk" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -61988,7 +61907,7 @@
 /area/rogue/outdoors/mountains)
 "lXd" = (
 /obj/structure/fermentation_keg/beer,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "lXe" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -62332,11 +62251,9 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/indoors/cave/northern)
 "maL" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/wood/north,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "maW" = (
 /obj/structure/fluff/psycross/psycrucifix/stone,
 /turf/open/floor/rogue/cobblerock,
@@ -62410,18 +62327,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
 "mbF" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 16;
-	pixel_x = -7
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "mbH" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach/central)
@@ -62463,12 +62371,6 @@
 /obj/structure/flora/roguegrass/herb/atropa,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/exposed/magiciantower)
-"mcc" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "mcd" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -62504,8 +62406,12 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/under/cave/dukecourt)
 "mcu" = (
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/light/rogue/torchholder/l{
+	pixel_y = 17
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
 /area/rogue/indoors/town/manor)
 "mcw" = (
 /obj/structure/table/finestone,
@@ -62581,10 +62487,6 @@
 /area/rogue/indoors/town/magician)
 "mcQ" = (
 /obj/structure/table/wood/long_table,
-/obj/item/candle/gold/lit{
-	pixel_y = 6;
-	pixel_x = 3
-	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "mcU" = (
@@ -62652,9 +62554,11 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "mdt" = (
-/obj/structure/closet/crate/chest/crate,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/basement/keep)
 "mdu" = (
 /obj/structure/fluff/railing/corner{
 	dir = 10
@@ -63226,9 +63130,8 @@
 /area/rogue/indoors/town)
 "mii" = (
 /obj/structure/stairs{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "mil" = (
@@ -63619,15 +63522,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
 "mmy" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border/east,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town/roofs/keep)
 "mmz" = (
 /obj/structure/fluff/walldeco/vinez{
 	pixel_y = 32;
@@ -63700,11 +63600,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
 "mnB" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/tile/masonic/single,
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "mnD" = (
 /obj/structure/fluff/railing/wood/north,
@@ -63841,6 +63739,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
 	},
+/obj/structure/curtain/black,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "mpi" = (
@@ -64432,11 +64331,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/pestra_sanctum)
 "muN" = (
-/obj/structure/fluff/walldeco/bigpainting/lake{
-	pixel_x = 0
+/obj/structure/fluff/railing/corner/north_east,
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "muR" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/storage/backpack/rogue/satchel,
@@ -64865,9 +64764,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "mzB" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border/east,
-/turf/open/transparent/openspace,
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "mzH" = (
 /obj/structure/stone_tile/surrounding_tile,
@@ -65275,10 +65175,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "mDF" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/herb/salvia,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mDG" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
@@ -65562,11 +65462,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
-"mGy" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "mGL" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -65995,12 +65890,8 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
 "mLY" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border/east,
 /obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement/keep)
 "mMt" = (
 /obj/structure/bars/pipe,
@@ -66152,6 +66043,10 @@
 /obj/structure/rack/rogue/shelf,
 /obj/item/storage/roguebag{
 	pixel_y = 21
+	},
+/obj/item/natural/bundle/cloth/bandage/full{
+	pixel_x = 5;
+	pixel_y = 9
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
@@ -67065,6 +66960,7 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "mXU" = (
 /obj/machinery/light/rogue/candle/blue,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
 /turf/open/water/bath,
 /area/rogue/indoors/town/manor)
 "mXX" = (
@@ -68479,10 +68375,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/beach/forest/south)
-"nnJ" = (
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "nnR" = (
 /obj/item/natural/worms/leech,
 /obj/item/natural/worms/leech{
@@ -68548,22 +68440,17 @@
 /turf/open/floor/rogue/crawl_space,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "noc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "noe" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cave/mazedungeon)
 "noj" = (
-/obj/structure/table/wood/long_table/mid/alt,
-/obj/item/paper/scroll,
+/obj/structure/table/wood/long_table/right,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "non" = (
@@ -68738,11 +68625,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/magiciantower)
-"npY" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "npZ" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -68888,10 +68770,6 @@
 	},
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
-"nrv" = (
-/obj/structure/fluff/railing/border/west,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "nrx" = (
 /obj/structure/fluff/railing/border/north,
 /obj/machinery/light/rogue/firebowl/stump,
@@ -69132,6 +69010,11 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/druidsgrove)
+"ntN" = (
+/obj/structure/roguewindow/openclose/reinforced,
+/obj/structure/curtain/black,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "ntO" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6;
@@ -69823,6 +69706,10 @@
 /obj/item/alch/salvia,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
+"nBg" = (
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "nBm" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
@@ -72033,18 +71920,14 @@
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cavewet/bogcaves/north)
 "nVW" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/gold{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = -11;
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 11;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 10;
-	pixel_y = 19
+/obj/item/candle/candlestick/gold/single/lit{
+	pixel_x = -1;
+	pixel_y = 18
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
@@ -72137,24 +72020,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
 "nXd" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 5;
-	pixel_x = 9
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = -16;
-	pixel_y = 29
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border/east,
+/obj/structure/fluff/railing/border/north,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "nXh" = (
 /obj/effect/decal/wood/herringbone2{
 	dir = 1
@@ -72288,12 +72157,6 @@
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
-"nYN" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Manor - Heir's Apartment - II"
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "nYO" = (
 /obj/structure/flora/roguegrass/herb/hypericum,
 /obj/effect/decal/cobble/mossy{
@@ -72389,10 +72252,6 @@
 "nZU" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/beach)
-"nZV" = (
-/obj/structure/fluff/statue/gargoyle/moss/candles,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "nZY" = (
 /obj/structure/fluff/railing/corner/south_west,
 /obj/effect/decal/cobbleedge{
@@ -72828,9 +72687,6 @@
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
-"odE" = (
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "odG" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/structure/flora/roguegrass,
@@ -72976,8 +72832,8 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "ofq" = (
-/obj/structure/chair/bench/couchablack/r,
 /obj/effect/landmark/start/councillor,
+/obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/manor)
 "ofu" = (
@@ -73219,8 +73075,20 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "ohQ" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/gold{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 10;
+	pixel_y = 19
+	},
+/obj/item/kitchen/fork/gold{
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "ohS" = (
 /obj/effect/decal/edge_corner{
@@ -74046,6 +73914,12 @@
 "orc" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/sewer)
+"ore" = (
+/obj/structure/fluff/pillow/purple{
+	dir = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/town/roofs/keep)
 "orl" = (
 /obj/item/ammo_casing/caseless/rogue/sling_bullet/stone{
 	pixel_x = 4;
@@ -74218,15 +74092,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "osN" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "walls";
+	name = "Secure section"
 	},
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/turf/closed/basic,
 /area/rogue/indoors/town/manor)
 "osO" = (
 /obj/structure/stairs/stone,
@@ -74546,10 +74417,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "ovY" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+/obj/structure/fluff/railing/border/east,
+/obj/structure/stairs/fancy/r{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/masonic,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "ovZ" = (
 /obj/structure/roguerock,
@@ -76767,6 +76639,11 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"oPT" = (
+/obj/structure/fluff/railing/corner/north_east,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "oPV" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -77343,7 +77220,7 @@
 /area/rogue/under/underdark/north)
 "oVr" = (
 /obj/structure/fluff/railing/corner/north_east,
-/obj/structure/fluff/railing/border/west,
+/obj/structure/fluff/railing/corner/south_west,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs/keep)
 "oVv" = (
@@ -77941,6 +77818,15 @@
 /obj/machinery/light/rogue/candle/floorcandle,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/pestra_sanctum)
+"pby" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/obj/structure/fluff/railing/corner/south_west,
+/obj/structure/fluff/railing/corner/south_east,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/basement/keep)
 "pbz" = (
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/ruinedwood,
@@ -78538,9 +78424,7 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
 "phu" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "phv" = (
@@ -78549,11 +78433,12 @@
 /area/rogue/under/cavewet/bogcaves/north)
 "phw" = (
 /obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+	pixel_y = 17
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "phx" = (
 /obj/structure/fermentation_keg/coffee,
@@ -78648,10 +78533,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "pie" = (
-/obj/structure/fluff/statue/knight/interior/r,
-/obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border/north,
+/obj/structure/fluff/railing/border/north{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "pif" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/flashlight/flare/torch/lantern,
@@ -79567,6 +79454,17 @@
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves/north)
+"prJ" = (
+/obj/structure/fluff/pillow/blue{
+	pixel_x = 13;
+	pixel_y = -15
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "prM" = (
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
 /turf/open/water/swamp,
@@ -79681,7 +79579,7 @@
 	icon_state = "cobbleedge-e";
 	pixel_x = -1
 	},
-/obj/machinery/gear_painter,
+/obj/machinery/loom,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "psN" = (
@@ -80007,11 +79905,6 @@
 /mob/living/carbon/human/species/human/northern/bog_deserters/better_gear,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
-"pwI" = (
-/obj/structure/fluff/railing/corner/north_east,
-/obj/structure/fluff/railing/corner/south_east,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "pwQ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -80134,11 +80027,6 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
-"pyb" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "pyf" = (
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/concrete,
@@ -81200,11 +81088,12 @@
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"pIg" = (
-/obj/structure/roguemachine/scomm{
-	scom_tag = "Manor - Throne Room"
+"pId" = (
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = -10;
+	pixel_y = 5
 	},
-/turf/open/floor/rogue/wood/herringbone,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "pIh" = (
 /obj/structure/fluff/railing/border/north,
@@ -81628,7 +81517,10 @@
 /area/rogue/under/town/basement/keep)
 "pMv" = (
 /obj/structure/fluff/railing/corner/north_east,
-/obj/structure/flora/roguegrass,
+/obj/structure/fluff/railing/border/north,
+/obj/structure/fluff/railing/border/north{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "pMz" = (
@@ -81716,11 +81608,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs/keep)
 "pNB" = (
-/obj/structure/chair/wood/rogue/throne,
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/structure/fluff/railing/border/north{
+	dir = 5
 	},
-/turf/open/floor/rogue/wood/herringbone,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "pNM" = (
 /obj/structure/fluff/walldeco/chains,
@@ -82164,10 +82055,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/ocean,
 /area/rogue/indoors/cave/central)
-"pRu" = (
-/obj/structure/fluff/railing/corner/north_east,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "pRE" = (
 /obj/structure/fluff/railing/wood/west,
 /obj/effect/decal/cobbleedge{
@@ -82233,7 +82120,12 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "heir";
+	name = "Heir's Apartment"
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "pSw" = (
 /obj/effect/decal/cobbleedge{
@@ -82802,6 +82694,15 @@
 	},
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
+"pZc" = (
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric_double{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/manor)
 "pZe" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/twig,
@@ -84964,17 +84865,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/magiciantower)
 "quT" = (
-/obj/structure/table/wood/long_table/right,
-/obj/item/natural/feather{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/natural/feather{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border/east,
+/obj/structure/fluff/railing/border,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "quW" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
@@ -85238,12 +85132,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
 "qxS" = (
-/obj/structure/table/wood/long_table/right,
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = -16;
-	pixel_y = 13
-	},
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "qxT" = (
 /mob/living/carbon/human/species/skeleton/npc/medium,
@@ -86277,6 +86167,15 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/cave)
+"qHp" = (
+/obj/structure/fluff/pillow/blue{
+	dir = 1;
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "qHq" = (
 /obj/structure/table/wood/long_table/right,
 /obj/item/rogueweapon/huntingknife/scissors{
@@ -86586,10 +86485,25 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
 "qJY" = (
-/obj/structure/fluff/railing/corner/north_east,
-/obj/machinery/light/rogue/candle/r,
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/gold{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/candle/candlestick/gold/single/lit{
+	pixel_x = 17;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 10;
+	pixel_y = 19
+	},
+/obj/item/kitchen/fork/gold{
+	pixel_x = -11;
+	pixel_y = 8
+	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/manor)
 "qJZ" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
@@ -86808,11 +86722,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
 "qMh" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Heir's Suite"
-	},
 /obj/structure/table/wood/fancy/red,
 /obj/item/candle/silver/lit,
+/obj/structure/roguemachine/vendor/keep_princes{
+	pixel_y = 32;
+	density = 0
+	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "qMl" = (
@@ -87846,25 +87761,8 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "qXR" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 5;
-	pixel_x = 9
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = -16;
-	pixel_y = 29
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "qXS" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
@@ -88202,6 +88100,15 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/cave/taricheamanor)
+"rbc" = (
+/obj/effect/decal/carpet/kover_darkred{
+	dir = 8;
+	pixel_y = 14;
+	pixel_x = 13
+	},
+/obj/item/alch/rosa,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/town/roofs/keep)
 "rbd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -88296,6 +88203,9 @@
 "rbI" = (
 /obj/machinery/light/rogue/candle/r,
 /obj/structure/curtain/red,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "rbL" = (
@@ -88314,13 +88224,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "rbU" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "rbX" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/twig,
@@ -88413,6 +88320,10 @@
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
+"rdc" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/turf/open/water/bath,
+/area/rogue/indoors/town/manor)
 "rdf" = (
 /obj/structure/fluff/railing/border/west,
 /obj/effect/decal/edge{
@@ -88422,9 +88333,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "rdi" = (
-/obj/machinery/light/rogue/candle/l,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile/harem,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "rdk" = (
 /obj/machinery/light/rogue/candle,
@@ -88537,11 +88446,6 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest/hamlet)
-"rdU" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "rdX" = (
 /mob/living/carbon/human/species/skeleton/npc/easy,
 /turf/open/floor/rogue/concrete,
@@ -89649,6 +89553,14 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/inq/embassy)
+"rpv" = (
+/obj/structure/standingbell{
+	name = "servantry service bell";
+	specific_location = "Heir's Apartment I";
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "rpx" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -90363,10 +90275,6 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest/hamlet)
-"rxO" = (
-/obj/structure/chair/bench/couch,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "rxS" = (
 /obj/structure/fluff/railing/corner/south_east,
 /obj/structure/fluff/walldeco/church/line,
@@ -90639,6 +90547,10 @@
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"rAK" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "rAP" = (
 /obj/item/roguecoin/gold{
 	pixel_x = 12;
@@ -90860,6 +90772,13 @@
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
+"rCs" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "rCt" = (
 /obj/item/chair/rogue,
 /obj/effect/decal/cleanable/blood/old,
@@ -91052,9 +90971,12 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/basement)
 "rEF" = (
-/obj/structure/fluff/statue/knight/interior/r,
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/carpet/red,
+/area/rogue/under/town/basement/keep)
 "rEG" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -91288,6 +91210,12 @@
 /obj/structure/fermentation_keg/beer,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
+"rHd" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "rHq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -91399,6 +91327,14 @@
 	},
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
+"rIe" = (
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "heir";
+	name = "Heir's Apartment"
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "rIi" = (
 /obj/structure/roguemachine/hag_ward,
@@ -91695,18 +91631,13 @@
 	},
 /area/rogue/outdoors/town)
 "rLl" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 16;
-	pixel_x = -7
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 8;
-	pixel_y = 5
+/obj/structure/fermentation_keg/water,
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = 19;
+	pixel_y = 16
 	},
 /turf/open/floor/rogue/tile/masonic{
-	dir = 1
+	dir = 4
 	},
 /area/rogue/indoors/town/manor)
 "rLo" = (
@@ -91720,6 +91651,11 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
+"rLq" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/start/prince,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "rLr" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
@@ -91893,6 +91829,13 @@
 "rNx" = (
 /turf/closed/wall/mineral/rogue/wooddark/end/west,
 /area/rogue/indoors/shelter/bog/bogmanfort)
+"rNA" = (
+/obj/structure/roguewindow/harem3,
+/obj/structure/curtain/blue,
+/turf/open/water/bath{
+	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
+	},
+/area/rogue/indoors/town/manor)
 "rNF" = (
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/grassred,
@@ -92428,6 +92371,12 @@
 /obj/item/rogueore/copper,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark/north)
+"rSP" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "rSS" = (
 /obj/structure/flora/hotspring_rocks/small{
 	pixel_x = -10;
@@ -92550,9 +92499,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "rTY" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/indoors/town/manor)
+/obj/machinery/gear_painter,
+/turf/open/floor/carpet/red,
+/area/rogue/under/town/basement/keep)
 "rUa" = (
 /obj/structure/fluff/walldeco/painting/skull{
 	pixel_x = -32
@@ -94374,6 +94323,10 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
+"snS" = (
+/obj/structure/curtain/blue,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/manor)
 "snT" = (
 /obj/structure/fluff/railing/corner/north_east,
 /obj/effect/decal/edge{
@@ -94462,6 +94415,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/exposed/town/keep)
+"soE" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "soH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -94624,14 +94583,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/north)
-"sqh" = (
-/obj/structure/table/wood/long_table/mid,
-/obj/item/candle/candlestick/gold/lit{
-	pixel_x = -10;
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "sqi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -94759,12 +94710,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
-"sqW" = (
-/obj/structure/fluff/pillow/blue{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "sqX" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/storage/roguebag,
@@ -95159,7 +95104,6 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "suH" = (
-/obj/structure/fluff/railing/border/west,
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/under/town/basement/keep)
@@ -95517,24 +95461,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "syK" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/gold{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 10;
-	pixel_y = 19
-	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_x = 11;
-	pixel_y = 11
-	},
-/turf/open/floor/rogue/wood/herringbone,
+/obj/machinery/light/rogue/candle,
+/obj/structure/chair/bench/couch/r,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/manor)
 "syN" = (
 /obj/structure/fluff/statue/tdummy,
@@ -96278,6 +96207,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"sGo" = (
+/obj/item/alch/salvia{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/town/roofs/keep)
 "sGu" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/concrete,
@@ -97060,7 +96996,7 @@
 	pixel_x = 7;
 	pixel_y = 13
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "sOz" = (
 /obj/structure/fluff/railing/border/west,
@@ -97204,15 +97140,6 @@
 /obj/item/organ/tongue/zombie,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bog/north)
-"sPT" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
-/area/rogue/indoors/town/manor)
 "sPW" = (
 /obj/effect/decal/cleanable/debris/stony,
 /turf/open/floor/rogue/hexstone,
@@ -97254,13 +97181,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/dukecourt)
 "sQp" = (
-/obj/structure/roguemachine/scomm{
-	scom_tag = "Manor - Frontdoor"
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
 	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/manor)
 "sQq" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -97522,20 +97447,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "sSy" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/gold{
-	pixel_x = -2;
-	pixel_y = 5
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 10;
-	pixel_y = 19
-	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/fluff/railing/border/north,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "sSz" = (
 /obj/structure/fluff/railing/corner/north_east,
@@ -97550,14 +97467,6 @@
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/central)
-"sSL" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "heir1";
-	name = "Heir's Apartment I";
-	locked = 1
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
 "sSP" = (
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/hexstone,
@@ -98200,6 +98109,13 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town)
+"sZh" = (
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 15;
+	pixel_y = 15
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "sZi" = (
 /obj/structure/fluff/railing/border/west,
 /obj/machinery/light/rogue/firebowl/standing,
@@ -98943,13 +98859,13 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
 "tgv" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/stairs,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/basement/keep)
 "tgC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -99662,6 +99578,12 @@
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
+"toi" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "tok" = (
 /obj/structure/bars/steel,
 /turf/open/floor/rogue/cobblerock,
@@ -99928,13 +99850,6 @@
 /obj/structure/flora/roguegrass/maneater/real,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
-"trv" = (
-/obj/structure/roguemachine/vendor/keep_princes{
-	pixel_y = 32;
-	density = 0
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "trx" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/concrete,
@@ -99991,13 +99906,6 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"tsa" = (
-/obj/machinery/light/rogue/candle/l,
-/obj/effect/landmark/start/prince{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/manor)
 "tsd" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road,
@@ -100880,6 +100788,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"tzT" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "tzV" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -101379,6 +101296,19 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblinfort)
+"tFv" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 4;
+	pixel_y = 15
+	},
+/obj/item/cooking/platter/gold,
+/obj/item/kitchen/fork/gold{
+	pixel_x = -10;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "tFB" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -101429,7 +101359,6 @@
 	lockid = "servant_room_two";
 	name = "Servant Bedroom II"
 	},
-/obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement/keep)
 "tGk" = (
@@ -102173,11 +102102,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "tNA" = (
-/obj/structure/stairs,
-/obj/structure/fluff/railing/border/east,
-/obj/structure/fluff/railing/border/west,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/manor)
 "tNC" = (
 /obj/structure/fluff/railing/border/west,
 /obj/structure/stairs/stone{
@@ -102760,13 +102690,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"tTl" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/fluff/railing/corner/north_east,
-/obj/structure/fluff/railing/border/north,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "tTo" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -103565,9 +103488,18 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "ubM" = (
 /obj/structure/table/wood/poor,
-/obj/item/natural/bundle/cloth/bandage/full,
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = 8;
+	pixel_y = 20
+	},
+/obj/item/cooking/platter/silver{
+	pixel_y = -6
+	},
+/obj/item/cooking/platter/silver{
+	pixel_y = -3
+	},
 /obj/machinery/light/rogue/candle/l,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "ubQ" = (
 /obj/structure/fluff/railing/fence{
@@ -103925,6 +103857,13 @@
 /obj/structure/fluff/psycross/necra/cloth,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
+"ufP" = (
+/obj/effect/decal/carpet/kover_darkred{
+	pixel_x = 16;
+	pixel_y = -14
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "ufW" = (
 /obj/machinery/light/rogue/candle/r,
 /obj/structure/lever/wall{
@@ -104047,11 +103986,13 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "ugJ" = (
-/obj/machinery/light/rogue/torchholder/l,
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/stairs{
+	dir = 1
 	},
+/obj/structure/fluff/railing/border/north{
+	dir = 4
+	},
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "ugM" = (
 /obj/structure/stairs/stone{
@@ -105336,14 +105277,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/physician)
-"utW" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border/west,
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
 "utZ" = (
 /obj/item/storage/belt/rogue/surgery_bag/full{
 	pixel_y = 5
@@ -105934,6 +105867,13 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
+"uAE" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "uAF" = (
 /obj/structure/fluff/pillow/black{
 	dir = 8
@@ -106753,12 +106693,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
 "uIk" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "heir";
-	name = "Heir's Apartment"
-	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/curtain/blue,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "uIl" = (
 /turf/open/floor/rogue/tile/harem2,
@@ -107330,11 +107266,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/town/basement/keep)
-"uOJ" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/book/rogue/blackmountain,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "uOL" = (
 /obj/structure/fluff/traveltile/bandit{
 	aportalgoesto = "banditin";
@@ -107448,6 +107379,13 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
+"uQd" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = -16;
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/manor)
 "uQf" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -108552,8 +108490,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "vak" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/structure/table/wood/fancy/black,
+/obj/item/candle/candlestick/gold/single/lit{
+	pixel_x = 7;
+	pixel_y = 15
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
@@ -108572,11 +108512,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "vaw" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/roguemachine/atm{
+	location_tag = "Keep Front Gate"
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/manor)
 "vax" = (
 /obj/effect/decal/cobbleedge{
@@ -108607,19 +108546,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "vaH" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 16;
-	pixel_x = -7
+/obj/structure/chair/wood/rogue/throne,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "vaJ" = (
 /obj/structure/chair/stool/rogue,
@@ -108654,7 +108585,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/inq/embassy)
 "vaU" = (
-/obj/structure/fluff/railing/corner,
+/obj/structure/stairs{
+	dir = 8
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "vaW" = (
@@ -109630,11 +109563,6 @@
 "vlv" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/mountains/decap/minotaurfort)
-"vlw" = (
-/obj/structure/chair/bench/couch,
-/obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/manor)
 "vly" = (
 /obj/structure/flora/roguetree/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -110326,6 +110254,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/woods)
+"vrM" = (
+/obj/structure/fluff/pillow/red,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/town/roofs/keep)
 "vrO" = (
 /obj/effect/decal/cleanable/debris/woody,
 /obj/effect/decal/cleanable/blood/drip{
@@ -110390,9 +110322,6 @@
 /obj/structure/standingbell{
 	name = "servantry service bell";
 	specific_location = "Main Hallway"
-	},
-/obj/structure/roguemachine/atm{
-	location_tag = "Keep Front Gate"
 	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/manor)
@@ -110616,11 +110545,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "vuR" = (
-/obj/structure/stairs{
+/obj/machinery/light/rogue/torchholder/l{
 	dir = 8
 	},
-/obj/structure/fluff/railing/border/north,
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
+	},
 /area/rogue/indoors/town/manor)
 "vuU" = (
 /obj/structure/roguemachine/scomm{
@@ -111058,6 +110988,15 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"vzi" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/landmark/start/prince{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "vzj" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/hexstone,
@@ -111103,9 +111042,14 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
 "vAd" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/manor)
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/basement/keep)
 "vAe" = (
 /obj/structure/fluff/railing/corner/south_east,
 /obj/structure/foxpelt{
@@ -111129,13 +111073,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
 "vAo" = (
-/obj/structure/stairs/fancy/r{
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/carpet/lord{
-	icon_state = "carpet_r"
-	},
-/area/rogue/indoors/town/manor)
+/turf/open/transparent/openspace,
+/area/rogue/under/town/basement/keep)
 "vAp" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -111406,10 +111348,8 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
 	},
-/obj/structure/bed/rogue/inn/double{
-	can_buckle = 0
-	},
 /obj/machinery/light/rogue/candle,
+/obj/machinery/gear_painter,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "vDr" = (
@@ -111767,9 +111707,13 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "vHi" = (
-/obj/structure/fluff/railing/wood/west,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/mineral_door/wood/fancywood{
+	lockid = "heir1";
+	name = "Heir's Apartment I";
+	locked = 1
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "vHm" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -111952,9 +111896,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "vIO" = (
-/obj/structure/fluff/railing/corner/south_west,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border/north,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
+/area/rogue/indoors/town/manor)
 "vIQ" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/bench,
@@ -112061,6 +112011,7 @@
 	pixel_x = -1;
 	pixel_y = -6
 	},
+/obj/machinery/tanningrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "vJU" = (
@@ -112087,11 +112038,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
 "vKj" = (
-/obj/structure/stairs/fancy/c{
-	dir = 1
-	},
-/turf/open/floor/rogue/carpet/lord,
-/area/rogue/indoors/town/manor)
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "vKo" = (
 /obj/effect/landmark/events/deadite_animal_migration_point{
 	order = 8
@@ -112159,6 +112108,15 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
+"vLh" = (
+/obj/machinery/gear_painter,
+/obj/structure/roguemachine/mail{
+	mailtag = "Heir's Suite";
+	pixel_y = 0;
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "vLw" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
@@ -112751,6 +112709,7 @@
 	icon_state = "cobbleedge-w";
 	pixel_y = -7
 	},
+/obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "vRh" = (
@@ -113450,8 +113409,11 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/manor)
 "vXV" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/curtain/purple,
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "vXX" = (
 /obj/structure/stairs/stone{
@@ -113958,12 +113920,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "wdu" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "wdA" = (
 /obj/structure/fluff/psycross/necra/cloth,
 /obj/machinery/light/rogue/candle/blue/l,
@@ -114165,12 +114124,21 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
 "wfS" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/structure/roguemachine/mail{
+	mailtag = "Throne Room"
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/roguemachine/atm{
+	location_tag = "Throne Room";
+	pixel_x = 33;
+	pixel_y = 2
 	},
+/obj/structure/standingbell{
+	dir = 1;
+	name = "servantry service bell";
+	specific_location = "Throne Room"
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "wfT" = (
 /obj/effect/landmark/events/haunts,
@@ -114358,11 +114326,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach)
 "whP" = (
-/obj/structure/fluff/walldeco/bigpainting{
-	pixel_x = 2
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "whR" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cavewet/bogcaves/west)
@@ -114977,13 +114943,6 @@
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"wol" = (
-/obj/structure/flora/roguegrass,
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "won" = (
 /obj/structure/fluff/railing/wood/north{
 	layer = 2.7;
@@ -115230,11 +115189,6 @@
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
-"wqr" = (
-/obj/structure/table/wood/long_table/north_east,
-/obj/item/clothing/ring/gold,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "wqs" = (
 /obj/effect/landmark/chest_or_mimic/loot_chest,
 /turf/open/floor/rogue/twig,
@@ -115352,8 +115306,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wrr" = (
-/obj/structure/fluff/railing/border/west,
-/obj/structure/fluff/railing/border/east,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/fluff/railing/border/north{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wru" = (
@@ -115364,6 +115321,15 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
+"wrx" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/candle/candlestick/gold/lit{
+	pixel_x = 16;
+	pixel_y = 16
+	},
+/obj/item/rogueweapon/huntingknife/scissors/steel,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "wrA" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/servant{
@@ -115551,6 +115517,12 @@
 /mob/living/carbon/human/species/skeleton/npc/easy,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/under/underdark/north)
+"wtw" = (
+/obj/effect/lily_petal/three,
+/turf/open/water/bath{
+	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
+	},
+/area/rogue/indoors/town/manor)
 "wtx" = (
 /obj/structure/table/wood/large_table/north,
 /obj/structure/mineral_door/wood/deadbolt/shutter{
@@ -115928,6 +115900,12 @@
 /obj/effect/landmark/chest_or_mimic/loot_chest,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
+"wxE" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "wxF" = (
 /obj/effect/particle_effect/smoke{
 	lifetime = 14400
@@ -116387,10 +116365,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
-"wBT" = (
-/obj/structure/fluff/pillow/blue,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "wBU" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
@@ -116784,14 +116758,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "wFI" = (
-/obj/structure/fluff/railing/border/north,
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/obj/machinery/gear_painter,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "wFM" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
@@ -117936,12 +117905,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/dukecourt)
 "wRu" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/fluff/railing/border/north{
+	dir = 9
 	},
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "wRz" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/blocks,
@@ -118667,6 +118635,7 @@
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk,
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
 /obj/item/storage/backpack/rogue/satchel,
+/obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "wZa" = (
@@ -118851,13 +118820,6 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
-"xbp" = (
-/obj/structure/standingbell{
-	name = "servantry service bell";
-	specific_location = "Heir's Apartment II"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "xbq" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -119496,6 +119458,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/exposed/town/keep)
+"xio" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/candlestick/gold/lit{
+	pixel_x = 16;
+	pixel_y = 5
+	},
+/obj/item/rogueweapon/huntingknife/scissors/steel,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "xiq" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/dirt,
@@ -119815,10 +119786,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/mazedungeon)
 "xna" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Throne Room"
-	},
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/table/wood/fancy/black,
+/obj/item/cooking/platter/silver,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "xnc" = (
 /obj/effect/decal/cobbleedge{
@@ -119974,24 +119944,11 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
 "xnY" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/gold{
-	pixel_x = -2;
-	pixel_y = 5
+/obj/structure/chair/wood/rogue/throne,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 10;
-	pixel_y = 19
-	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_x = -17;
-	pixel_y = 11
-	},
-/turf/open/floor/rogue/wood/herringbone,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "xoe" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -120491,17 +120448,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/druidsgrove)
 "xsF" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 16;
-	pixel_x = -7
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 21
 	},
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 8;
-	pixel_y = 5
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
 	},
-/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "xsL" = (
 /obj/effect/decal/edge{
@@ -120832,10 +120784,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/dukecourt)
 "xwv" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "xww" = (
 /obj/structure/bed/rogue/inn{
@@ -121418,9 +121370,11 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
 	},
-/obj/structure/fluff/walldeco/med2{
-	pixel_y = 32
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_x = -14;
+	pixel_y = -5
 	},
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "xDd" = (
@@ -121680,14 +121634,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/west)
 "xFl" = (
-/obj/effect/decal/cobbleedge{
+/obj/machinery/light/rogue/lanternpost{
 	dir = 1;
-	icon_state = "borderfall"
+	pixel_x = -11
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "xFp" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/canvas,
@@ -123850,8 +123802,13 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/underdark)
 "ybK" = (
-/obj/structure/mineral_door/wood/deadbolt,
-/turf/open/floor/rogue/concrete,
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "ybM" = (
 /obj/structure/closet/crate/roguecloset/dark,
@@ -124059,6 +124016,7 @@
 "ydl" = (
 /obj/machinery/light/rogue/candle/blue/l,
 /obj/machinery/light/rogue/candle/blue,
+/obj/effect/lily_petal/three,
 /turf/open/water/bath,
 /area/rogue/indoors/town/manor)
 "ydq" = (
@@ -124644,12 +124602,9 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "yjc" = (
-/obj/structure/table/wood,
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 10;
-	pixel_y = 10
+/obj/structure/stairs/fancy/r{
+	dir = 1
 	},
-/obj/item/mini_flagpole/duke,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "yjd" = (
@@ -176852,11 +176807,11 @@ tsN
 tsN
 tsN
 tsN
+oxx
+mTl
 tsN
-tsN
-tsN
-tsN
-tsN
+oxx
+ehs
 tsN
 tsN
 tsN
@@ -193584,7 +193539,7 @@ iad
 gtx
 lLx
 iad
-lIc
+cte
 cPO
 cPO
 loD
@@ -194488,8 +194443,8 @@ iad
 iIF
 cPO
 iad
-fzW
-gYO
+iad
+iad
 cPO
 iad
 qcz
@@ -195392,8 +195347,8 @@ iad
 iad
 iad
 iad
-wRu
-qJY
+cPO
+cPO
 cPO
 iad
 kYL
@@ -195844,9 +195799,9 @@ iad
 iad
 iad
 iad
-iad
-iad
-iad
+cPO
+cPO
+cPO
 iad
 iad
 iad
@@ -196297,7 +196252,7 @@ iad
 iad
 iad
 iad
-ehs
+iad
 iad
 iad
 iad
@@ -288049,7 +288004,7 @@ exD
 exD
 njB
 pWT
-pWT
+whP
 njB
 njB
 xkZ
@@ -288951,9 +288906,9 @@ exD
 exD
 njB
 pWT
-pWT
-pWT
-pWT
+oRD
+pYb
+pYb
 pWT
 pWT
 xkZ
@@ -289404,10 +289359,10 @@ exD
 pWT
 pWT
 pWT
+pYb
+fLY
 pWT
-pWT
-pWT
-njB
+mDF
 wMX
 aFv
 phl
@@ -289850,10 +289805,10 @@ aFv
 yap
 hvv
 hvv
-njB
+rbU
 exD
 exD
-exD
+xFl
 pWT
 pWT
 pWT
@@ -290310,7 +290265,7 @@ exD
 njB
 pWT
 pWT
-pWT
+oRD
 njB
 wMX
 aFv
@@ -292113,10 +292068,10 @@ khy
 khy
 khy
 khy
+bDo
 khy
 khy
-khy
-khy
+bDo
 khy
 khy
 khy
@@ -307029,7 +306984,7 @@ iad
 iad
 iad
 iad
-oDj
+iad
 iad
 lIA
 iad
@@ -308392,10 +308347,10 @@ dpA
 iad
 iad
 iad
-iad
-fYI
+mdt
+aal
+aal
 qJZ
-aOv
 iad
 reQ
 hFg
@@ -308842,14 +308797,14 @@ dIn
 psL
 iad
 iad
-eeh
-wdu
 iad
-jxL
-qJZ
-elk
 iad
-wCC
+mdt
+aal
+aal
+aOv
+iad
+mEr
 hFg
 hFg
 iKP
@@ -309294,14 +309249,14 @@ qMr
 iad
 iad
 iad
-fCC
-vIO
-ybK
-qJZ
-qJZ
-iys
 iad
-mEr
+iad
+iad
+aal
+aal
+iad
+iad
+wCC
 hFg
 gzy
 gzy
@@ -309746,11 +309701,11 @@ aal
 qeU
 rnI
 iad
-iIF
-cPO
 iad
 iad
 iad
+vAd
+ybK
 iad
 iad
 qcz
@@ -310197,11 +310152,11 @@ pAz
 pAz
 bfG
 rnI
-aUd
-cPO
-cPO
-utW
-eIA
+aLr
+iad
+iad
+iad
+vAo
 suH
 xgW
 tUV
@@ -310644,17 +310599,17 @@ kws
 wLF
 wLF
 wLF
-aRN
-tNA
+pby
+tgv
 iad
-wFI
-wLF
-aUd
-cPO
-cPO
+iXo
+rEF
+rTY
+iad
+iad
 mLY
-hHF
-klB
+vAo
+suH
 xgW
 wCC
 kYL
@@ -311093,8 +311048,8 @@ iad
 vDE
 iad
 iad
-wCC
-wCC
+kSj
+bOt
 iad
 iad
 iad
@@ -311539,8 +311494,8 @@ jWw
 xri
 jWw
 hrE
-khy
-khy
+bDo
+bDo
 iad
 iad
 iad
@@ -311558,7 +311513,7 @@ aal
 fmt
 iad
 iad
-khy
+iad
 iad
 xgW
 iad
@@ -311992,8 +311947,8 @@ jWw
 jWw
 khy
 khy
-khy
-khy
+bDo
+bDo
 iad
 iad
 iad
@@ -406016,14 +405971,14 @@ khy
 khy
 khy
 khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
+pyw
+apD
+apD
+apD
+apD
+apD
+apD
+nLk
 bGf
 bGf
 bGf
@@ -406467,16 +406422,16 @@ khy
 khy
 khy
 khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
+pyw
+quT
+vKj
+iys
+eoS
+vKj
+iys
+eoS
+nXd
+nLk
 khy
 khy
 khy
@@ -406919,16 +406874,16 @@ khy
 khy
 khy
 khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
+fQU
+maL
+vKj
+iys
+eoS
+vKj
+iys
+eoS
+wdu
+qUA
 khy
 khy
 khy
@@ -407371,16 +407326,16 @@ khy
 khy
 khy
 khy
-khy
-khy
-pyw
-apD
-apD
-apD
-apD
-nLk
-khy
-khy
+fQU
+maL
+fwF
+fwF
+fwF
+fwF
+fwF
+fwF
+wdu
+qUA
 khy
 khy
 khy
@@ -407823,16 +407778,16 @@ khy
 khy
 khy
 khy
-khy
-khy
 fQU
-fLY
-eoS
-eoS
+iys
+iys
+fwF
+fwF
+fwF
+fwF
+elk
 eYM
 qUA
-khy
-khy
 khy
 pyw
 apD
@@ -414599,7 +414554,7 @@ fAA
 fAA
 eYb
 vGJ
-vAd
+vGJ
 iGh
 vxe
 coN
@@ -415050,7 +415005,7 @@ eYb
 eYb
 eYb
 eYb
-vGJ
+igK
 ofq
 fkj
 vxe
@@ -417762,7 +417717,7 @@ eYb
 eYb
 eYb
 eYb
-ijM
+fHc
 fHc
 mcQ
 vxe
@@ -418210,12 +418165,12 @@ khy
 khy
 vxe
 vxe
-muN
-fAA
+cJK
+cJK
 fAA
 eYb
 fHc
-cte
+fHc
 noj
 vxe
 coN
@@ -418659,29 +418614,29 @@ khy
 khy
 khy
 khy
-emT
 vxe
 vxe
-cJK
-cJK
-hAu
-eYb
-fHc
-fHc
-quT
 vxe
-mCI
-bvB
 vxe
-qAt
+vxe
+vxe
+vxe
+uRY
+uRY
+vxe
+vxe
+vxe
+vxe
+vxe
+ovY
 oaK
 cUp
 lzQ
 lzQ
 vGz
-wxu
-kVK
-nOa
+wrr
+pie
+lpr
 uVN
 uVN
 wWM
@@ -419110,20 +419065,20 @@ bGf
 khy
 khy
 khy
-emT
-emT
 vxe
 vxe
-vxe
-vxe
-vxe
-uRY
-vxe
-vxe
-vxe
-vxe
-ccY
-vxe
+fYI
+wFI
+ijM
+pNB
+tCI
+dir
+tCI
+dir
+tCI
+dir
+uQf
+eYQ
 vxe
 vxe
 set
@@ -419131,10 +419086,10 @@ but
 sLn
 nyF
 vxe
-wrr
-abi
+uwe
+uwe
 pMv
-gzy
+eHv
 gzy
 gzy
 jWw
@@ -419564,19 +419519,19 @@ khy
 khy
 eIk
 chn
-vxe
-vxe
+lRg
+lRg
 vak
-fIa
-lpr
-uBe
-eYQ
-uQf
-uBe
-xwv
-tCI
+sSy
+dir
 fZc
-vxe
+dir
+tCI
+dir
+jxs
+jxs
+tCI
+dir
 vxe
 vxe
 sLn
@@ -419585,7 +419540,7 @@ vxe
 vxe
 uwe
 uwe
-gTe
+uwe
 dVY
 gzy
 gzy
@@ -420014,31 +419969,31 @@ bGf
 khy
 khy
 khy
-emT
-emT
 vxe
+gYO
 lRg
+kvn
 ohQ
-syK
-bnK
+sSy
 tCI
-uBe
+ibw
+rLl
+dir
+qXR
+aZJ
 lvE
-rbU
-uBe
-lvE
-rbU
-uBe
+lLP
+tCI
 vxe
 vxe
 eNS
 eNS
 vxe
 vxe
-uwe
-uwe
-uwe
-kVK
+vxe
+vxe
+vxe
+vxe
 gzy
 icB
 jWw
@@ -420466,31 +420421,31 @@ bGf
 khy
 khy
 khy
-khy
-emT
 vxe
-whP
+ewz
+lRg
+ezn
 ohQ
 sSy
-ddf
+dir
+wWq
+ibw
+xsF
+qXR
+aZJ
+lvE
+lLP
 dir
 tCI
-xsF
-vaH
-tCI
-mbF
-rLl
-tCI
-uBe
 fux
 ygR
 ygR
 oFa
+sQp
+rdi
+mnB
+ieA
 vxe
-vxe
-uwe
-uwe
-kVK
 izp
 gzy
 gzy
@@ -420918,30 +420873,30 @@ bGf
 khy
 khy
 khy
-khy
-khy
-vxe
+eIk
+nVW
 lRg
-ohQ
+lRg
 dPn
-noc
-uBe
-phw
-bmd
-nXd
-dir
-bmd
-nXd
-sPT
+sSy
 tCI
+jxs
+phw
+dir
+qXR
+aZJ
+lvE
+lLP
+tCI
+dir
 vxe
 iii
 ygR
+ygR
+tNA
 jHD
-vxe
-vxe
-vxe
-vxe
+ere
+qxS
 vxe
 rMf
 gzy
@@ -421370,32 +421325,32 @@ bGf
 khy
 khy
 khy
-khy
-khy
 vxe
-pNB
+xnY
+fAA
 lRg
-lRg
-ewz
+etj
+wRu
+dir
+xna
+xna
 tCI
-wWq
-osN
-igK
-uBe
-liH
-igK
-wWq
-bOt
+dir
+ibw
+ibw
+tCI
+dir
+tCI
 vxe
 vxe
 gKo
 ygR
 hmU
-rio
+qxS
 kLi
-rdi
+qxS
 vxe
-sQp
+mZo
 rMf
 gzy
 tPo
@@ -421822,30 +421777,30 @@ bGf
 khy
 khy
 khy
-khy
-khy
 vxe
-kSj
-eki
+vxe
+vaH
 lRg
-fdR
-dir
-uQf
-uBe
+vIO
 dir
 tCI
-uBe
 dir
-uQf
-uBe
-eYQ
+tCI
+dir
+tCI
+dir
+mcu
+dir
+tCI
+dir
+cWR
 vxe
+vaw
 ygR
-ygR
-ygR
-ere
+hmU
+xZf
 qxS
-vXV
+xZf
 vxe
 vxe
 rMf
@@ -422274,13 +422229,13 @@ bGf
 khy
 khy
 khy
-khy
-khy
 vxe
 vxe
 mvH
 jiA
-aLr
+dTb
+jiA
+jiA
 jiA
 jiA
 jiA
@@ -422295,9 +422250,9 @@ bHU
 jiA
 jiA
 jiA
-jiA
-jiA
-jiA
+gTe
+gTe
+gTe
 nYb
 kEJ
 gzy
@@ -422726,13 +422681,13 @@ bGf
 khy
 khy
 khy
-khy
-khy
 vxe
 vxe
 cpa
 fZT
-vKj
+fwe
+fZT
+fZT
 fZT
 fZT
 fZT
@@ -423178,13 +423133,12 @@ bGf
 hNF
 khy
 khy
-khy
-khy
 vxe
 vxe
+ddf
+lzQ
 yjc
 lzQ
-vAo
 lzQ
 lzQ
 lzQ
@@ -423200,8 +423154,9 @@ lzQ
 lzQ
 lzQ
 lzQ
-lzQ
-lzQ
+bvB
+jQJ
+jQJ
 rbI
 kEJ
 gzy
@@ -423630,30 +423585,30 @@ bGf
 hNF
 khy
 khy
-khy
-khy
 vxe
-dnA
-eki
+vxe
+vaH
 lRg
-mnB
-xwF
-ovY
-kMx
+eki
+ruD
 xwF
 ruD
-kMx
 xwF
-ovY
-kMx
+ruD
+xwF
+ruD
+aUM
+ruD
+xwF
+ruD
 uEf
 vxe
+rio
 ygR
-ygR
-ygR
-vuR
-vaw
-ygR
+hmU
+fAA
+mzB
+fSz
 vxe
 vxe
 caU
@@ -424082,31 +424037,31 @@ bGf
 hNF
 khy
 khy
-khy
-khy
 vxe
+xnY
+fAA
+lRg
+ugJ
 pNB
-lRg
-lRg
-xFl
 ruD
-wWq
-gGv
-key
-kMx
-tgv
-key
-wWq
-wfS
+xna
+xna
+xwF
+ruD
+ibw
+ibw
+xwF
+ruD
+xwF
 vxe
 vxe
-gKo
+syK
 ygR
-pie
-kLp
+hmU
+fAA
 mzB
-rEF
-vxe
+fSz
+eIk
 nwG
 pjT
 sLo
@@ -424534,31 +424489,31 @@ bGf
 khy
 khy
 khy
-khy
-khy
-vxe
-xna
-ohQ
-lsP
-dWM
-kMx
-xHQ
-aZJ
-fwe
+eIk
+kWx
+lRg
+lRg
+dPn
+sSy
 xwF
+dPu
+jxL
+ruD
+qXR
+lvE
 aZJ
-fwe
-ugJ
+lLP
+xwF
 ruD
 vxe
 vsy
 ygR
-jHD
-vxe
-vGz
-vGz
-vGz
-vxe
+ygR
+hmU
+eeh
+xwv
+xwv
+eIk
 nwG
 lRA
 rtQ
@@ -424986,30 +424941,30 @@ fYu
 apD
 nLk
 khy
-khy
 vxe
-vxe
+lUs
+lRg
 kvn
 ohQ
-nVW
-mnB
+sSy
+ruD
+wWq
+ibw
+eOA
+qXR
+lvE
+aZJ
+lLP
+ruD
 xwF
-ruD
-eOA
-qXR
-ruD
-eOA
-qXR
-ruD
-kMx
 fux
 ygR
 ygR
 ygR
-jLN
+hmU
 fAA
-mdt
-jQJ
+fAA
+fAA
 vxe
 vgL
 tGl
@@ -425439,29 +425394,29 @@ iRV
 lOO
 xdx
 vxe
-vxe
-vxe
-pIg
-ohQ
-xnY
-hkp
+lsP
+lRg
+ezn
+qJY
+sSy
+xwF
+ibw
+kMx
 ruD
-kMx
-kAv
-lUs
-kMx
-kAv
-lUs
-kMx
+qXR
+lvE
+aZJ
+lLP
+xwF
 vxe
 vxe
 vGz
-jze
-jze
+jLN
+fCC
 vxe
-mcu
-fAA
-etj
+jze
+jze
+jze
 vxe
 tGl
 tGl
@@ -425890,23 +425845,23 @@ aDs
 hNP
 lOO
 tWS
+eIk
+wfS
+lRg
+lRg
+dPn
+sSy
+ruD
+xHQ
+ruD
+xwF
+ruD
+dPu
+dPu
+xwF
+ruD
 vxe
-vxe
-vxe
-vxe
-vak
-kWx
-mmy
-kMx
-uEf
-maL
-kMx
-cWR
-bVl
-dTb
-vxe
-vxe
-aUM
+bFM
 dPx
 xZf
 jMq
@@ -426344,18 +426299,18 @@ lOO
 xdx
 vxe
 vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vSb
-vxe
-vxe
-vxe
+fIa
+dnA
+aRN
+wRu
+xwF
+ruD
+xwF
+ruD
+xwF
+ruD
+vuR
+bmd
 vxe
 vxe
 bgH
@@ -426797,14 +426752,14 @@ khy
 khy
 vxe
 vxe
-mDF
 vxe
 vxe
-khy
-khy
 vxe
 vxe
-kpO
+vxe
+vxe
+osN
+vxe
 vxe
 vxe
 vxe
@@ -426812,7 +426767,7 @@ vxe
 vxe
 kfK
 iTO
-xZf
+rdi
 lOl
 xZf
 dnT
@@ -427253,20 +427208,20 @@ oIN
 vxe
 khy
 khy
-khy
-khy
+emT
 vxe
+kpO
 vxe
-vxe
+emT
 khy
 khy
 vxe
 vxe
 xdJ
 iTO
-xZf
+rdi
 sOx
-xZf
+rdi
 dnT
 tbc
 vxe
@@ -427706,9 +427661,9 @@ mTy
 khy
 khy
 khy
-khy
-khy
-khy
+vxe
+vxe
+vxe
 khy
 khy
 khy
@@ -434029,7 +433984,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+mbF
 aBB
 aBB
 aBB
@@ -520365,7 +520320,7 @@ ddY
 ddY
 ddY
 ddY
-bGf
+soE
 bGf
 bGf
 bGf
@@ -522175,17 +522130,17 @@ nLk
 khy
 khy
 khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
+diO
+rSP
+rSP
+rSP
+rSP
+tzT
+rSP
+rSP
+rSP
+rSP
+wxE
 khy
 khy
 khy
@@ -522627,17 +522582,17 @@ vxe
 khy
 khy
 khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
-khy
+fQU
+iXc
+rbc
+iXc
+iXc
+rCs
+iXc
+iXc
+ore
+iXc
+rHd
 khy
 khy
 khy
@@ -523074,28 +523029,28 @@ khy
 khy
 vxe
 vxe
-atE
+rdc
 vxe
 vxe
 khy
+khy
+fQU
+vrM
+iXc
+iXc
+iXc
+rCs
+iXc
+iXc
+eYJ
+sGo
+rHd
 khy
 pyw
 apD
 apD
 nLk
 pyw
-apD
-apD
-apD
-apD
-nLk
-pyw
-apD
-apD
-apD
-apD
-pwI
-apD
 apD
 tGl
 iVE
@@ -523532,22 +523487,22 @@ vxe
 vxe
 vxe
 vxe
-mpb
-mpb
+vxe
+gfN
+erB
+vxe
 vxe
 vxe
 vHi
-vHi
-vHi
-vHi
+vXV
 vxe
 vxe
-nZV
-xZf
-xZf
-nZV
 vxe
-iVE
+vxe
+hsd
+hsd
+vxe
+vxe
 iVE
 tGl
 xri
@@ -523975,31 +523930,31 @@ bGf
 khy
 khy
 fQU
-qlu
+ntN
+aoN
 atE
 atE
-atE
-atE
+rdc
 pOz
 xTb
 vxe
-uOJ
-wqr
-sqh
-ecv
 vxe
-iXc
-iXc
-iXc
-iXc
+abi
+fHc
+fHc
+jVV
+vxe
+jVV
+vGJ
+vGJ
+pZc
 vxe
 vxe
-kia
-kia
-kia
-kia
+kVR
+koZ
+eFX
+dBw
 vxe
-iWa
 iWa
 iWa
 iWa
@@ -524435,23 +524390,23 @@ raP
 sYF
 tkH
 vxe
-rxO
-fAA
-dPu
-aVJ
+vxe
+fHc
+fHc
+fHc
+fVk
+vxe
+fVk
+vGJ
+vGJ
+vGJ
 vxe
 vxe
-mpb
+snS
+wtw
+efr
 vxe
-uIk
 vxe
-jyc
-adt
-gFm
-npY
-phu
-vxe
-iVE
 iVE
 tGl
 dAK
@@ -524887,21 +524842,21 @@ sYF
 tkH
 tkH
 vxe
-bEL
-fAA
-fAA
-fAA
 vxe
-eaD
-fTj
-xbp
-fAA
+gNj
+fHc
+toi
 vxe
-odE
-jRJ
-mcc
-wBT
-ilp
+vxe
+vxe
+dRb
+vGJ
+uQd
+vxe
+adt
+keM
+snS
+rNA
 vxe
 oVr
 pNy
@@ -525339,22 +525294,22 @@ fmU
 fAA
 fAA
 vxe
-lAj
-eYb
-eYb
-lpD
 vxe
-phS
-fAA
-fAA
-aVJ
+aSd
+xZf
+cCL
 vxe
-nrv
-rdU
-gxR
-ayb
-nnJ
-kia
+rdi
+vxe
+tFv
+xZf
+eaD
+vxe
+uAE
+phu
+iRl
+cjc
+hsd
 jHJ
 vmi
 pEK
@@ -525791,22 +525746,22 @@ aaK
 fAA
 fAA
 vxe
-aSd
-eYb
-eYb
-jxZ
 vxe
-kvx
-fAA
-fAA
-bRj
+eOt
+eOt
+dmv
 vxe
-ilp
-gxR
-pyb
-sqW
-gxR
-kia
+vxe
+vxe
+ejC
+eOt
+eOt
+vxe
+bcp
+rLq
+cuS
+qHp
+hsd
 jHJ
 vmi
 vmi
@@ -526243,22 +526198,22 @@ vxe
 oLa
 vxe
 vxe
-sRm
-fAA
-fAA
-nIY
 vxe
-vlw
-eYb
-ezH
-kSd
+lDA
+lRg
+ufP
+xio
 vxe
+wrx
+sZh
+lRg
+rpv
+vxe
+gHS
+prJ
+pId
+phu
 hsd
-gxR
-nnJ
-mGy
-gxR
-kia
 jHJ
 vmi
 vmi
@@ -526688,29 +526643,29 @@ khy
 khy
 khy
 fQU
-qlu
+ntN
 wPg
 ehU
 oiq
 uQS
 hlK
 vxe
-nYN
-qFa
-fAA
-erB
 vxe
-bEL
-ixa
-eYb
-hAy
 vxe
-pRu
-lOn
-kXU
-pRu
-itj
-kia
+dtm
+lRg
+nBg
+vxe
+gFd
+lRg
+lWi
+vxe
+vxe
+dls
+hfm
+vzi
+oPT
+hsd
 jHJ
 vmi
 vmi
@@ -527140,7 +527095,7 @@ khy
 khy
 khy
 fQU
-qlu
+ntN
 eAv
 uQS
 eoH
@@ -527149,21 +527104,21 @@ jrt
 vxe
 vxe
 vxe
-sSL
+vxe
+erB
 vxe
 vxe
 vxe
+vHi
 vxe
-eYJ
 vxe
 vxe
-iwi
-jQL
-kia
-tTl
-gxR
-kia
-jHJ
+kas
+gGv
+vxe
+rAK
+vxe
+pYK
 vmi
 vmi
 vmi
@@ -527600,22 +527555,22 @@ fAA
 fAA
 wYV
 vxe
-cuS
-fAA
-myt
-fIB
-tsa
-uQS
-uQS
-njj
 vxe
-uDZ
 gZs
-gdy
-dQD
-wol
+gZs
+gZs
+gZs
+gZs
+gZs
+gZs
+uIk
+gfb
+fIB
+gfb
 vxe
-pYK
+vxe
+vxe
+vmi
 vmi
 vmi
 vmi
@@ -528053,18 +528008,18 @@ fAA
 kNS
 vxe
 vxe
-trv
-fAA
-fAA
-uQS
-fAA
-fAA
-fAA
+gZs
+gZs
+gZs
+gZs
+gZs
+gZs
+gZs
 uIk
-gZs
-gZs
-ewt
-aMK
+sLn
+sLn
+dzz
+vxe
 vxe
 vxe
 vmi
@@ -528511,10 +528466,10 @@ vxe
 qMh
 yao
 tcH
-rKa
+vLh
 vxe
-gZs
-gZs
+sLn
+sLn
 vxe
 vxe
 vxe
@@ -528960,15 +528915,15 @@ vSi
 jbi
 jln
 vxe
-kia
-kia
 vxe
+kia
+kia
 vxe
 vxe
 pSr
-fHc
+rIe
 vxe
-lxg
+vmi
 vmi
 vmi
 vmi
@@ -529419,8 +529374,8 @@ jeE
 vxe
 fHc
 fHc
-kia
-jHJ
+vxe
+vmi
 vmi
 vmi
 vmi
@@ -529871,8 +529826,8 @@ bFM
 vxe
 rYB
 fHc
-kia
-gtM
+vxe
+woI
 lxg
 vmi
 vmi
@@ -531222,7 +531177,7 @@ vxe
 qHk
 fAA
 fAA
-fAA
+rKa
 sLn
 kys
 rnm
@@ -535296,10 +535251,10 @@ fFi
 gZs
 gZs
 vxe
-vmi
-vmi
-vmi
-vmi
+noc
+noc
+noc
+noc
 vmi
 vmi
 arw
@@ -535727,7 +535682,7 @@ bGf
 khy
 khy
 khy
-khy
+vxe
 vxe
 vxe
 joB
@@ -535749,9 +535704,9 @@ gZs
 gZs
 vxe
 vxe
-woI
-woI
-lxg
+hkp
+mmy
+muN
 vmi
 vmi
 vmi
@@ -536179,8 +536134,8 @@ bGf
 khy
 khy
 khy
-khy
-khy
+vxe
+vxe
 vxe
 vxe
 vxe
@@ -536631,8 +536586,8 @@ bGf
 khy
 khy
 khy
-khy
-khy
+fzW
+vxe
 vxe
 vxe
 vxe
@@ -537083,11 +537038,11 @@ bGf
 khy
 khy
 khy
-khy
-khy
-vxe
-vxe
+fzW
+fzW
 rFp
+jeE
+jeE
 jeE
 jeE
 jeE
@@ -537535,11 +537490,11 @@ bGf
 khy
 khy
 khy
-khy
-khy
-rTY
-kia
+dWM
+fdR
 bIh
+fSz
+fSz
 fSz
 fSz
 fSz
@@ -537987,15 +537942,15 @@ bGf
 khy
 khy
 khy
-khy
-khy
-rTY
-kia
+dWM
+fdR
 bIh
 fSz
 hox
 fSz
 fSz
+fSz
+hox
 fSz
 fSz
 fSz
@@ -538439,11 +538394,11 @@ bGf
 khy
 khy
 khy
-khy
-khy
-rTY
-kia
+dWM
+fdR
 bIh
+fSz
+fSz
 fSz
 fSz
 fSz
@@ -538891,11 +538846,11 @@ bGf
 khy
 khy
 khy
-khy
-khy
-vxe
-vxe
+fzW
+fzW
 kYO
+bFM
+bFM
 bFM
 bFM
 bFM
@@ -539343,8 +539298,8 @@ bGf
 khy
 khy
 khy
-khy
-khy
+fzW
+vxe
 vxe
 fGP
 fGP
@@ -539795,8 +539750,8 @@ bGf
 khy
 khy
 khy
-khy
-khy
+vxe
+vxe
 vxe
 kia
 vxe
@@ -540247,7 +540202,7 @@ bGf
 khy
 khy
 khy
-khy
+vxe
 vxe
 vxe
 xZf
@@ -541612,8 +541567,8 @@ vxe
 vxe
 vxe
 vxe
+xZf
 vxe
-vSb
 vxe
 vxe
 oEr
@@ -542061,11 +542016,11 @@ vxe
 kpO
 vxe
 vxe
-khy
-khy
 vxe
 vxe
-kpO
+vxe
+vSb
+vxe
 vxe
 vxe
 out
@@ -542514,9 +542469,9 @@ oIN
 vxe
 khy
 khy
-khy
-khy
 vxe
+vxe
+kpO
 vxe
 vxe
 oPX
@@ -542967,9 +542922,9 @@ piy
 khy
 khy
 khy
-khy
-khy
-khy
+vxe
+vxe
+vxe
 khy
 khy
 oPX

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -3536,9 +3536,11 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woods/southeast)
 "aLr" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/carpet/red,
-/area/rogue/under/town/basement/keep)
+/obj/effect/landmark/start/prince{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "aLs" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/effect/decal/cleanable/blood/drip{
@@ -4057,15 +4059,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "aRN" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/fermentation_keg/water,
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = 16;
+	pixel_y = -9
 	},
-/obj/structure/fluff/railing/border/north{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "aRP" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -4102,8 +4101,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
 "aSd" = (
-/obj/structure/fluff/walldeco/bigpainting/lake,
-/turf/open/floor/rogue/cobble,
+/obj/effect/decal/cobbleedge{
+	dir = 6;
+	pixel_y = 0;
+	pixel_x = -3
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "aSg" = (
 /obj/structure/mirror,
@@ -4361,9 +4364,7 @@
 	dir = 8;
 	pixel_y = 17
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
 "aUO" = (
 /turf/open/floor/rogue/wood,
@@ -5126,13 +5127,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "bcp" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
-	},
-/turf/open/floor/rogue/grass,
+/obj/structure/table/wood/long_table/right,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "bcr" = (
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
@@ -6948,14 +6945,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/inq/embassy)
 "bvB" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/turf/open/floor/rogue/carpet/lord/right,
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "bvC" = (
 /obj/structure/ladder,
@@ -9741,23 +9732,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
-"bYm" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -5;
-	pixel_y = 16
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = -14;
-	pixel_y = 24
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "bYr" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road,
@@ -12771,16 +12745,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "cCL" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/cooking/platter/gold,
-/obj/item/kitchen/fork/gold{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 4;
-	pixel_y = 15
-	},
+/obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "cCQ" = (
@@ -16047,10 +16012,7 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "dls" = (
 /obj/structure/fluff/railing/corner/north_east,
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
-	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "dlt" = (
@@ -16171,9 +16133,7 @@
 	icon_state = "cobbleedge-w";
 	pixel_x = -1
 	},
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
+/obj/structure/bookcase/random/reference,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "dmw" = (
@@ -16453,14 +16413,6 @@
 "dpy" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter/woods)
-"dpA" = (
-/obj/structure/table/wood/long_table/right,
-/obj/item/needle/thorn{
-	pixel_x = -9;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
 "dpH" = (
 /obj/structure/table/wood/long_table,
 /obj/item/paper/scroll,
@@ -17778,13 +17730,9 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "dBw" = (
-/obj/machinery/light/rogue/candle/floorcandle{
-	pixel_y = -14;
-	pixel_x = 0
-	},
-/obj/item/soap/bath,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/hay,
+/area/rogue/outdoors/town/roofs/keep)
 "dBy" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/naturalstone,
@@ -19095,9 +19043,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest/north)
 "dPn" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/bouquet/salvia,
-/turf/open/floor/rogue/wood/herringbone,
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "dPo" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
@@ -19317,7 +19263,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "dRb" = (
-/obj/structure/chair/wood/rogue/chair5{
+/obj/structure/chair/wood/rogue/chair4{
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -20178,11 +20124,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "eaD" = (
-/obj/structure/fluff/walldeco/bigpainting/lake{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/town/basement/keep)
 "eaG" = (
 /obj/structure/flora/rogueshroom{
 	icon_state = "mush2"
@@ -20596,10 +20540,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "eeh" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/table/wood,
+/obj/structure/curtain/red,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "eei" = (
 /obj/structure/table/wood,
@@ -20676,9 +20619,8 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "efr" = (
-/turf/open/water/bath{
-	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
-	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "efw" = (
 /mob/living/carbon/human/species/skeleton/npc/medium,
@@ -21058,7 +21000,7 @@
 	icon_state = "cobbleedge-w";
 	pixel_x = -1
 	},
-/obj/structure/chair/wood/rogue/chair5{
+/obj/structure/chair/wood/rogue/chair4{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood/herringbone,
@@ -21125,9 +21067,7 @@
 	icon_state = "borderfall"
 	},
 /obj/structure/fluff/railing/border/north,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "ekj" = (
 /obj/effect/decal/cobbleedge{
@@ -21873,6 +21813,7 @@
 /area/rogue/outdoors/mountains)
 "ere" = (
 /obj/structure/table/wood/long_table,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "erp" = (
@@ -23228,10 +23169,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "eFX" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
-/turf/open/water/bath{
-	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
-	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "eGa" = (
 /obj/structure/table/wood/poor,
@@ -23993,12 +23931,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter)
 "eOA" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 21
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "eOB" = (
 /obj/machinery/light/rogue/cauldron,
@@ -24964,19 +24898,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs/keep)
-"eYJ" = (
-/obj/effect/decal/carpet/kover_purple{
-	dir = 4;
-	pixel_x = -13;
-	pixel_y = -13
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/town/roofs/keep)
 "eYM" = (
-/obj/structure/fermentation_keg/water,
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/exposed/town/keep/unbuildable)
+/obj/structure/roguemachine/mail/r{
+	mailtag = "Meeting Room"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "eYN" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/cobble/mossy,
@@ -26265,7 +26192,6 @@
 /obj/structure/mirror/fancy{
 	pixel_y = -32
 	},
-/obj/item/paper/scroll,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/manor)
 "fkk" = (
@@ -28523,9 +28449,6 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "fIa" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
-	},
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
@@ -30181,9 +30104,6 @@
 /turf/closed/wall/mineral/rogue/wooddark/end/north,
 /area/rogue/indoors/cave)
 "fYI" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
-	},
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
@@ -30217,12 +30137,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter)
 "fZc" = (
-/obj/machinery/light/rogue/torchholder/l{
+/obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "fZe" = (
 /obj/structure/roguemachine/scomm{
@@ -33190,7 +33108,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/forest/north)
 "gFd" = (
-/obj/structure/table/wood/fancy/purple,
+/obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "gFh" = (
@@ -33476,10 +33394,6 @@
 "gHS" = (
 /obj/structure/roguemachine/scomm{
 	scom_tag = "Manor - Heir's Lounge"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
@@ -33947,7 +33861,8 @@
 /area/rogue/outdoors/beach/forest/north)
 "gNj" = (
 /obj/machinery/light/rogue/campfire/fireplace{
-	pixel_x = -16
+	pixel_x = -32;
+	pixel_y = 32
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
@@ -34542,12 +34457,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "gTe" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w";
-	pixel_x = -1
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/carpet/lord/left,
+/obj/structure/fluff/railing/border/north{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "gTh" = (
 /obj/effect/particle_effect/smoke{
@@ -35762,7 +35678,6 @@
 /area/rogue/under/cave/dukecourt)
 "hfm" = (
 /obj/structure/fluff/railing/corner/south_east,
-/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "hfq" = (
@@ -41032,10 +40947,8 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "ieA" = (
-/obj/structure/roguemachine/scomm/l{
-	scom_tag = "Manor - Lobby"
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/closet/crate/chest/crate,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "ieC" = (
 /obj/structure/table/wood/poor,
@@ -45536,6 +45449,7 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border/north,
+/obj/machinery/gear_painter,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement/keep)
 "iXq" = (
@@ -48275,15 +48189,12 @@
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/shop)
 "jxL" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8;
-	pixel_y = 17
+/obj/item/candle/candlestick/silver/lit{
+	pixel_x = -5;
+	pixel_y = 9
 	},
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/under/town/basement/keep)
 "jxM" = (
 /obj/structure/fluff/railing/border/east,
 /obj/item/roguebin/water,
@@ -50259,10 +50170,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "jQM" = (
@@ -50798,6 +50705,7 @@
 	pixel_y = 0
 	},
 /obj/item/clothing/ring/gold,
+/obj/item/rogueweapon/huntingknife/scissors/steel,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "jVX" = (
@@ -51786,8 +51694,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods/south)
 "keM" = (
-/obj/item/clothing/head/peaceflower,
-/turf/open/floor/rogue/tile/bath,
+/turf/closed/wall/mineral/rogue/decostone/mossy/cand,
 /area/rogue/indoors/town/manor)
 "keN" = (
 /obj/structure/flora/roguegrass/water,
@@ -55097,14 +55004,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest/south)
 "kMx" = (
-/obj/structure/fermentation_keg/water,
-/obj/effect/decal/carpet/kover_black{
-	pixel_x = -17;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/tile/masonic{
+/obj/machinery/light/rogue/torchholder/l{
 	dir = 8
 	},
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "kME" = (
 /obj/effect/decal/edge{
@@ -56135,13 +56038,14 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods/southwest)
 "kVR" = (
-/obj/structure/curtain/blue,
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/shoes/roguetown/sandals,
-/obj/item/clothing/shoes/roguetown/sandals,
-/turf/open/floor/rogue/tile/bath,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n";
+	pixel_y = 4;
+	pixel_x = -3
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "kVU" = (
 /obj/structure/stairs{
@@ -59782,22 +59686,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "lCV" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = -9;
-	pixel_x = -7
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 9;
-	pixel_y = 17
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "lCW" = (
 /obj/structure/closet/crate/roguecloset/inn/chest,
 /obj/item/rogueweapon/huntingknife/idagger/navaja,
@@ -61993,7 +61886,7 @@
 /area/rogue/outdoors/mountains)
 "lXd" = (
 /obj/structure/fermentation_keg/beer,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "lXe" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -62413,9 +62306,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
 "mbF" = (
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "mbH" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach/central)
@@ -62573,10 +62468,6 @@
 /area/rogue/indoors/town/magician)
 "mcQ" = (
 /obj/structure/table/wood/long_table,
-/obj/item/cooking/platter/silver{
-	pixel_x = 15;
-	pixel_y = 4
-	},
 /obj/item/candle/candlestick/silver/single/lit{
 	pixel_x = -6;
 	pixel_y = 9
@@ -63694,9 +63585,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
 "mnB" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "mnD" = (
 /obj/structure/fluff/railing/wood/north,
@@ -64949,13 +64842,11 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
 "mAn" = (
-/obj/structure/table/wood/poor,
-/obj/item/roguebin/water,
-/obj/item/natural/cloth{
-	pixel_y = 5;
-	pixel_x = 11
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 1;
+	name = "changing room door"
 	},
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement/keep)
 "mAo" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -65995,6 +65886,11 @@
 "mLY" = (
 /obj/structure/curtain/blue,
 /obj/machinery/light/rogue/candle/r,
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "heir";
+	name = "Heir's Apartment"
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "mMt" = (
@@ -68554,19 +68450,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cave/mazedungeon)
 "noj" = (
-/obj/structure/table/wood/long_table/right,
-/obj/item/flowercrown/matricaria{
-	pixel_x = -16;
-	pixel_y = 6
+/obj/structure/table/wood/long_table/mid{
+	dir = 1
 	},
-/obj/item/alch/matricaria{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/obj/item/alch/matricaria{
-	pixel_x = 1;
-	pixel_y = -5
-	},
+/obj/item/paper/scroll,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "non" = (
@@ -69824,6 +69711,12 @@
 /area/rogue/outdoors/rtfield/eora)
 "nBg" = (
 /obj/structure/table/wood/fancy/red,
+/obj/item/book/rogue/naledi1,
+/obj/item/book/rogue/naledi2{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/book/rogue/law,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "nBm" = (
@@ -74031,10 +73924,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/sewer)
 "ore" = (
-/obj/structure/fluff/pillow/purple{
-	dir = 8
+/obj/structure/fluff/nest{
+	name = "Hay";
+	pixel_x = 7;
+	pixel_y = 24
 	},
-/turf/open/floor/rogue/twig,
+/turf/open/floor/rogue/hay,
 /area/rogue/outdoors/town/roofs/keep)
 "orl" = (
 /obj/item/ammo_casing/caseless/rogue/sling_bullet/stone{
@@ -76757,7 +76652,7 @@
 /area/rogue/indoors/town/church/chapel)
 "oPT" = (
 /obj/structure/fluff/railing/corner/north_east,
-/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "oPV" = (
@@ -78559,15 +78454,6 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves/north)
-"phw" = (
-/obj/machinery/light/rogue/torchholder/l{
-	pixel_y = 17
-	},
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "phx" = (
 /obj/structure/fermentation_keg/coffee,
 /turf/open/floor/rogue/church,
@@ -81267,7 +81153,6 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave/central)
 "pIC" = (
-/obj/structure/table/wood/long_table/mid/alt,
 /obj/item/natural/cloth{
 	pixel_y = 5
 	},
@@ -81281,6 +81166,11 @@
 	},
 /obj/item/natural/cloth{
 	pixel_y = 5
+	},
+/obj/structure/table/wood/long_table/right,
+/obj/item/needle/thorn{
+	pixel_x = 14;
+	pixel_y = 6
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -82248,12 +82138,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "heir";
-	name = "Heir's Apartment"
-	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "pSw" = (
 /obj/effect/decal/cobbleedge{
@@ -82829,7 +82714,7 @@
 /obj/item/bedsheet/rogue/fabric_double{
 	dir = 1
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "pZe" = (
 /obj/structure/bed/rogue/shit,
@@ -86847,7 +86732,7 @@
 	pixel_y = 32;
 	density = 0
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "qMl" = (
 /obj/structure/lever/wall{
@@ -87880,8 +87765,9 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "qXR" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/roguewindow,
+/obj/structure/curtain/red,
+/turf/closed/basic,
 /area/rogue/indoors/town/manor)
 "qXS" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
@@ -91452,12 +91338,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "rIe" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "heir";
-	name = "Heir's Apartment"
-	},
-/turf/open/floor/rogue/concrete,
+/turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
 "rIi" = (
 /obj/structure/roguemachine/hag_ward,
@@ -91509,18 +91390,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/orcdungeon)
 "rIT" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = -9;
-	pixel_y = 5
+/turf/open/floor/rogue/tile/masonic{
+	dir = 2
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 9;
-	pixel_y = 17
-	},
-/obj/item/candle/candlestick/silver/lit,
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "rIW" = (
 /obj/item/reagent_containers/glass/cup/ceramic/fancy,
@@ -91785,14 +91657,8 @@
 	},
 /area/rogue/outdoors/town)
 "rLl" = (
-/obj/structure/fermentation_keg/water,
-/obj/effect/decal/carpet/kover_black{
-	pixel_x = 19;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/manor)
 "rLo" = (
 /obj/structure/fluff/railing/border/north,
@@ -91984,11 +91850,11 @@
 /turf/closed/wall/mineral/rogue/wooddark/end/west,
 /area/rogue/indoors/shelter/bog/bogmanfort)
 "rNA" = (
-/obj/structure/roguewindow/harem3,
-/obj/structure/curtain/blue,
-/turf/open/water/bath{
-	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
+/obj/item/clothing/head/peaceflower{
+	pixel_x = 13;
+	pixel_y = 4
 	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "rNF" = (
 /obj/machinery/light/rogue/lanternpost,
@@ -92653,9 +92519,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "rTY" = (
-/obj/machinery/gear_painter,
-/turf/open/floor/carpet/red,
-/area/rogue/under/town/basement/keep)
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "rUa" = (
 /obj/structure/fluff/walldeco/painting/skull{
 	pixel_x = -32
@@ -92882,9 +92748,15 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "rWs" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/bouquet/matricaria,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/fluff/railing/border/north{
+	dir = 5
+	},
+/obj/structure/standingbell{
+	dir = 1;
+	name = "servantry service bell";
+	specific_location = "Throne Room"
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "rWt" = (
 /obj/structure/ladder,
@@ -94483,8 +94355,10 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
 "snS" = (
-/obj/structure/curtain/blue,
-/turf/open/floor/rogue/tile/bath,
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "snT" = (
 /obj/structure/fluff/railing/corner/north_east,
@@ -94575,11 +94449,13 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/exposed/town/keep)
 "soE" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/roguemachine/scomm{
+	scom_tag = "Manor - Front Door"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "soH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -95262,23 +95138,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"suH" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -5;
-	pixel_y = 16
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 14;
-	pixel_y = 24
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "suQ" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -96380,11 +96239,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "sGo" = (
-/obj/item/alch/salvia{
+/obj/structure/fluff/nest{
+	name = "Hay";
 	pixel_x = -7;
-	pixel_y = 3
+	pixel_y = 22
 	},
-/turf/open/floor/rogue/twig,
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/hay,
 /area/rogue/outdoors/town/roofs/keep)
 "sGu" = (
 /obj/structure/roguewindow/openclose/reinforced,
@@ -97168,7 +97031,7 @@
 	pixel_x = 7;
 	pixel_y = 13
 	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "sOz" = (
 /obj/structure/fluff/railing/border/west,
@@ -98282,11 +98145,11 @@
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town)
 "sZh" = (
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 15;
-	pixel_y = 15
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = -17;
+	pixel_y = 20
 	},
-/turf/open/floor/rogue/wood/herringbone,
+/turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/indoors/town/manor)
 "sZi" = (
 /obj/structure/fluff/railing/border/west,
@@ -101477,7 +101340,6 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblinfort)
 "tFv" = (
-/obj/structure/table/wood/fancy/purple,
 /obj/item/reagent_containers/glass/cup/golden/small{
 	pixel_x = 4;
 	pixel_y = 15
@@ -101487,6 +101349,8 @@
 	pixel_x = -10;
 	pixel_y = 6
 	},
+/obj/structure/rogue/trophy/deer,
+/obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "tFB" = (
@@ -106882,6 +106746,11 @@
 /area/rogue/indoors/town/church/chapel)
 "uIk" = (
 /obj/structure/curtain/blue,
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "heir";
+	name = "Heir's Apartment"
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "uIl" = (
@@ -107572,14 +107441,21 @@
 	pixel_x = -16;
 	pixel_y = -32
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "uQf" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
+/obj/structure/table/wood/poor,
+/obj/item/roguebin/water,
+/obj/item/natural/cloth{
+	pixel_y = 5;
+	pixel_x = 11
 	},
-/area/rogue/indoors/town/manor)
+/obj/structure/rack/rogue/shelf/big{
+	icon_state = "shelf_biggest";
+	pixel_y = 28
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/town/basement/keep)
 "uQn" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -108777,22 +108653,11 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/inq/embassy)
 "vaU" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = -9;
-	pixel_y = 5
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 9;
-	pixel_y = 17
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 15;
-	pixel_y = 25
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "vaW" = (
 /obj/structure/fluff/psycross/astrata/golden,
 /turf/open/floor/rogue/churchrough,
@@ -110464,6 +110329,9 @@
 /area/rogue/indoors/shelter/woods)
 "vrM" = (
 /obj/structure/fluff/pillow/red,
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs/keep)
 "vrO" = (
@@ -110753,12 +110621,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "vuR" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/obj/structure/chair/wood/rogue/fancy,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "vuU" = (
 /obj/structure/roguemachine/scomm{
@@ -111199,9 +111063,6 @@
 "vzi" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
-	},
-/obj/effect/landmark/start/prince{
-	dir = 8
 	},
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/grass,
@@ -112113,9 +111974,7 @@
 	icon_state = "borderfall"
 	},
 /obj/structure/fluff/railing/border/north,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "vIQ" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -112223,7 +112082,6 @@
 	pixel_x = -1;
 	pixel_y = -6
 	},
-/obj/machinery/tanningrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "vJU" = (
@@ -112921,7 +112779,7 @@
 	icon_state = "cobbleedge-w";
 	pixel_y = -7
 	},
-/obj/structure/closet/crate/roguecloset/inn,
+/obj/machinery/tanningrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "vRh" = (
@@ -113621,12 +113479,11 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/manor)
 "vXV" = (
-/obj/structure/curtain/purple,
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 4
+/obj/structure/fluff/railing/border/west{
+	dir = 10
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/exposed/town/keep/unbuildable)
 "vXX" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -114344,11 +114201,6 @@
 	location_tag = "Throne Room";
 	pixel_x = 33;
 	pixel_y = 2
-	},
-/obj/structure/standingbell{
-	dir = 1;
-	name = "servantry service bell";
-	specific_location = "Throne Room"
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
@@ -115534,12 +115386,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wrx" = (
-/obj/structure/table/wood/fancy/purple,
 /obj/item/candle/candlestick/gold/lit{
 	pixel_x = 16;
 	pixel_y = 16
 	},
-/obj/item/rogueweapon/huntingknife/scissors/steel,
+/obj/structure/fireaxecabinet/south,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/effect/decal/carpet/kover_black{
+	pixel_x = 14;
+	pixel_y = -9
+	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "wrA" = (
@@ -115730,10 +115586,18 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/under/underdark/north)
 "wtw" = (
-/obj/effect/lily_petal/three,
-/turf/open/water/bath{
-	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
+/obj/structure/fluff/walldeco/bigpainting/lake,
+/obj/structure/table/wood/fancy/red,
+/obj/item/cooking/platter/gold,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 4;
+	pixel_y = 15
 	},
+/obj/item/kitchen/fork/gold{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "wtx" = (
 /obj/structure/table/wood/large_table/north,
@@ -117815,17 +117679,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "wOi" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -5;
-	pixel_y = 16
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "wOj" = (
 /obj/structure/fluff/railing/corner/south_east,
@@ -119706,10 +119561,13 @@
 "xio" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/candle/candlestick/gold/lit{
-	pixel_x = 16;
-	pixel_y = 5
+	pixel_x = -3;
+	pixel_y = 19
 	},
-/obj/item/rogueweapon/huntingknife/scissors/steel,
+/obj/item/alch/rosa{
+	pixel_x = 4;
+	pixel_y = 0
+	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "xiq" = (
@@ -120031,19 +119889,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/mazedungeon)
 "xna" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/cooking/platter/silver,
-/obj/item/candle/candlestick/silver/lit{
-	pixel_x = 12;
-	pixel_y = -14
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -5;
-	pixel_y = 16
+/obj/structure/bookcase/random/archive,
+/obj/structure/fluff/walldeco/bigpainting/lake{
+	pixel_x = -32
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
@@ -120705,12 +120553,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/druidsgrove)
 "xsF" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 21
+/obj/structure/fluff/railing/border/north{
+	dir = 9
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
+/obj/structure/standingbell{
+	name = "servantry service bell";
+	specific_location = "Throne Room"
 	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "xsL" = (
 /obj/effect/decal/edge{
@@ -121041,10 +120891,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/dukecourt)
 "xwv" = (
-/obj/structure/fluff/railing/border{
+/obj/machinery/light/rogue/torchholder/l{
 	dir = 8
 	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/manor)
 "xww" = (
 /obj/structure/bed/rogue/inn{
@@ -122113,10 +121963,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cavewet/bogcaves/west)
 "xHQ" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "xHU" = (
 /obj/structure/bed/rogue/shit,
@@ -124062,6 +123912,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
+/obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "ybM" = (
@@ -196944,7 +196795,7 @@ ixP
 toJ
 iad
 iad
-iad
+jOq
 jOq
 jOq
 iad
@@ -197396,7 +197247,7 @@ tMY
 tMY
 tMY
 tMY
-tMY
+jOq
 tMY
 tMY
 tMY
@@ -308597,14 +308448,14 @@ iad
 xCV
 aal
 vJP
-dpA
+iad
 iad
 iad
 iad
 mdt
 aal
-rKD
-mAn
+iad
+iad
 iad
 reQ
 hFg
@@ -309050,13 +308901,13 @@ vDp
 dIn
 psL
 iad
-iad
-iad
-iad
-mdt
-aal
-qJZ
 aOv
+rKD
+iad
+iad
+uYL
+aal
+iad
 iad
 mEr
 hFg
@@ -309501,12 +309352,12 @@ iad
 iad
 qMr
 iad
-iad
-iad
-iad
-iad
-iad
-uYL
+jxL
+uQf
+qJZ
+qJZ
+mAn
+aal
 aal
 iad
 iad
@@ -309953,10 +309804,10 @@ aal
 mta
 aal
 qeU
-rnI
 iad
 iad
-iad
+eaD
+qJZ
 iad
 vAd
 ybK
@@ -310406,8 +310257,8 @@ pAz
 pAz
 bfG
 rnI
-aLr
 iad
+qJZ
 iad
 iad
 vAo
@@ -310858,8 +310709,8 @@ tgv
 iad
 iXo
 rEF
-rTY
-iad
+aUd
+qJZ
 iad
 iad
 ccT
@@ -311748,8 +311599,8 @@ jWw
 xri
 jWw
 hrE
-bDo
-bDo
+iad
+iad
 iad
 iad
 iad
@@ -312201,11 +312052,11 @@ jWw
 jWw
 khy
 khy
-bDo
-bDo
+khy
 iad
 iad
 iad
+vXV
 lkX
 lkX
 iad
@@ -406225,14 +406076,14 @@ khy
 khy
 khy
 khy
-pyw
-apD
-apD
-apD
-apD
-apD
-apD
-nLk
+khy
+khy
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -406676,16 +406527,16 @@ khy
 khy
 khy
 khy
-pyw
-quT
-vKj
-iys
-eoS
-vKj
-iys
-eoS
-nXd
-nLk
+khy
+khy
+khy
+khy
+khy
+khy
+khy
+khy
+khy
+khy
 khy
 khy
 khy
@@ -407128,16 +406979,16 @@ khy
 khy
 khy
 khy
-fQU
-maL
-vKj
-iys
-eoS
-vKj
-iys
-eoS
-wdu
-qUA
+khy
+pyw
+apD
+apD
+apD
+apD
+apD
+apD
+nLk
+khy
 khy
 khy
 khy
@@ -407580,16 +407431,16 @@ khy
 khy
 khy
 khy
-fQU
-maL
+pyw
+quT
+elk
+vKj
+iys
+iys
+eoS
 fwF
-fwF
-fwF
-fwF
-fwF
-fwF
-wdu
-qUA
+nXd
+nLk
 khy
 khy
 khy
@@ -408033,14 +407884,14 @@ khy
 khy
 khy
 fQU
-iys
-iys
+maL
+vaU
 fwF
 fwF
 fwF
 fwF
-elk
-eYM
+vaU
+wdu
 qUA
 khy
 pyw
@@ -418419,12 +418270,12 @@ khy
 khy
 vxe
 vxe
-cJK
-cJK
-fAA
+eYb
+eYb
+eYb
 eYb
 fHc
-fHc
+vuR
 noj
 vxe
 coN
@@ -418871,16 +418722,16 @@ khy
 vxe
 vxe
 vxe
+xna
+cJK
+eYM
+eYb
+fHc
+fHc
+bcp
 vxe
-vxe
-vxe
-vxe
-uRY
-uRY
-vxe
-vxe
-vxe
-vxe
+eYb
+rLl
 vxe
 ovY
 oaK
@@ -419322,17 +419173,17 @@ khy
 vxe
 vxe
 fYI
-wFI
-ijM
-pNB
-tCI
-eYQ
-tCI
-dir
-tCI
-dir
-uQf
-eYQ
+vxe
+vxe
+vxe
+vxe
+uRY
+vxe
+vxe
+vxe
+vxe
+ccY
+vxe
 vxe
 vxe
 set
@@ -419774,18 +419625,18 @@ khy
 eIk
 chn
 lRg
-lRg
-vak
-sSy
-dir
-fZc
+wFI
+ijM
+pNB
 dir
 tCI
+uBe
 dir
-jxs
-jxs
 tCI
+eOA
 dir
+tCI
+eYQ
 vxe
 vxe
 sLn
@@ -420229,14 +420080,14 @@ lRg
 kvn
 ohQ
 sSy
-tCI
-ibw
-rLl
+uBe
 dir
-qXR
-aZJ
-vaU
-lLP
+tCI
+jxs
+jxs
+tCI
+jxs
+jxs
 tCI
 vxe
 vxe
@@ -420244,10 +420095,10 @@ eNS
 eNS
 vxe
 vxe
-vxe
-vxe
-vxe
-vxe
+uwe
+uwe
+uwe
+kVK
 gzy
 icB
 jWw
@@ -420681,24 +420532,24 @@ lRg
 ezn
 ohQ
 sSy
-dir
-wWq
-ibw
-xsF
-qXR
-aZJ
-rIT
-lLP
-dir
 tCI
+aRN
+ibw
+aZJ
+rKa
+dir
+aZJ
+rKa
+dir
 fux
+ygR
 ygR
 ygR
 oFa
 sQp
-rdi
-mnB
-ieA
+vxe
+vxe
+vxe
 vxe
 izp
 gzy
@@ -421131,20 +420982,20 @@ eIk
 nVW
 lRg
 lRg
-rWs
+vak
 sSy
-tCI
-jxs
-phw
 dir
-qXR
+ibw
+wWq
 aZJ
 lvE
-lLP
-tCI
-dir
+uBe
+aZJ
+lvE
+uBe
 vxe
 iii
+ygR
 ygR
 ygR
 tNA
@@ -421584,27 +421435,27 @@ xnY
 fAA
 lRg
 etj
-wRu
+xsF
+uBe
 dir
-xna
-wOi
+mcu
+dPu
+dPu
 tCI
-dir
-ibw
-ibw
-tCI
-dir
+dPu
+dPu
 tCI
 vxe
 vxe
 gKo
+ygR
 ygR
 wSV
 lqN
 kLi
 qxS
 vxe
-mZo
+soE
 rMf
 gzy
 tPo
@@ -422038,18 +421889,18 @@ lRg
 vIO
 dir
 tCI
+uBe
 dir
 tCI
+uBe
 dir
 tCI
-dir
-mcu
-dir
-tCI
+uBe
 dir
 cWR
 vxe
 vaw
+ygR
 ygR
 hmU
 xZf
@@ -422499,14 +422350,14 @@ jiA
 jiA
 jiA
 jiA
-jiA
 bHU
 jiA
 jiA
 jiA
-gTe
-gTe
-gTe
+jiA
+jiA
+jiA
+jiA
 nYb
 kEJ
 gzy
@@ -423408,8 +423259,8 @@ lzQ
 lzQ
 lzQ
 lzQ
-bvB
-jQJ
+lzQ
+xHQ
 jQJ
 rbI
 kEJ
@@ -423844,20 +423695,20 @@ vxe
 vaH
 lRg
 eki
-ruD
 xwF
 ruD
+dPn
 xwF
 ruD
+dPn
 xwF
-ruD
 aUM
-ruD
+dPn
 xwF
-ruD
-uEf
+bmd
 vxe
 rio
+ygR
 ygR
 hmU
 fAA
@@ -424296,26 +424147,26 @@ xnY
 fAA
 lRg
 ugJ
-pNB
-ruD
-lCV
-rKa
+rWs
+dPn
 xwF
+aUM
+jxs
+jxs
 ruD
-ibw
-ibw
-xwF
+jxs
+jxs
 ruD
-xwF
 vxe
 vxe
 syK
 ygR
+ygR
 hmU
 fAA
-mzB
-fSz
-eIk
+snS
+fZc
+vxe
 nwG
 pjT
 sLo
@@ -424747,27 +424598,27 @@ iBT
 kWx
 lRg
 lRg
-dPn
+tgX
 sSy
 xwF
-dPu
-jxL
-ruD
-qXR
+ibw
+wWq
+aZJ
 rKa
-suH
-lLP
-xwF
-ruD
+dPn
+aZJ
+rKa
+dPn
 vxe
 vsy
 ygR
 ygR
-hmU
+ygR
+sQp
 eeh
-xwv
-xwv
-eIk
+jze
+jze
+vxe
 nwG
 lRA
 rtQ
@@ -425202,20 +425053,20 @@ kvn
 ohQ
 sSy
 ruD
-wWq
-ibw
-eOA
-qXR
-rKa
+bvB
+sZh
 aZJ
-lLP
-ruD
+lvE
+xwF
+aZJ
+lvE
 xwF
 fux
 ygR
-ygR
-ygR
-hmU
+fAA
+fAA
+fAA
+qXR
 fAA
 fAA
 fAA
@@ -425653,24 +425504,24 @@ lRg
 ezn
 ohQ
 sSy
+dPn
 xwF
-ibw
-kMx
 ruD
-qXR
-rKa
-bYm
-lLP
-xwF
+dPu
+dPu
+rIT
+dPu
+dPu
+rIT
 vxe
 vxe
-vGz
-jLN
 fCC
+jLN
+qXR
 vxe
-jze
-jze
-jze
+uQS
+uQS
+ieA
 vxe
 tGl
 tGl
@@ -426102,26 +425953,26 @@ tWS
 iBT
 wfS
 lRg
-lRg
-tgX
-sSy
-ruD
-xHQ
-ruD
+dnA
+gTe
+wRu
 xwF
 ruD
-dPu
-dPu
+dPn
 xwF
-ruD
+rIT
+kMx
+xwF
+rIT
+uEf
 vxe
 bFM
 dPx
 xZf
 jMq
 uQS
-fAA
-fAA
+uQS
+uQS
 lXd
 vxe
 xri
@@ -426554,17 +426405,17 @@ xdx
 vxe
 vxe
 fIa
-dnA
-aRN
-wRu
-xwF
-ruD
-uEf
-ruD
-xwF
-ruD
-vuR
-bmd
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+osN
+vxe
+vxe
+vxe
+vxe
 vxe
 vxe
 bgH
@@ -427006,13 +426857,13 @@ khy
 khy
 vxe
 vxe
+mnB
 vxe
 vxe
 vxe
 vxe
 vxe
-vxe
-osN
+kpO
 vxe
 vxe
 vxe
@@ -427021,7 +426872,7 @@ vxe
 vxe
 kfK
 iTO
-rdi
+xZf
 lOl
 xZf
 dnT
@@ -427462,20 +427313,20 @@ oIN
 vxe
 khy
 khy
-emT
+khy
 vxe
-kpO
 vxe
-emT
+vxe
+khy
 khy
 khy
 vxe
 vxe
 xdJ
 iTO
-rdi
+xZf
 sOx
-rdi
+xZf
 dnT
 tbc
 vxe
@@ -427915,9 +427766,9 @@ mTy
 khy
 khy
 khy
-vxe
-vxe
-vxe
+khy
+khy
+khy
 khy
 khy
 khy
@@ -431087,7 +430938,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+lCV
 aBB
 aBB
 aBB
@@ -434238,7 +434089,7 @@ aBB
 aBB
 aBB
 aBB
-mbF
+aBB
 aBB
 aBB
 aBB
@@ -520574,7 +520425,7 @@ ddY
 ddY
 ddY
 ddY
-soE
+bGf
 bGf
 bGf
 bGf
@@ -522845,7 +522696,7 @@ rCs
 iXc
 iXc
 ore
-iXc
+dBw
 rHd
 khy
 khy
@@ -523296,7 +523147,7 @@ iXc
 rCs
 iXc
 iXc
-eYJ
+iXc
 sGo
 rHd
 khy
@@ -523746,9 +523597,9 @@ gfN
 erB
 vxe
 vxe
-vxe
+rIe
 vHi
-vXV
+mpb
 vxe
 vxe
 vxe
@@ -524199,15 +524050,15 @@ fHc
 jVV
 vxe
 jVV
-vGJ
-vGJ
+fAA
+fAA
 pZc
 vxe
-vxe
+adt
 kVR
 efr
 eFX
-dBw
+vxe
 vxe
 iWa
 iWa
@@ -524651,14 +524502,14 @@ fHc
 fVk
 vxe
 fVk
-vGJ
-vGJ
-vGJ
+fAA
+fAA
+fAA
 vxe
-vxe
-snS
-wtw
-efr
+rNA
+phu
+iRl
+cjc
 vxe
 vxe
 iVE
@@ -525096,21 +524947,21 @@ sYF
 tkH
 tkH
 vxe
-vxe
+toi
 gNj
 fHc
-toi
+rTY
 vxe
 vxe
-vxe
+rIe
 dRb
-vGJ
+fAA
 uQd
 vxe
-adt
-keM
-snS
-rNA
+aSd
+rLq
+cuS
+qHp
 vxe
 oVr
 pNy
@@ -525548,21 +525399,21 @@ fmU
 fAA
 fAA
 vxe
-vxe
-aSd
+wtw
+xZf
 xZf
 cCL
 vxe
 rdi
-vxe
+keM
 tFv
 xZf
-eaD
-vxe
 xZf
+vxe
+wOi
+prJ
+pId
 phu
-iRl
-cjc
 hsd
 jHJ
 vmi
@@ -526000,21 +525851,21 @@ aaK
 fAA
 fAA
 vxe
-vxe
+mbF
 eOt
 eOt
 dmv
 vxe
 vxe
-vxe
+rIe
 ejC
 eOt
 eOt
 vxe
-bcp
-rLq
-cuS
-qHp
+iRl
+cjc
+aLr
+iRl
 hsd
 jHJ
 vmi
@@ -526459,14 +526310,14 @@ ufP
 xio
 vxe
 wrx
-sZh
+lRg
 lRg
 rpv
 vxe
 gHS
-prJ
-pId
-phu
+eFX
+efr
+eFX
 hsd
 jHJ
 vmi
@@ -529175,7 +529026,7 @@ kia
 vxe
 vxe
 pSr
-rIe
+fHc
 vxe
 vmi
 vmi
@@ -533235,7 +533086,7 @@ mHM
 vxe
 vxe
 gSP
-eYb
+xwv
 kJN
 sLn
 sLn
@@ -541821,7 +541672,7 @@ vxe
 vxe
 vxe
 vxe
-xZf
+vSb
 vxe
 vxe
 vxe
@@ -542273,7 +542124,7 @@ vxe
 vxe
 vxe
 vxe
-vSb
+kpO
 vxe
 vxe
 vxe
@@ -542725,7 +542576,7 @@ khy
 khy
 vxe
 vxe
-kpO
+vxe
 vxe
 vxe
 oPX
@@ -543176,9 +543027,9 @@ piy
 khy
 khy
 khy
-vxe
-vxe
-vxe
+khy
+khy
+khy
 khy
 khy
 oPX

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -335,11 +335,7 @@
 	pixel_y = 6;
 	pixel_x = -18
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
-	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "adw" = (
 /obj/effect/decal/cobbleedge{
@@ -5422,17 +5418,6 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "bfP" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows{
-	pixel_x = 3
-	},
-/obj/item/quiver/arrows,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow{
-	pixel_x = -11
-	},
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow{
-	pixel_x = -6
-	},
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -5441,6 +5426,7 @@
 	dir = 9;
 	pixel_y = 19
 	},
+/obj/structure/rack/rogue,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/exposed/town/keep)
 "bfR" = (
@@ -12124,6 +12110,13 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault)
+"cwl" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "cwo" = (
 /obj/structure/table/wood/large_table/south_west,
 /obj/item/reagent_containers/glass/cup/steel,
@@ -15839,8 +15832,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/exposed/town/keep/unbuildable)
 "diU" = (
-/obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/corner/north_east,
+/obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "diV" = (
@@ -17789,6 +17782,7 @@
 	pixel_y = -14;
 	pixel_x = 0
 	},
+/obj/item/soap/bath,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
 "dBy" = (
@@ -25878,6 +25872,11 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"fhj" = (
+/obj/structure/fluff/railing/corner,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "fhl" = (
 /obj/item/roguecoin/gold{
 	pixel_x = -6;
@@ -26502,8 +26501,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
 "fmJ" = (
-/obj/structure/fluff/railing/corner/south_west,
-/turf/open/floor/rogue/twig,
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "fmL" = (
 /obj/structure/flora/roguegrass/bush,
@@ -27174,15 +27174,11 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/scarymaze)
 "ftc" = (
-/obj/item/reagent_containers/glass/bottle/rogue/wine{
-	pixel_x = 7;
-	pixel_y = 13
+/obj/structure/fluff/pillow/purple{
+	pixel_x = -8;
+	pixel_y = -9
 	},
-/obj/item/cooking/platter{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "ftd" = (
 /mob/living/carbon/human/species/skeleton/npc/easy,
@@ -31660,8 +31656,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest/north)
 "gnV" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/carpet/purple,
+/obj/structure/fluff/railing/wood/north,
+/obj/structure/fluff/railing/wood/west{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors/exposed/town/keep)
 "gnY" = (
 /obj/structure/flora/roguegrass,
@@ -31936,6 +31936,11 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/bog/bogmanfort)
+"grl" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "grn" = (
 /obj/structure/fluff/statue/pillar{
 	pixel_x = 13
@@ -36481,7 +36486,19 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "hlN" = (
-/turf/open/floor/carpet/purple,
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = -7;
+	pixel_y = -21
+	},
+/obj/item/cooking/platter{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "hlP" = (
 /obj/structure/table/wood/long_table,
@@ -43391,7 +43408,6 @@
 /area/rogue/outdoors/mountains/decap)
 "iBT" = (
 /obj/structure/curtain/red,
-/obj/structure/roguewindow/harem3,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "iBX" = (
@@ -44625,12 +44641,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/taricheamanor)
 "iOv" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/rope/chain,
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
-	},
-/turf/open/floor/rogue/twig,
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "iOy" = (
 /obj/effect/decal/cleanable/debris/woody{
@@ -47428,8 +47441,7 @@
 /obj/structure/fluff/pillow/purple{
 	dir = 8
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "jpY" = (
 /obj/structure/bed/rogue/shit{
@@ -52704,11 +52716,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "koZ" = (
-/obj/item/soap/bath,
-/turf/open/water/bath{
-	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "kpb" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -56190,16 +56203,8 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
 "kWx" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = -14;
-	pixel_y = 7
+/obj/structure/roguemachine/scomm{
+	scom_tag = "Manor - Throne Room"
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
@@ -77815,7 +77820,19 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault/three)
 "paj" = (
-/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/wood/north,
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows{
+	pixel_x = 3
+	},
+/obj/item/quiver/arrows,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow{
+	pixel_x = -6
+	},
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow{
+	pixel_x = -11
+	},
+/obj/item/rope/chain,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/exposed/town/keep)
 "pam" = (
@@ -85958,6 +85975,13 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
+"qDW" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "qDZ" = (
 /obj/structure/fluff/railing/border/west,
 /obj/effect/decal/edge{
@@ -100510,8 +100534,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "twd" = (
-/obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border/north,
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "twj" = (
@@ -102262,6 +102286,16 @@
 	icon_state = "cobbleedge-sread"
 	},
 /obj/machinery/light/rogue/candle/l,
+/obj/structure/table/wood/folding,
+/obj/item/reagent_containers/glass/bottle/rogue/water{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/glass/cup{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/manor)
 "tNC" = (
@@ -106024,12 +106058,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
 "uAE" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
-	},
+/obj/structure/fluff/railing/border/north,
+/obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/exposed/town/keep)
 "uAF" = (
 /obj/structure/fluff/pillow/black{
 	dir = 8
@@ -109562,6 +109594,11 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"vjv" = (
+/obj/structure/fluff/railing/border/east,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "vjA" = (
 /obj/structure/lever{
 	redstone_id = "minotaurfort3"
@@ -117990,6 +118027,11 @@
 	dir = 4
 	},
 /area/rogue/under/cave/his_vault/two)
+"wQo" = (
+/obj/structure/fluff/railing/border,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "wQp" = (
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/dirt/road,
@@ -118249,6 +118291,21 @@
 /obj/machinery/light/roguestreet/midlamp,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/underdark/south)
+"wSV" = (
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/obj/structure/table/wood/folding,
+/obj/item/kitchen/spoon{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/bucket/pot/stone{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/manor)
 "wSY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -118487,8 +118544,8 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "wVm" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/corner,
+/obj/structure/fluff/railing/border/north,
+/obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wVu" = (
@@ -409795,7 +409852,7 @@ rvu
 fKR
 vxe
 diU
-gXH
+qDW
 tGl
 sFu
 tGl
@@ -410246,8 +410303,8 @@ gZs
 iFP
 nMo
 kia
-twd
-gXH
+wVm
+iOv
 paj
 bKY
 jWw
@@ -410698,9 +410755,9 @@ gZs
 xVu
 xJE
 kia
-twd
+kVK
+iOv
 gXH
-fmJ
 ugY
 iVE
 qJw
@@ -411151,8 +411208,8 @@ pDf
 ieF
 kia
 twd
+gkK
 gXH
-qdH
 nyB
 iVE
 qJw
@@ -411602,9 +411659,9 @@ rMs
 rvu
 rvu
 kia
-twd
+kVK
+gkK
 gXH
-qdH
 nyB
 jWw
 pKQ
@@ -412054,9 +412111,9 @@ ibw
 rvu
 fKR
 vxe
-wVm
+uJe
+grl
 gXH
-qdH
 nyB
 iVE
 qJw
@@ -412506,9 +412563,9 @@ vXz
 mSO
 mSO
 vxe
+rMf
 gkK
 gXH
-qdH
 nyB
 iVE
 qJw
@@ -412958,9 +413015,9 @@ uRj
 sFp
 vxe
 vxe
+kAx
 gkK
 gXH
-qdH
 soD
 jWw
 pKQ
@@ -413410,9 +413467,9 @@ vxe
 vxe
 vxe
 mZo
+rMf
 gkK
 gXH
-qdH
 nyB
 iVE
 qJw
@@ -413859,12 +413916,12 @@ dVK
 sLn
 pRL
 vxe
-syW
+vjv
 rbP
 izp
-gkK
+rMf
+iOv
 gXH
-qdH
 nyB
 iVE
 qJw
@@ -414312,11 +414369,11 @@ jiA
 jiA
 vGz
 krV
-kVK
+twd
 rMf
-gkK
+rMf
+fmJ
 gXH
-qdH
 nyB
 jWw
 pKQ
@@ -414764,11 +414821,11 @@ fZT
 fZT
 vGz
 vJq
-kVK
-hlN
+uAE
+rMf
 jpU
+gkK
 gXH
-qdH
 nyB
 iVE
 qJw
@@ -415218,9 +415275,9 @@ vxe
 vxe
 uJe
 hlN
-gnV
+rMf
+gkK
 gXH
-qdH
 nyB
 iVE
 qJw
@@ -415670,9 +415727,9 @@ vxe
 vxe
 hhz
 ftc
-gnV
+rMf
+wQo
 gXH
-qdH
 soD
 jWw
 cUq
@@ -416122,9 +416179,9 @@ vGz
 mZo
 kVK
 kAx
-gkK
+koZ
+cwl
 gXH
-qdH
 nyB
 iVE
 jHJ
@@ -416575,9 +416632,9 @@ krV
 kVK
 rMf
 gkK
-gXH
+gnV
 qdH
-iOv
+nyB
 iVE
 jHJ
 vmi
@@ -417476,7 +417533,7 @@ jiA
 fUt
 vxe
 vxe
-uJe
+fhj
 nOa
 mnQ
 qdH
@@ -419269,7 +419326,7 @@ wFI
 ijM
 pNB
 tCI
-dir
+eYQ
 tCI
 dir
 tCI
@@ -421542,7 +421599,7 @@ vxe
 vxe
 gKo
 ygR
-hmU
+wSV
 lqN
 kLi
 qxS
@@ -424686,7 +424743,7 @@ bGf
 khy
 khy
 khy
-eIk
+iBT
 kWx
 lRg
 lRg
@@ -426502,7 +426559,7 @@ aRN
 wRu
 xwF
 ruD
-xwF
+uEf
 ruD
 xwF
 ruD
@@ -524148,7 +524205,7 @@ pZc
 vxe
 vxe
 kVR
-koZ
+efr
 eFX
 dBw
 vxe
@@ -525502,7 +525559,7 @@ tFv
 xZf
 eaD
 vxe
-uAE
+xZf
 phu
 iRl
 cjc

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -26227,6 +26227,7 @@
 /obj/structure/mirror/fancy{
 	pixel_y = -32
 	},
+/obj/item/rogueweapon/huntingknife/scissors/steel,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/manor)
 "fkk" = (
@@ -43748,9 +43749,10 @@
 "iGh" = (
 /obj/structure/table/wood/long_table,
 /obj/item/candle/gold/lit{
-	pixel_y = 6;
-	pixel_x = 3
+	pixel_y = 16;
+	pixel_x = -6
 	},
+/obj/item/natural/fur,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/manor)
 "iGi" = (
@@ -91716,6 +91718,12 @@
 /area/rogue/outdoors/town)
 "rLl" = (
 /obj/structure/closet/crate/roguecloset,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
+/obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/manor)
 "rLo" = (
@@ -423785,7 +423793,7 @@ xwF
 ruD
 dPn
 xwF
-aUM
+ruD
 dPn
 xwF
 bmd

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -6472,6 +6472,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
+"bqN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w";
+	pixel_x = -1
+	},
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "brc" = (
 /obj/structure/bars/steel,
 /turf/open/transparent/openspace,
@@ -7708,6 +7717,14 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
+"bCB" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread";
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "bCD" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -29878,6 +29895,18 @@
 "fWp" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/cave/mazedungeon)
+"fWv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = -7;
+	pixel_x = -4
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "fWw" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/wood,
@@ -46370,6 +46399,13 @@
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
+"jhd" = (
+/obj/structure/foxpelt{
+	pixel_y = -18;
+	pixel_x = -2
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "jhh" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/edge{
@@ -60986,6 +61022,10 @@
 /obj/item/rogueweapon/scabbard/gwstrap,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"lNE" = (
+/obj/structure/bobcatpelt,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "lNG" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/cave/east)
@@ -62721,6 +62761,11 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
+"meJ" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/manor)
 "meN" = (
 /obj/effect/decal/edge{
 	color = "#3f3f3f";
@@ -76652,8 +76697,7 @@
 /area/rogue/indoors/town/church/chapel)
 "oPT" = (
 /obj/structure/fluff/railing/corner/north_east,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "oPV" = (
 /obj/structure/stairs/stone{
@@ -82867,6 +82911,12 @@
 "qaH" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
+"qaI" = (
+/obj/structure/mirror/fancy{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "qaQ" = (
 /obj/structure/stairs{
 	dir = 4
@@ -88338,6 +88388,18 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "rdi" = (
+/obj/item/cooking/pan/aalloy,
+/obj/item/reagent_containers/food/snacks/rogue/preserved/rice_cooked{
+	name = "fried rice"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/fryfish/swamp_shrimp{
+	pixel_x = 8;
+	pixel_y = 16
+	},
+/obj/item/clothing/head/roguetown/chef{
+	pixel_x = 5;
+	pixel_y = 25
+	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/manor)
 "rdk" = (
@@ -89564,6 +89626,11 @@
 	specific_location = "Heir's Apartment I";
 	dir = 1
 	},
+/obj/structure/table/wood/poor,
+/obj/item/rogueweapon/huntingknife{
+	pixel_x = -14;
+	pixel_y = 6
+	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "rpx" = (
@@ -90553,8 +90620,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
 "rAK" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32;
+	pixel_x = 16
+	},
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "rAP" = (
 /obj/item/roguecoin/gold{
@@ -107441,6 +107511,10 @@
 	pixel_x = -16;
 	pixel_y = -32
 	},
+/obj/structure/giantfur/small{
+	pixel_x = -26;
+	pixel_y = 2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "uQf" = (
@@ -111065,6 +111139,11 @@
 	dir = 4
 	},
 /obj/machinery/light/rogue/candle/r,
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread";
+	pixel_y = -6
+	},
+/obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "vzj" = (
@@ -120096,6 +120175,18 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
+"xoy" = (
+/obj/structure/closet/crate/drawer/random{
+	pixel_y = 0
+	},
+/obj/item/clothing/ring/gold,
+/obj/item/rogueweapon/huntingknife/scissors/steel,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32;
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "xoB" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -524049,8 +524140,8 @@ fHc
 fHc
 jVV
 vxe
-jVV
-fAA
+xoy
+lNE
 fAA
 pZc
 vxe
@@ -525408,7 +525499,7 @@ rdi
 keM
 tFv
 xZf
-xZf
+qaI
 vxe
 wOi
 prJ
@@ -525860,12 +525951,12 @@ vxe
 rIe
 ejC
 eOt
-eOt
+bqN
 vxe
-iRl
+meJ
 cjc
 aLr
-iRl
+fWv
 hsd
 jHJ
 vmi
@@ -526316,8 +526407,8 @@ rpv
 vxe
 gHS
 eFX
-efr
-eFX
+bCB
+xZf
 hsd
 jHJ
 vmi
@@ -526762,7 +526853,7 @@ lRg
 nBg
 vxe
 gFd
-lRg
+jhd
 lWi
 vxe
 vxe
@@ -527221,7 +527312,7 @@ vxe
 kas
 gGv
 vxe
-rAK
+cCL
 vxe
 pYK
 vmi
@@ -529024,7 +529115,7 @@ vxe
 kia
 kia
 vxe
-vxe
+rAK
 pSr
 fHc
 vxe


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

This PR touches up some issues that I, personally, have with the keep. Specifically surrounding the keep lobby, throne room, and heirs apartment area. I consider this a bandaid solution to mapping issues in the keep, as fixing some of the traffic issues in the keep would require a ground up rework(Aka touch every z level). This, hopefully, will alleviate some things I noticed.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

Heir's apartment (+ twink to scale_
<img width="597" height="776" alt="image" src="https://github.com/user-attachments/assets/dfe97f31-71d0-4b51-bfcc-b0017a790371" />
<img width="681" height="552" alt="image" src="https://github.com/user-attachments/assets/c9145a73-97ef-4448-b733-98fd1e45ec02" />
<img width="644" height="470" alt="image" src="https://github.com/user-attachments/assets/590ffa9e-3971-4432-9069-bd845f8f293d" />
<img width="758" height="514" alt="image" src="https://github.com/user-attachments/assets/44d271b4-f522-40af-ab7d-6b1fb89f31aa" />

Throne Room

<img width="878" height="799" alt="image" src="https://github.com/user-attachments/assets/91964779-b25b-474b-82b4-1b836d13dee5" />
<img width="1084" height="1002" alt="image" src="https://github.com/user-attachments/assets/b9a7a4be-cdb2-4b75-9d13-5c3e19e44315" />
<img width="965" height="840" alt="image" src="https://github.com/user-attachments/assets/7fa95e00-9303-440a-b07a-246dbbf7396d" />


Lobby with kitchen 

<img width="803" height="517" alt="image" src="https://github.com/user-attachments/assets/75355aa3-4e9a-4b9d-b107-c95aadf49cb2" />
<img width="1072" height="730" alt="image" src="https://github.com/user-attachments/assets/ec78136c-a87f-4994-9c9d-ecf4403b367c" />"
<img width="942" height="764" alt="image" src="https://github.com/user-attachments/assets/71aadb25-cb4b-40b4-8159-3bc4e380c2ee" />

Ball room balcony

<img width="349" height="654" alt="image" src="https://github.com/user-attachments/assets/0b6f4169-052b-41a3-9302-f0e22cf9c951" />
<img width="535" height="742" alt="image" src="https://github.com/user-attachments/assets/50e1484c-5977-41a1-8aab-52c2046fbcf4" />

Made this garden spot outside the keep prettier

<img width="871" height="582" alt="image" src="https://github.com/user-attachments/assets/27c7b818-31bc-4901-8264-4d57ea5fb0e4" />
<img width="672" height="499" alt="image" src="https://github.com/user-attachments/assets/f090d7aa-e8ca-428f-86da-da438d02e7ee" />


Stairs leading down to the guest room + the servants access
<img width="516" height="610" alt="image" src="https://github.com/user-attachments/assets/2b741cd9-4d6c-428a-927a-5e2f24b85d0e" />
<img width="709" height="929" alt="image" src="https://github.com/user-attachments/assets/3a4b5120-1436-4b8d-badb-2548aa01296b" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Better mapping is good. Better mapping that solves consistency issues is good. 

Making the heirs rooms virtually the same means that an heir can still have the same spawning items regardless of which room they get. Both rooms being physically the same means they are both exposed to the same weaknesses in terms of intruders. It also means there is no functional incentive between choosing the first or second apartment. 

Better furniture flow in the throne room means that (hopefully) combat is more thoughtful, and throne room RP is not as jumbled as a mess. Throne room that looks better is good. Councillors can now get to their meeting room without knocking down every chair in fucking existence. 

The FUCKING LOBBY was a congestion hellscape. Moving the side that the servants serving window is on, in addition to re-arranging the lobby will hopefully address the congestion issues.

I thought the bed in the servants sewing station was weirdly out of place, so I replaced it with a potato skinning station. Rejoice. Anything that was in the upstairs kitchen was moved downstairs

The balcony has been touched up to make it at least viable of a place to sit down and speak. Before it was just a weird slab that barely constituted a balcony.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
map: Touches up the throne room, keep lobby, and heirs apartment areas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
