### PR TITLE
maillecall - minor alternative to PR #7800; imparts armor-filtering onto haubyrines, corrects coverage

### DIFF
--- a/code/datums/components/armour_filtering.dm
+++ b/code/datums/components/armour_filtering.dm
@@ -155,6 +155,33 @@ TRAIT UNIQUE PROCS
 			REMOVE_TRAIT(user, TRAIT_ARMOUR_DISLIKED, TRAIT_GENERIC)
 		return
 
+	if(HAS_TRAIT(user, TRAIT_ARCYNE))
+		if(!positive)
+			user.dropItemToGround(parent, TRUE, TRUE)
+			to_chat(user, span_warning("It may be light, but this armor chafes my focus far too much. I couldn't hope to channel my magicka, while wearing it."))
+			if(!HAS_TRAIT(user, TRAIT_ARMOUR_DISLIKED))
+				return
+			REMOVE_TRAIT(user, TRAIT_ARMOUR_DISLIKED, TRAIT_GENERIC)
+		return
+
+	if(HAS_TRAIT(user, TRAIT_CIVILIZEDBARBARIAN))
+		if(!positive)
+			user.dropItemToGround(parent, TRUE, TRUE)
+			to_chat(user, span_warning("It may be light, but this armor chafes my focus far too much. I couldn't hope to hone my techniques, while wearing it."))
+			if(!HAS_TRAIT(user, TRAIT_ARMOUR_DISLIKED))
+				return
+			REMOVE_TRAIT(user, TRAIT_ARMOUR_DISLIKED, TRAIT_GENERIC)
+		return
+
+	if(HAS_TRAIT(user, TRAIT_DODGEEXPERT))
+		if(!positive)
+			user.dropItemToGround(parent, TRUE, TRUE)
+			to_chat(user, span_warning("It may be light, but this armor chafes my focus far too much. I couldn't hope to keep my reflexes sharp, while wearing it."))
+			if(!HAS_TRAIT(user, TRAIT_ARMOUR_DISLIKED))
+				return
+			REMOVE_TRAIT(user, TRAIT_ARMOUR_DISLIKED, TRAIT_GENERIC)
+		return
+
 	if(HAS_TRAIT(user, TRAIT_PSYDONIAN_GRIT) && id == "ornate_plate")
 		if(positive)
 			user.apply_status_effect(/datum/status_effect/buff/psydonic_endurance)

--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -4,9 +4,9 @@
 	desc = "A sleeveless maille shirt, fashioned from dozens of interlinked steel rings. It's light enough to comfortably tuck underneath a \
 	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. For the discerning nobleman."
 	icon_state = "haubyrnie"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_STEEL
+	max_integrity = ARMOR_INT_CHEST_LIGHT_STEEL - 30
 	armor_class = ARMOR_CLASS_LIGHT
-	body_parts_covered = COVERAGE_TORSO
+	body_parts_covered = CHEST | VITALS
 	flags_inv = HIDEBOOB //Let it hang, sire.
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
@@ -14,6 +14,7 @@
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/ComponentInitialize()
 	..()
 	AddComponent(/datum/component/adjustable_clothing, CHEST, null, null, 'sound/foley/equip/equip_armor_chain.ogg', null, UPD_CHEST)
+	AddComponent(/datum/component/armour_filtering/negative, TRAIT_ARCYNE, TRAIT_DODGEEXPERT, TRAIT_CIVILIZEDBARBARIAN)
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/get_mechanics_examine(mob/user)
 	. = ..()
@@ -22,17 +23,19 @@
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/iron
 	name = "iron haubyrnie"
 	desc = "A sleeveless maille shirt, fashioned from dozens of interlinked iron rings. It's light enough to comfortably tuck underneath a \
-	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. For the discerning peasant."
+	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. The lack of any padding underneath makes the rings chafe, \
+	however; an issue that compromises finer martial-and-arcyne techniques. For the discerning peasant."
 	icon_state = "ihaubyrnie"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON
+	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON - 30
 	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/bronze
 	name = "bronze haubyrnie"
 	desc = "A sleeveless maille shirt, fashioned from dozens of interlinked bronze rings. It's light enough to comfortably tuck underneath a \
-	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. For the discerning traveler - ideally, from an antique land."
+	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. The lack of any padding underneath makes the rings chafe, \
+	however; an issue that compromises finer martial-and-arcyne techniques. For the discerning traveler - ideally, from an antique land."
 	icon_state = "bhaubyrnie"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON - 30
+	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON - 50
 	smeltresult = /obj/item/ingot/bronze
 	armor = ARMOR_BRONZE
 
@@ -146,8 +149,6 @@
 	item_state = "bhauberk"
 	smeltresult = /obj/item/ingot/bronze
 	max_integrity = ARMOR_INT_CHEST_MEDIUM_BRONZE
-
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy
 	name = "decrepit hauberk"

--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -14,7 +14,7 @@
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/ComponentInitialize()
 	..()
 	AddComponent(/datum/component/adjustable_clothing, CHEST, null, null, 'sound/foley/equip/equip_armor_chain.ogg', null, UPD_CHEST)
-	AddComponent(/datum/component/armour_filtering/negative, TRAIT_ARCYNE, TRAIT_DODGEEXPERT, TRAIT_CIVILIZEDBARBARIAN)
+	AddComponent(/datum/component/armour_filtering/negative, TRAIT_ARCYNE, TRAIT_CIVILIZEDBARBARIAN)
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/get_mechanics_examine(mob/user)
 	. = ..()
@@ -23,8 +23,7 @@
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/iron
 	name = "iron haubyrnie"
 	desc = "A sleeveless maille shirt, fashioned from dozens of interlinked iron rings. It's light enough to comfortably tuck underneath a \
-	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. The lack of any padding underneath makes the rings chafe, \
-	however; an issue that compromises finer martial-and-arcyne techniques. For the discerning peasant."
+	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. For the discerning peasant."
 	icon_state = "ihaubyrnie"
 	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON - 30
 	smeltresult = /obj/item/ingot/iron
@@ -32,8 +31,7 @@
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/bronze
 	name = "bronze haubyrnie"
 	desc = "A sleeveless maille shirt, fashioned from dozens of interlinked bronze rings. It's light enough to comfortably tuck underneath a \
-	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. The lack of any padding underneath makes the rings chafe, \
-	however; an issue that compromises finer martial-and-arcyne techniques. For the discerning traveler - ideally, from an antique land."
+	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. For the discerning traveler - ideally, from an antique land."
 	icon_state = "bhaubyrnie"
 	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON - 50
 	smeltresult = /obj/item/ingot/bronze

--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -4,7 +4,7 @@
 	desc = "A sleeveless maille shirt, fashioned from dozens of interlinked steel rings. It's light enough to comfortably tuck underneath a \
 	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. For the discerning nobleman."
 	icon_state = "haubyrnie"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_STEEL - 30
+	max_integrity = ARMOR_INT_CHEST_LIGHT_STEEL
 	armor_class = ARMOR_CLASS_LIGHT
 	body_parts_covered = CHEST | VITALS
 	flags_inv = HIDEBOOB //Let it hang, sire.
@@ -25,7 +25,7 @@
 	desc = "A sleeveless maille shirt, fashioned from dozens of interlinked iron rings. It's light enough to comfortably tuck underneath a \
 	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. For the discerning peasant."
 	icon_state = "ihaubyrnie"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON - 30
+	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON
 	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/light/bronze
@@ -33,7 +33,7 @@
 	desc = "A sleeveless maille shirt, fashioned from dozens of interlinked bronze rings. It's light enough to comfortably tuck underneath a \
 	blouse, yet tough enough to thwart the razor-sharp edges of unwelcomed company. For the discerning traveler - ideally, from an antique land."
 	icon_state = "bhaubyrnie"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON - 50
+	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON - 30
 	smeltresult = /obj/item/ingot/bronze
 	armor = ARMOR_BRONZE
 


### PR DESCRIPTION
## About The Pull Request

I woke up at six in the morning to see a fairly heated discussion over the _haubyrine_.
While I'm trying to stay a _bit_ farther away from balance-heavy PRs, they did bring up some fair issues that I'd like to address.
This is, henceforth, a PR intended to be a potential alternative to[ this](https://github.com/Azure-Peak/Azure-Peak/pull/7800) PR.

The unintentional stuff that I've fixed:
* Haubyrines now properly cover _just_ the stomach and chest, as intended. I fully intended this to let your shit hang freely.

The intentional stuff that I've decided to tackle:
* Haubyrines now have an armor-filtering tag, which prevents it from being worn by the _arcyne_ and the _pugilistic._
* Introduces an example _(in chainmail.dm)_ of an item with multiple tags applied at once, for more customizable restrictions.
* Adds three new universally-designed tags _(in armor_filtering.dm)_ - for ARCYNE, DODGEEXPERT, and CIVBARBARIAN.
_(Haubyrines are still directly inferior to the besilked haubergeons in almost every way, so I kept them dodge-friendly.)_

## Testing Evidence

<img width="719" height="404" alt="twea" src="https://github.com/user-attachments/assets/c4aa5ae4-68f6-42ee-b425-9d958ff4727c" />

## Why It's Good For The Game

* Preserves the intended niche of a maille-related garment for noncombat-oriented roles _(chiefly peasants and nobility)_ without having to worry about it being repurposed by others.
* Preserves the value of the fencer's cuirass and the besilked haubergeon _(the latter being nearly twice the durability and coverage)_ as the unobjectively best choices for light-armored classes.
* Adds the necessary touches to a preexisting framework to permit dynamic blacklisting of armor being worn by certain roles, so that discussions of _"certain armorpieces being stretched and abused by mages, fistfighters, and dodgers"_ become a thing of the past.

## Changelog

:cl:
fix: Haubyrines no longer inherit unintended coverage of the groin.
balance: Haubyrines cannot be worn by those with TRAIT_ARCYNE or TRAIT_CIVILIZEDBARBARIAN; magicka casters and dedicated pugilists, more plainly.
code: Added new tags in armour_filtering.dm that allows for tagged items to be unwearable by those with TRAIT_ARCYNE, TRAIT_CIVILIZEDBARBARIAN, or TRAIT_DODGEEXPERT-- independently or all together. Check out chainmail.dm for an example of how to add multiple tags to the same armor-filtering component.
/:cl: