### PR TITLE
Smithing silver amulets is now possible, with a catch

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
@@ -32,6 +32,46 @@
 
 //
 
+/datum/anvil_recipe/valuables/silver_psycross
+	name = "Silver Psycross (+1 Psycross)"
+	req_bar = /obj/item/ingot/silver
+	additional_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	craftdiff = SKILL_LEVEL_EXPERT
+	created_item = /obj/item/clothing/neck/roguetown/psicross/silver
+	display_category = ITEM_CAT_VALUABLES_HOLY
+
+/datum/anvil_recipe/valuables/silver_amulet_ten
+	name = "Silver Amulet of Ten (+1 Any Tennite Amulet)"
+	req_bar = /obj/item/ingot/silver
+	additional_items = list(/obj/item/clothing/neck/roguetown/psicross) // bandaid until someone makes proper silver amulet sprites for the other Ten
+	craftdiff = SKILL_LEVEL_EXPERT
+	created_item = /obj/item/clothing/neck/roguetown/psicross/silver/undivided
+	display_category = ITEM_CAT_VALUABLES_HOLY
+
+/datum/anvil_recipe/valuables/silver_amulet_noc
+	name = "Silver Amulet of Noc (+1 Amulet of Noc)"
+	req_bar = /obj/item/ingot/silver
+	additional_items = list(/obj/item/clothing/neck/roguetown/psicross/noc)
+	craftdiff = SKILL_LEVEL_EXPERT
+	created_item = /obj/item/clothing/neck/roguetown/psicross/silver/noc
+	display_category = ITEM_CAT_VALUABLES_HOLY
+
+/datum/anvil_recipe/valuables/silver_amulet_astrata
+	name = "Silver Amulet of Astrata (+1 Amulet of Astrata)"
+	req_bar = /obj/item/ingot/silver
+	additional_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	craftdiff = SKILL_LEVEL_EXPERT
+	created_item = /obj/item/clothing/neck/roguetown/psicross/silver/astrata
+	display_category = ITEM_CAT_VALUABLES_HOLY
+
+/datum/anvil_recipe/valuables/silver_amulet_necra
+	name = "Silver Amulet of Necra (+1 Amulet of Necra)"
+	req_bar = /obj/item/ingot/silver
+	additional_items = list(/obj/item/clothing/neck/roguetown/psicross/necra)
+	craftdiff = SKILL_LEVEL_EXPERT
+	created_item = /obj/item/clothing/neck/roguetown/psicross/silver/necra
+	display_category = ITEM_CAT_VALUABLES_HOLY
+
 /datum/anvil_recipe/valuables/gold_reformcross
 	name = "Golden Reformist Psycross (+1 Reformist Cross)"
 	req_bar = /obj/item/ingot/gold


### PR DESCRIPTION
## About The Pull Request
allows amulets to be smithed out of non-silver amulets and a bar of silver, just like gold amulets. still can't smelt them into silver bars. 

## Testing Evidence
<img width="793" height="557" alt="image" src="https://github.com/user-attachments/assets/83fb78f7-5b2c-42fe-ab1f-5f4f7effe051" />

## Why It's Good For The Game
hot take but you shouldn't have to pay 542 mammons for a silver tennite amulet (which is a real thing that happened in a round today) just because you don't want a vampire to walk into your house and interrupt your scene by putting you to sleep instantly. it makes no sense that they're not craftable when you can make every other kind of amulet, and silver is rare enough that it's not exactly going to be highly proliferated (and again. these are used for literally 2 very niche things, as opposed to silver weapons which are pretty universally good = a better use of silver most times.)

## Changelog

:cl:
add: Smiths can now make silver amulets and psycrosses, if given an amulet as a base.
/:cl:
