### PR TITLE
[FIX] fix chimeric heart rack not working

### DIFF
--- a/code/modules/roguetown/roguemachine/heartbeast/heart_component.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_component.dm
@@ -37,6 +37,8 @@
 	var/response_time_threshold = 10 SECONDS // 10 second threshold for patient/impatient quirks
 
 	var/obj/structure/stone_rack/linked_rack
+	var/last_link_attempt = 0
+	var/link_attempt_interval = 30 SECONDS
 
 /datum/component/chimeric_heart_beast/Initialize()
 	. = ..()
@@ -191,6 +193,11 @@
 		process_environment_quirks()
 		last_environment_process = world.time
 
+	// Re-attempt linking to a rack periodically if we don't have one yet.
+	// (The rack may have been built/moved after our initial one-shot link timer.)
+	if(!linked_rack && world.time > last_link_attempt + link_attempt_interval)
+		link_to_racks()
+
 /datum/component/chimeric_heart_beast/proc/decay_happiness()
 	happiness = max(happiness - (max_happiness * 0.05), 0)
 
@@ -329,7 +336,8 @@
 	score = trigger_behavior_quirks(score, speaker, message)
 
 	// Determine success
-	linked_rack.advance_calibration()
+	if(linked_rack)
+		linked_rack.advance_calibration()
 	if(score >= 20) // Passing score
 		complete_task(score, speaker, quirk_effects)
 	else
@@ -341,7 +349,7 @@
 	// Calculate rewards
 	var/blood_reward = (max_blood_pool / 10) * reward_multiplier * (quirk_effects["blood_multiplier"] || 1)
 	// 8 - 16 - 32 - 64 Under perfect circumstances
-	var/rack_multiplier = linked_rack.update_rack_stats()
+	var/rack_multiplier = linked_rack ? linked_rack.update_rack_stats() : 0
 	var/tech_reward = (8 * (2 ** (language_tier - 1))) * reward_multiplier * ((quirk_effects["tech_multiplier"] || 1) * rack_multiplier)
 	var/happiness_reward = (max_happiness / 4) * reward_multiplier * (quirk_effects["happiness_multiplier"] || 1)
 	// 2 perfect answers, or 4 mediocre ones, 8 serviceable answers
@@ -495,6 +503,15 @@
 /datum/component/chimeric_heart_beast/proc/link_to_racks()
 	if(!heart_beast || !heart_beast.loc)
 		return
+
+	last_link_attempt = world.time
+
+	// Already linked - make sure the link is still valid (rack wasn't destroyed/moved).
+	if(linked_rack)
+		if(!istype(linked_rack) || !linked_rack.loc || linked_rack.heart_component != src)
+			linked_rack = null
+		else
+			return
 
 	//Range() might be better, but I couldn't find racks through walls so we're doing it this way
 	var/search_range = 7

--- a/code/modules/roguetown/roguemachine/heartbeast/heart_rack.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_rack.dm
@@ -146,7 +146,7 @@
 
 /obj/structure/stone_rack/proc/update_rack_stats()
 	if(!heart_component)
-		return
+		return 0
 
 	var/calibrated_count
 	var/total_penalty = 0


### PR DESCRIPTION
## About The Pull Request

Tries to fix #7582. The suspicion here is that, the linking process only happens once 5s after placing the heart, after which it's never tried again. If for whatever reason the rack fails to spawn during this time it means the linking will never happen. Also fixes a possible runtime if the rack is destroyed. This PR makes it do a poll every 30s in its process proc until it finds one.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Checked locally, spawned a heart, then a rack within 7 tiles. After some time the heart component had the linked_rack set to the stone rack.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bugfix.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Chimeric heart rack should stay linked and work as advertised now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
