### PR TITLE
circlet onmob fix

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/crowns.dm
+++ b/code/modules/clothing/rogueclothes/headwear/crowns.dm
@@ -51,6 +51,7 @@
 /obj/item/clothing/head/roguetown/circlet/carvedgem
 	name = "generic carved gem circlet"
 	desc = "You shouldn't see this."
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/head.dmi'
 	smeltresult = null
 	salvage_result = null
 


### PR DESCRIPTION
## About The Pull Request
gemcarved circlets now actually render when you wear them. advanced stuff, folks

## Testing Evidence
<img width="110" height="116" alt="image" src="https://github.com/user-attachments/assets/09c4499c-bb52-4123-a14d-79ff97af6559" />
<img width="187" height="222" alt="image" src="https://github.com/user-attachments/assets/a800055a-6dfc-4196-b5fe-b9f00506d927" />

## Why It's Good For The Game
this shit's expensive and hard to make it should at least actually show up on your sprite

## Changelog

:cl:
fix: Gemcarved circlets are no longer invisible
/:cl: