### PR TITLE
silverface markup is now contingent upon a corresponding vendor

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -44,3 +44,5 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
+
+GLOBAL_LIST_EMPTY(goldfaces) // all /obj/structure/roguemachine/goldface instances, so we can tell them to update pricing on login/logout

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -755,6 +755,9 @@ SUBSYSTEM_DEF(job)
 				M.client.holder.auto_deadmin()
 			else
 				handle_auto_deadmin_roles(M.client, rank)
+		
+		for(var/obj/structure/roguemachine/goldface/face in GLOB.goldfaces)
+			face.recalc_should_markup()
 
 //	if(job)
 //		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")

--- a/code/game/objects/structures/fartravel.dm
+++ b/code/game/objects/structures/fartravel.dm
@@ -102,3 +102,6 @@
 			QDEL_NULL(thing)
 	QDEL_NULL(departing_mob)
 
+	for(var/obj/structure/roguemachine/goldface/face in GLOB.goldfaces)
+		face.recalc_should_markup()
+

--- a/code/modules/roguetown/roguemachine/merchant/_goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/_goldface.dm
@@ -69,6 +69,7 @@
 	var/is_public = FALSE // Whether it is a public access vendor.
 	var/extra_fee = 0 // Public-tier Porters/Gnomes margin tacked onto base price. Meant to make publicface very unprofitable until Gnomes are unlocked and the margin flows to the Merchant Fund.
 	/// Running tally of Crown import tariff actually collected via this specific machine.
+	var/should_charge_extra = TRUE // Cache for whether there is an associated vendor role (merchant for silverface, guild folk for guildface, etc), for performance reasons
 	var/tariff_collected_here = 0
 	/// Running tally of Crown import tariff that WOULD have been owed but was dodged
 	/// via the NOTAX flag. Surfaced in-UI for audit transparency.
@@ -162,6 +163,7 @@
 /obj/structure/roguemachine/goldface/Initialize()
 	. = ..()
 	update_icon()
+	GLOB.goldfaces += src
 
 /obj/structure/roguemachine/goldface/examine(mob/user)
 	. = ..()
@@ -176,10 +178,18 @@
 			if(AKR)
 				. += span_info("As an Agent, you personally recognize <b>[AKR.name]</b> as kin - your goldface buys from their ships cost -[round((1 - KINSHIP_BUY_MULT) * 100)]%.")
 
+// if there's no associated vendor in round, no markup since there's no-one else to buy from
+/obj/structure/roguemachine/goldface/proc/recalc_should_markup()
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.job in profit_id)
+			should_charge_extra = TRUE
+			return
+	should_charge_extra = FALSE
+
 /obj/structure/roguemachine/goldface/proc/get_effective_fee()
 	if(is_public && SSmerchant_trade?.gnome_automation_unlocked)
 		return SSmerchant_trade.silverface_margin_percent / 100
-	return extra_fee
+	return should_charge_extra ? extra_fee : 0 
 
 /obj/structure/roguemachine/goldface/proc/compute_pack_price(datum/supply_pack/PA)
 	var/cost = PA.cost + PA.cost * get_effective_fee()
@@ -1069,10 +1079,12 @@
 
 /obj/structure/roguemachine/goldface/Destroy()
 	set_light(0)
+	GLOB.goldfaces -= src
 	return ..()
 
 /obj/structure/roguemachine/goldface/Initialize()
 	. = ..()
 	update_icon()
+	recalc_should_markup()
 
 #undef UPGRADE_NOTAX


### PR DESCRIPTION
## About The Pull Request
silverfaces no longer charge their markup if there's no corresponding vendor in-round. the prices are still high at base compared to what a vendor might charge, but they no longer have a 50% markup on top of it

## Testing Evidence
roundstart joins, latejoins, and fartravels all update the pricing. "associated vendors" are defined by the profit_id variable that was already set for silverface types
<img width="894" height="821" alt="image" src="https://github.com/user-attachments/assets/3dd1e0dc-afbb-4d1c-984d-4470d880b587" />
<img width="535" height="50" alt="image" src="https://github.com/user-attachments/assets/2be78c03-0f37-4e20-9d7f-f744b7ed1e37" />
<img width="899" height="824" alt="image" src="https://github.com/user-attachments/assets/bdd8dd73-9278-4c8c-bc07-0f791f90f9d8" />

## Why It's Good For The Game
the silverface markup is meant to push people to interact with vendor roles. if there's no vendor roles, there's no point to it... and we probably shouldn't punish lowpop players even more than the high silverface base costs already do (you're already paying like double what most smiths would charge for armor, for example!)

## Changelog

:cl:
add: Silverfaces no longer mark up prices while there is no corresponding vendor in round
/:cl: