### PR TITLE
[Balance] Message tweaks

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/message.dm
+++ b/code/modules/spells/spell_types/wizard/utility/message.dm
@@ -10,7 +10,7 @@
 	self_cast_possible = TRUE
 
 	primary_resource_type = SPELL_COST_STAMINA
-	primary_resource_cost = SPELLCOST_CANTRIP
+	primary_resource_cost = SPELLCOST_CANTRIP + 30
 
 	invocations = list("Mens Dicta")
 	invocation_type = INVOCATION_WHISPER
@@ -26,7 +26,7 @@
 	spell_tier = 1
 	spell_impact_intensity = SPELL_IMPACT_NONE
 
-	point_cost = 2
+	point_cost = 1
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 

--- a/code/modules/spells/spell_types/wizard/utility/message.dm
+++ b/code/modules/spells/spell_types/wizard/utility/message.dm
@@ -20,7 +20,7 @@
 	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_SMALL
 	charge_sound = 'sound/magic/charging.ogg'
-	cooldown_time = 60 SECONDS
+	cooldown_time = 90 SECONDS
 
 	associated_skill = /datum/skill/magic/arcane
 	spell_tier = 1
@@ -61,6 +61,13 @@
 
 		var/message_color = "7246ff"
 		var/is_projection = FALSE
+
+		if(HL.stat == DEAD)
+			to_chat(user, span_userdanger("My thoughts brush against a cold, endless void. Something stares back. SOMETHING STARES BACK. WHERE DID THEIR MIND GO?!"))
+			user.freak_out()
+			user.playsound_local(user, pick('sound/misc/heroin_rush.ogg'), 80, 1)
+			user.playsound_local(user, pick('sound/vo/mobs/ghost/whisper (1).ogg','sound/vo/mobs/ghost/whisper (2).ogg','sound/vo/mobs/ghost/whisper (3).ogg'), 100, 1)
+			return FALSE
 
 		if(alert(user, "Transmit as a wordlessly projected vision or as a whispered message?", "", "Projection", "Message") == "Projection")
 			is_projection = TRUE


### PR DESCRIPTION
## About The Pull Request

- Message costs 1 Spell Point instead of 2 Spell Points.
- Message now drains 35 Energy instead of 5 Energy.
- Message's cooldown increased to 90 seconds from 60 seconds.
- Message won't work work if your target is dead, you'll get a dreadful backlash.

## Testing Evidence

It's just value changes. Compiles just fine, check the code. B*lance Changes.

## Why It's Good For The Game

Think Mindlink does what Message does but better, for allowing a whole conversation to happen in a single cast, and one that lasts a good while. I scarcely see a reason to pick Message over Mindlink. They cost the same, but have vastly different effectiveness. Thus. Halving the cost of Message, but making it more expensive in other means (especially if used before combat, as it will chunk out your Blue).

## Changelog
:cl:
balance: Message costs 1 SP now.
/:cl: