### PR TITLE
standardize movement behavior between witch's bat, crow, and rat forms

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -21,7 +21,7 @@
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 1)
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	faction = list(FACTION_HOSTILE)
 	attack_sound = 'sound/blank.ogg'
 	obj_damage = 0


### PR DESCRIPTION
## About The Pull Request
For some reason I don't particularly care to untangle, tiny mobs - bat and crow forms - can be walked through by players, swapping their location with nothing the small animal can do about it. Most of them have PASSMOB to allow them to run between peoples' legs, so it never comes up. But if you are in bat or crow form, you can genuinely just have people deny your movement by walking through you repeatedly (happened in a round recently). So they get the same passflags as small rat form to make up for it, because... well, it makes sense? You still die in one hit, and the main balance issue with these is their flight, so I don't see this becoming... like, an issue. ...and also witches are weak as hell anyway, what with the 'no combat trait towner role' thing?

## Testing Evidence
var change, compiles.

## Why It's Good For The Game
People shouldn't be able to just deny you, a small animal, the ability to move by running through you repeatedly, and... also this lets you perch on someone's shoulder and larp familiar gaming. Which is a pretty cool thing to be able to do I think.