### PR TITLE
the (actual) final rebalance to end all rebalances / [TM ONLY, DISCUSS] - reduces unarmortrained parry cap to 35% (from 70%), adds medium AC to maille + plated bracers / gauntlets / boots / bevors

### DIFF
--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -63,6 +63,8 @@
 	icon_state = "ancientboots"
 	smeltresult = /obj/item/ingot/aaslag
 	color = "#bb9696"
+	armor = ARMOR_LEATHER
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/shoes/roguetown/boots/paalloy
 	name = "ancient boots"
@@ -77,6 +79,7 @@
 	equip_sound = 'sound/foley/equip/equip_armor_plate.ogg'
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/aaslag
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/shoes/roguetown/boots/psydonboots
 	name = "psydonic leather boots"
@@ -321,6 +324,7 @@
 	anvilrepair = /datum/skill/craft/armorsmithing
 	sewrepair = FALSE
 	smeltresult = /obj/item/ingot/steel
+	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/shoes/roguetown/boots/maille/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/negative, TRAIT_FENCERDEXTERITY)
@@ -344,7 +348,9 @@
 	icon_state = "bsoldierboots"
 	item_state = "bsoldierboots"
 	max_integrity = ARMOR_INT_SIDE_BRONZE
+	armor = ARMOR_BRONZE
 	smeltresult = /obj/item/ingot/bronze
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/shoes/roguetown/boots/maille/copper
 	name = "copper lamellar boots"
@@ -355,6 +361,7 @@
 	max_integrity = ARMOR_INT_SIDE_LEATHER
 	armor = ARMOR_LEATHER
 	smeltresult = /obj/item/ingot/copper
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/shoes/roguetown/boots/armor
 	name = "plated boots"

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -194,6 +194,7 @@
 	desc = "Frayed bronze platforms, curled about to cradle the feet. The beaches that these sandals once treaded are no more; pearly sands, long since turnt to glass from the Comet Syon's impact."
 	icon_state = "ancientsandals"
 	color = "#bb9696"
+	armor = ARMOR_LEATHER
 
 /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	name = "ancient sandals"
@@ -281,15 +282,6 @@
 	item_state = "freiboots"
 	max_integrity = ARMOR_INT_SIDE_HARDLEATHER + 50
 
-/obj/item/clothing/shoes/roguetown/boots/armor/dwarven
-	name = "grudgebearer dwarven boots"
-	desc = "Clatters mightily."
-	icon = 'icons/roguetown/clothing/special/race_armor.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
-	allowed_race = list(/datum/species/dwarf, /datum/species/dwarf/mountain)
-	icon_state = "dwarfshoe"
-	item_state = "dwarfshoe"
-
 /obj/item/clothing/shoes/roguetown/boots/elven_boots
 	name = "woad elven boots"
 	desc = "'Tread lightly, for the ground remembers every footfall.'"
@@ -308,44 +300,6 @@
 /obj/item/clothing/shoes/roguetown/boots/elven_boots/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/item_equipped_movement_rustle, SFX_WOOD_ARMOR, 10)
-
-/obj/item/clothing/shoes/roguetown/boots/armor
-	name = "plated boots"
-	desc = "Custom-fitted sabatons, made from a series of interlinking steel plates. The only weakness it has, beyond its inaffordability \
-	amongst those of ignobility, is its inability to properly stand firm across softer surfaces. There's a very good reason as to why \
-	you'd rarely see a knight treading the Terrorbog's muddied paths, after all."
-	body_parts_covered = FEET
-	icon_state = "armorboots"
-	item_state = "armorboots"
-	color = null
-	blocksound = PLATEHIT
-	resistance_flags = FIRE_PROOF
-	max_integrity = ARMOR_INT_SIDE_STEEL
-	armor = ARMOR_PLATE
-	pickup_sound = 'sound/foley/equip/equip_armor_plate.ogg'
-	equip_sound = 'sound/foley/equip/equip_armor_plate.ogg'
-	anvilrepair = /datum/skill/craft/armorsmithing
-	sewrepair = FALSE
-	smeltresult = /obj/item/ingot/steel
-
-/obj/item/clothing/shoes/roguetown/boots/armor/ComponentInitialize()
-	AddComponent(/datum/component/armour_filtering/negative, TRAIT_FENCERDEXTERITY)
-	AddComponent(/datum/component/armour_filtering/negative, TRAIT_HONORBOUND)
-
-/obj/item/clothing/shoes/roguetown/boots/armor/iron
-	name = "iron plated boots"
-	desc = "Antiquated sabatons, fitted to leather boots that've been reinforced with layers of iron maille. While it has largely fallen \
-	out of favor with Psydonia's knights since the advent of custom-fitted steel sabatons, it nevertheless remains an excellent choice \
-	for those who'd rather not catch an career-ending arrow to the knee."
-	body_parts_covered = FEET
-	icon_state = "iplateboots"
-	item_state = "iplateboots"
-	color = null
-	blocksound = PLATEHIT
-	max_integrity = ARMOR_INT_SIDE_IRON
-	armor = ARMOR_PLATE
-	anvilrepair = /datum/skill/craft/armorsmithing
-	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/shoes/roguetown/boots/maille
 	name = "maille boots"
@@ -402,6 +356,54 @@
 	armor = ARMOR_LEATHER
 	smeltresult = /obj/item/ingot/copper
 
+/obj/item/clothing/shoes/roguetown/boots/armor
+	name = "plated boots"
+	desc = "Custom-fitted sabatons, made from a series of interlinking steel plates. The only weakness it has, beyond its inaffordability \
+	amongst those of ignobility, is its inability to properly stand firm across softer surfaces. There's a very good reason as to why \
+	you'd rarely see a knight treading the Terrorbog's muddied paths, after all."
+	body_parts_covered = FEET
+	icon_state = "armorboots"
+	item_state = "armorboots"
+	color = null
+	blocksound = PLATEHIT
+	resistance_flags = FIRE_PROOF
+	max_integrity = ARMOR_INT_SIDE_STEEL
+	armor = ARMOR_PLATE
+	pickup_sound = 'sound/foley/equip/equip_armor_plate.ogg'
+	equip_sound = 'sound/foley/equip/equip_armor_plate.ogg'
+	anvilrepair = /datum/skill/craft/armorsmithing
+	sewrepair = FALSE
+	smeltresult = /obj/item/ingot/steel
+	armor_class = ARMOR_CLASS_MEDIUM
+
+/obj/item/clothing/shoes/roguetown/boots/armor/ComponentInitialize()
+	AddComponent(/datum/component/armour_filtering/negative, TRAIT_FENCERDEXTERITY)
+	AddComponent(/datum/component/armour_filtering/negative, TRAIT_HONORBOUND)
+
+/obj/item/clothing/shoes/roguetown/boots/armor/iron
+	name = "iron plated boots"
+	desc = "Antiquated sabatons, fitted to leather boots that've been reinforced with layers of iron maille. While it has largely fallen \
+	out of favor with Psydonia's knights since the advent of custom-fitted steel sabatons, it nevertheless remains an excellent choice \
+	for those who'd rather not catch an career-ending arrow to the knee."
+	body_parts_covered = FEET
+	icon_state = "iplateboots"
+	item_state = "iplateboots"
+	color = null
+	blocksound = PLATEHIT
+	max_integrity = ARMOR_INT_SIDE_IRON
+	armor = ARMOR_PLATE
+	anvilrepair = /datum/skill/craft/armorsmithing
+	smeltresult = /obj/item/ingot/iron
+
+/obj/item/clothing/shoes/roguetown/boots/armor/dwarven
+	name = "grudgebearer dwarven boots"
+	desc = "Clatters mightily."
+	icon = 'icons/roguetown/clothing/special/race_armor.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
+	allowed_race = list(/datum/species/dwarf, /datum/species/dwarf/mountain)
+	icon_state = "dwarfshoe"
+	item_state = "dwarfshoe"
+
 /obj/item/clothing/shoes/roguetown/boots/armor/gold
 	name = "golden greaves"
 	desc = "Resplendant sabatons of pure gold, adorned with angled greaves that proudly bare the holy sigil. Its besilked cuffs have remained surprisingly bereft of debris - not even a sprig of lint remains to be criticized."
@@ -430,8 +432,9 @@
 	icon_state = "bronzegreaves"
 	body_parts_covered = FEET | LEGS
 	smeltresult = /obj/item/ingot/bronze
-	armor = ARMOR_PLATE
+	armor = ARMOR_BRONZE
 	max_integrity = ARMOR_INT_SIDE_BRONZE
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/shoes/roguetown/boots/armor/graggar
 	name = "vicious boots"
@@ -519,6 +522,149 @@
 	armor = ARMOR_PLATE
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/iron
+
+/obj/item/clothing/shoes/roguetown/boots/armor/blacksteel/modern
+	name = "blacksteel plate boots"
+	desc = "Magnificent sabatons of blacksteel, pointed-yet-restrained. By the click of your heels, a thousand levymen shall march without question - and 'pon a leaping start, they shall see the bravery that earned such alloyed gifts to begin with."
+	icon_state = "bplateboots"
+	item_state = "bplateboots"
+
+/obj/item/clothing/shoes/roguetown/boots/armor/blacksteel
+	name = "ancient blacksteel plate boots"
+	desc = "Antiquated sabatons, forged from segmented plates of blacksteel. Am I the cancer that is killing this world? Is it my hate, my spite, my lust - that, which poisons the ones around me, and siphons away the hope of Man and God alike? When the last hearth is quenched and Psydonia is nothing more than a shriveled husk, will I still blame the corpses for what I had done? </br>‎  </br>Let go of your hate. Your lyfe is yours, and yours alone to arbitrate."
+	icon_state = "bkboots"
+	item_state = "bkboots"
+	max_integrity = ARMOR_INT_SIDE_BLACKSTEEL
+	armor = ARMOR_PLATE_BSTEEL
+	smeltresult = /obj/item/ingot/blacksteel
+	chunkcolor = "#303036"
+
+/obj/item/clothing/shoes/roguetown/anklets
+	name = "golden anklets"
+	desc = "Luxurious anklets made of the finest gold. They leave the feet bare while adding a silky flair."
+	gender = PLURAL
+	icon_state = "anklets"
+	item_state = "anklets"
+	is_barefoot = TRUE
+	sewrepair = TRUE
+	armor = ARMOR_CLOTHING
+
+//kazen update
+/obj/item/clothing/shoes/roguetown/armor/rumaclan
+	name = "raised sandals"
+	desc = "A pair of strange sandals that push you off the ground."
+	icon_state = "eastsandals"
+	item_state = "eastsandals"
+	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
+	armor = ARMOR_LEATHER
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
+	sewrepair = TRUE
+	armor_class = ARMOR_CLASS_LIGHT
+
+/obj/item/clothing/shoes/roguetown/armor/rumaclan/shitty
+	armor = ARMOR_CLOTHING
+
+// horseshoes!
+/obj/item/clothing/shoes/roguetown/horseshoes
+	name = "iron horseshoes"
+	desc = "A pair of sturdy iron horseshoes nailed onto thick leather soles. These are ready to be attached to some hooves."
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/64x32/saiga.dmi'
+	icon_state = "iron_horseshoes"
+	item_state = "iron_horseshoes"
+	clothing_flags = TAUR_COMPATIBLE
+	max_integrity = ARMOR_INT_LEG_IRON_PLATE
+	sewrepair = FALSE
+	armor = ARMOR_PLATE
+	smeltresult = /obj/item/ingot/iron
+
+/obj/item/clothing/shoes/roguetown/horseshoes/build_worn_icon(default_layer, default_icon_file, isinhands, femaleuniform, override_state, female, customi, sleeveindex, boobed_overlay, icon/clip_mask)
+	var/mutable_appearance/image = ..()
+	image.pixel_x = -16
+	image.pixel_y = -1
+	return image
+
+/obj/item/clothing/shoes/roguetown/horseshoes/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning)
+	var/mob/living/equipped_to_mob = equipper || M
+	var/obj/item/bodypart/taur/taur = equipped_to_mob.get_taur_tail()
+	if(!istype(taur, /obj/item/bodypart/taur/horse))
+		if(!disable_warning)
+			to_chat(M, span_warning("These horseshoes can only be equipped by beings with hooves."))
+		return FALSE
+	return ..()
+
+/obj/item/clothing/shoes/roguetown/horseshoes/steel
+	name = "steel horseshoes"
+	desc = "A pair of robust steel horseshoes nailed onto thick leather soles. These are ready to be attached to some hooves."
+	icon_state = "steel_horseshoes"
+	item_state = "steel_horseshoes"
+	max_integrity = ARMOR_INT_LEG_STEEL_CHAIN
+	sewrepair = FALSE
+	armor = ARMOR_PLATE
+	smeltresult = /obj/item/ingot/steel
+
+/obj/item/clothing/shoes/roguetown/horseshoes/silver
+	name = "silver horseshoes"
+	desc = "A pair of shining silver horseshoes nailed onto thick leather soles. These are ready to be attached to some hooves."
+	icon_state = "silver_horseshoes"
+	item_state = "silver_horseshoes"
+	max_integrity = ARMOR_INT_LEG_HARDLEATHER
+	sewrepair = FALSE
+	armor = ARMOR_PLATE
+	smeltresult = /obj/item/ingot/silver
+
+/obj/item/clothing/shoes/roguetown/horseshoes/gold
+	name = "gold horseshoes"
+	desc = "A pair of opulent golden horseshoes nailed onto thick leather soles. These are ready to be attached to some hooves."
+	icon_state = "gold_horseshoes"
+	item_state = "gold_horseshoes"
+	max_integrity = ARMOR_INT_LEG_LEATHER
+	sewrepair = FALSE
+	armor = ARMOR_PLATE // these are awful!
+	smeltresult = /obj/item/ingot/gold
+
+/obj/item/clothing/shoes/roguetown/horseshoes/bronze
+	name = "bronze horseshoes"
+	desc = "A pair of venerable bronze horsehoes nailed onto thick leather soles. These are ready to be attached to some hooves."
+	icon_state = "bronze_horseshoes"
+	item_state = "bronze_horseshoes"
+	clothing_flags = TAUR_COMPATIBLE
+	max_integrity = ARMOR_INT_LEG_BRONZE
+	sewrepair = FALSE
+	smeltresult = /obj/item/ingot/bronze
+
+/obj/item/clothing/shoes/courtphysician
+	name = "sanguine shoes"
+	desc = "Leather shoes, the solemn tap of these bears grim news, or salvation."
+	icon_state = "docshoes"
+	item_state = "docshoes"
+	icon = 'icons/roguetown/clothing/special/courtphys.dmi'
+	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_courtphys.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/courtphys.dmi'
+	salvage_result = /obj/item/natural/hide/cured
+
+/obj/item/clothing/shoes/courtphysician/female
+	name = "sanguine heels"
+	desc = "Leather heels, the solemn tap of these bears grim news, or salvation."
+	icon_state = "docheels"
+	item_state = "docheels"
+	icon = 'icons/roguetown/clothing/special/courtphys.dmi'
+	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_courtphys.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/courtphys.dmi'
+	detail_tag = "_detail"
+	detail_color = CLOTHING_RED
+
+/obj/item/clothing/shoes/courtphysician/female/Initialize()
+	. = ..()
+	update_icon()
+
+/obj/item/clothing/shoes/courtphysician/female/update_icon()
+	cut_overlays()
+	if(get_detail_tag())
+		var/mutable_appearance/pic = mutable_appearance(icon(icon, "[icon_state][detail_tag]"))
+		pic.appearance_flags = RESET_COLOR
+		if(get_detail_color())
+			pic.color = get_detail_color()
+		add_overlay(pic)
 
 /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/kazengun
 	name = "armored sandals"
@@ -635,150 +781,3 @@
 	item_state = "inqboots"
 	allowed_race = ALL_RACES_TYPES
 	armor = ARMOR_PLATE
-
-
-// ----------------- BLACKSTEEL -----------------------
-
-/obj/item/clothing/shoes/roguetown/boots/armor/blacksteel/modern
-	name = "blacksteel plate boots"
-	desc = "Magnificent sabatons of blacksteel, pointed-yet-restrained. By the click of your heels, a thousand levymen shall march without question - and 'pon a leaping start, they shall see the bravery that earned such alloyed gifts to begin with."
-	icon_state = "bplateboots"
-	item_state = "bplateboots"
-
-/obj/item/clothing/shoes/roguetown/boots/armor/blacksteel
-	name = "ancient blacksteel plate boots"
-	desc = "Antiquated sabatons, forged from segmented plates of blacksteel. Am I the cancer that is killing this world? Is it my hate, my spite, my lust - that, which poisons the ones around me, and siphons away the hope of Man and God alike? When the last hearth is quenched and Psydonia is nothing more than a shriveled husk, will I still blame the corpses for what I had done? </br>‎  </br>Let go of your hate. Your lyfe is yours, and yours alone to arbitrate."
-	icon_state = "bkboots"
-	item_state = "bkboots"
-	max_integrity = ARMOR_INT_SIDE_BLACKSTEEL
-	armor = ARMOR_PLATE_BSTEEL
-	smeltresult = /obj/item/ingot/blacksteel
-	chunkcolor = "#303036"
-
-// ----------------- BLACKSTEEL END -----------------------
-
-/obj/item/clothing/shoes/roguetown/anklets
-	name = "golden anklets"
-	desc = "Luxurious anklets made of the finest gold. They leave the feet bare while adding a silky flair."
-	gender = PLURAL
-	icon_state = "anklets"
-	item_state = "anklets"
-	is_barefoot = TRUE
-	sewrepair = TRUE
-	armor = ARMOR_CLOTHING
-
-//kazen update
-/obj/item/clothing/shoes/roguetown/armor/rumaclan
-	name = "raised sandals"
-	desc = "A pair of strange sandals that push you off the ground."
-	icon_state = "eastsandals"
-	item_state = "eastsandals"
-	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
-	sewrepair = TRUE
-
-/obj/item/clothing/shoes/roguetown/armor/rumaclan/shitty
-	armor = ARMOR_CLOTHING
-
-// horseshoes!
-/obj/item/clothing/shoes/roguetown/horseshoes
-	name = "iron horseshoes"
-	desc = "A pair of sturdy iron horseshoes nailed onto thick leather soles. These are ready to be attached to some hooves."
-	mob_overlay_icon = 'icons/roguetown/clothing/onmob/64x32/saiga.dmi'
-	icon_state = "iron_horseshoes"
-	item_state = "iron_horseshoes"
-	clothing_flags = TAUR_COMPATIBLE
-	max_integrity = ARMOR_INT_LEG_IRON_PLATE
-	sewrepair = FALSE
-	armor = ARMOR_PLATE
-	smeltresult = /obj/item/ingot/iron
-
-/obj/item/clothing/shoes/roguetown/horseshoes/build_worn_icon(default_layer, default_icon_file, isinhands, femaleuniform, override_state, female, customi, sleeveindex, boobed_overlay, icon/clip_mask)
-	var/mutable_appearance/image = ..()
-	image.pixel_x = -16
-	image.pixel_y = -1
-	return image
-
-/obj/item/clothing/shoes/roguetown/horseshoes/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning)
-	var/mob/living/equipped_to_mob = equipper || M
-	var/obj/item/bodypart/taur/taur = equipped_to_mob.get_taur_tail()
-	if(!istype(taur, /obj/item/bodypart/taur/horse))
-		if(!disable_warning)
-			to_chat(M, span_warning("These horseshoes can only be equipped by beings with hooves."))
-		return FALSE
-	return ..()
-
-/obj/item/clothing/shoes/roguetown/horseshoes/steel
-	name = "steel horseshoes"
-	desc = "A pair of robust steel horseshoes nailed onto thick leather soles. These are ready to be attached to some hooves."
-	icon_state = "steel_horseshoes"
-	item_state = "steel_horseshoes"
-	max_integrity = ARMOR_INT_LEG_STEEL_CHAIN
-	sewrepair = FALSE
-	armor = ARMOR_PLATE
-	smeltresult = /obj/item/ingot/steel
-
-/obj/item/clothing/shoes/roguetown/horseshoes/silver
-	name = "silver horseshoes"
-	desc = "A pair of shining silver horseshoes nailed onto thick leather soles. These are ready to be attached to some hooves."
-	icon_state = "silver_horseshoes"
-	item_state = "silver_horseshoes"
-	max_integrity = ARMOR_INT_LEG_HARDLEATHER
-	sewrepair = FALSE
-	armor = ARMOR_PLATE
-	smeltresult = /obj/item/ingot/silver
-
-/obj/item/clothing/shoes/roguetown/horseshoes/gold
-	name = "gold horseshoes"
-	desc = "A pair of opulent golden horseshoes nailed onto thick leather soles. These are ready to be attached to some hooves."
-	icon_state = "gold_horseshoes"
-	item_state = "gold_horseshoes"
-	max_integrity = ARMOR_INT_LEG_LEATHER
-	sewrepair = FALSE
-	armor = ARMOR_PLATE // these are awful!
-	smeltresult = /obj/item/ingot/gold
-
-/obj/item/clothing/shoes/roguetown/horseshoes/bronze
-	name = "bronze horseshoes"
-	desc = "A pair of venerable bronze horsehoes nailed onto thick leather soles. These are ready to be attached to some hooves."
-	icon_state = "bronze_horseshoes"
-	item_state = "bronze_horseshoes"
-	clothing_flags = TAUR_COMPATIBLE
-	max_integrity = ARMOR_INT_LEG_BRONZE
-	sewrepair = FALSE
-	smeltresult = /obj/item/ingot/bronze
-
-/obj/item/clothing/shoes/courtphysician
-	name = "sanguine shoes"
-	desc = "Leather shoes, the solemn tap of these bears grim news, or salvation."
-	icon_state = "docshoes"
-	item_state = "docshoes"
-	icon = 'icons/roguetown/clothing/special/courtphys.dmi'
-	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_courtphys.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/courtphys.dmi'
-	salvage_result = /obj/item/natural/hide/cured
-
-/obj/item/clothing/shoes/courtphysician/female
-	name = "sanguine heels"
-	desc = "Leather heels, the solemn tap of these bears grim news, or salvation."
-	icon_state = "docheels"
-	item_state = "docheels"
-	icon = 'icons/roguetown/clothing/special/courtphys.dmi'
-	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_courtphys.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/courtphys.dmi'
-	detail_tag = "_detail"
-	detail_color = CLOTHING_RED
-
-/obj/item/clothing/shoes/courtphysician/female/Initialize()
-	. = ..()
-	update_icon()
-
-/obj/item/clothing/shoes/courtphysician/female/update_icon()
-	cut_overlays()
-	if(get_detail_tag())
-		var/mutable_appearance/pic = mutable_appearance(icon(icon, "[icon_state][detail_tag]"))
-		pic.appearance_flags = RESET_COLOR
-		if(get_detail_color())
-			pic.color = get_detail_color()
-		add_overlay(pic)

--- a/code/modules/clothing/rogueclothes/gloves/blacksteel.dm
+++ b/code/modules/clothing/rogueclothes/gloves/blacksteel.dm
@@ -1,9 +1,3 @@
-/obj/item/clothing/gloves/roguetown/plate/blacksteel/modern
-	name = "blacksteel plate gauntlets"
-	desc = "Alloyed plate gauntlets, meticulously assembled from blacksteel. Each joint, a dozen segments; interconnected, interlinked, intertwined. Metal should not move so freely, like skin on flesh - yet it does."
-	icon_state = "bplategloves"
-	item_state = "bplategloves"
-
 /obj/item/clothing/gloves/roguetown/plate/blacksteel
 	name = "ancient blacksteel plate gauntlets"
 	desc = "Wide-cuffed plate gauntlets, alloyed from a singular sheet of blacksteel. How would it feel, to see your greatest works slip away from your grasp; to see it twisted, violated, and alchemized into the very thing you swore to detest? To fall into Hell, with a head crooked up to forever-leer at the Paradise that was meant for you to reign? </br>  </br>Don't spare a breath; we both know the answer."
@@ -12,3 +6,10 @@
 	armor = ARMOR_PLATE_BSTEEL
 	max_integrity = ARMOR_INT_SIDE_BLACKSTEEL
 	smeltresult = /obj/item/ingot/blacksteel
+	armor_class = ARMOR_CLASS_MEDIUM
+
+/obj/item/clothing/gloves/roguetown/plate/blacksteel/modern
+	name = "blacksteel plate gauntlets"
+	desc = "Alloyed plate gauntlets, meticulously assembled from blacksteel. Each joint, a dozen segments; interconnected, interlinked, intertwined. Metal should not move so freely, like skin on flesh - yet it does."
+	icon_state = "bplategloves"
+	item_state = "bplategloves"

--- a/code/modules/clothing/rogueclothes/gloves/plate.dm
+++ b/code/modules/clothing/rogueclothes/gloves/plate.dm
@@ -12,10 +12,10 @@
 	equip_sound = 'sound/foley/equip/equip_armor_plate.ogg'
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
-
 	grid_width = 64
 	grid_height = 32
 	unarmed_bonus = 3
+	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/gloves/roguetown/plate/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/positive, TRAIT_FENCERDEXTERITY)

--- a/code/modules/clothing/rogueclothes/gloves/plate.dm
+++ b/code/modules/clothing/rogueclothes/gloves/plate.dm
@@ -12,10 +12,10 @@
 	equip_sound = 'sound/foley/equip/equip_armor_plate.ogg'
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
+
 	grid_width = 64
 	grid_height = 32
 	unarmed_bonus = 3
-	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/gloves/roguetown/plate/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/positive, TRAIT_FENCERDEXTERITY)
@@ -47,12 +47,14 @@
 	material_category = ARMOR_MAT_PLATE
 	smeltresult = /obj/item/ingot/aaslag
 	anvilrepair = null
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/gloves/roguetown/plate/paalloy
 	name = "ancient plate gauntlets"
 	desc = "Polished gilbranze mechanisms, meticulously interconnected to shroud splayed hands. 'Mercy' and 'innocence' are concepts paraded by the unenlightened; spill their blood without guilt, so that the world may yet be remade in Her image." 
 	icon_state = "agauntlets"
 	smeltresult = /obj/item/ingot/aaslag
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/gloves/roguetown/plate/graggar
 	name = "vicious gauntlets"

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -264,6 +264,7 @@
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	blocksound = PLATEHIT
+	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/neck/roguetown/bevor/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, 'sound/items/visor.ogg', null, (UPD_HEAD|UPD_MASK|UPD_NECK)) // adjustable falling buffe for the bevor

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -179,6 +179,7 @@
 	body_parts_covered = NECK|MOUTH
 	slot_flags = ITEM_SLOT_NECK
 	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
+	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/neck/roguetown/chaincoif/chainmantle/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, (NECK), null, null, 'sound/foley/equip/equip_armor_chain.ogg', null, (UPD_HEAD|UPD_MASK|UPD_NECK))	//Chain coif.

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -41,6 +41,7 @@
 	anvilrepair = /datum/skill/craft/armorsmithing
 	sewrepair = FALSE
 	smeltresult = /obj/item/ingot/steel
+	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/wrists/roguetown/bracers/get_mechanics_examine(mob/user)
 	. = ..()
@@ -50,6 +51,13 @@
 /obj/item/clothing/wrists/roguetown/bracers/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/negative, TRAIT_FENCERDEXTERITY)
 	AddComponent(/datum/component/armour_filtering/negative, TRAIT_HONORBOUND)
+
+/obj/item/clothing/wrists/roguetown/bracers/fencer
+	name = "besilked bracers"
+	desc = "A pair of light steel vambraces, protecting the arms from blows-most-foul. Silk cuffs comfort the arms of those not trained to \
+	carry maille, ensuring each noble flick remains unmarred by weight."
+	max_integrity = ARMOR_INT_SIDE_STEEL - 30
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/wrists/roguetown/bracers/gold
 	name = "golden bracers"
@@ -80,6 +88,7 @@
 	desc = "Oversized gold pauldrons that protect the forearms and upper-arms. Surprisingly protective and flashy, but heavy...!"
 	icon_state = "goldpauldron"
 	sellprice = 20
+	armor_class = ARMOR_CLASS_LIGHT //Role-exclusive.
 
 /obj/item/clothing/wrists/roguetown/bracers/psythorns
 	name = "psydonic thorns"
@@ -94,7 +103,7 @@
 	anvilrepair = /datum/skill/craft/armorsmithing
 	sewrepair = FALSE
 	alternate_worn_layer = WRISTS_LAYER
-	armor_class = ARMOR_CLASS_LIGHT
+	armor_class = ARMOR_CLASS_LIGHT //Role-exclusive.
 
 /obj/item/clothing/wrists/roguetown/bracers/psythorns/equipped(mob/user, slot)
 	. = ..()
@@ -161,6 +170,7 @@
 	salvage_amount = 0 // sry
 	salvage_result = /obj/item/natural/hide/cured
 	color = "#b76f61"
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/wrists/roguetown/bracers/leather/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/positive, TRAIT_FENCERDEXTERITY)
@@ -185,6 +195,7 @@
 	smeltresult = /obj/item/ingot/copper
 	armor = ARMOR_BRONZE
 	max_integrity = ARMOR_INT_SIDE_BRONZE
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/wrists/roguetown/wrappings
 	name = "solar wrappings"
@@ -222,6 +233,7 @@
 	blocksound = SOFTHIT
 	anvilrepair = null
 	sewrepair = TRUE
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/wrists/roguetown/bracers/cloth/monk
 	name = "padded wrappings"
@@ -290,6 +302,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FIRE_PROOF
 	sewrepair = FALSE
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/wrists/roguetown/bracers/brigandine/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/negative, TRAIT_FENCERDEXTERITY)
@@ -309,6 +322,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FIRE_PROOF
 	sewrepair = FALSE
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/wrists/roguetown/bracers/iron
 	name = "iron bracers"
@@ -332,6 +346,7 @@
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	smeltresult = /obj/item/ingot/iron
 	anvilrepair = /datum/skill/craft/armorsmithing
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/wrists/roguetown/bracers/jackchain/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/positive, TRAIT_FENCERDEXTERITY)
@@ -402,6 +417,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
+	armor_class = ARMOR_CLASS_LIGHT
 	var/wrapped = FALSE
 
 /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain/attack_right(mob/user)
@@ -437,6 +453,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
+	armor_class = ARMOR_CLASS_LIGHT
 	var/wrapped = FALSE
 
 /obj/item/clothing/wrists/roguetown/bracers/paalloy/chain/attack_right(mob/user)
@@ -472,6 +489,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
+	armor_class = ARMOR_CLASS_LIGHT
 	var/wrapped = FALSE
 
 /obj/item/clothing/wrists/roguetown/bracers/iron/chain/attack_right(mob/user)
@@ -508,6 +526,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
+	armor_class = ARMOR_CLASS_LIGHT
 	var/wrapped = FALSE
 
 /obj/item/clothing/wrists/roguetown/bracers/bronze/chain/attack_right(mob/user)
@@ -543,6 +562,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
+	armor_class = ARMOR_CLASS_LIGHT
 	var/wrapped = FALSE
 
 /obj/item/clothing/wrists/roguetown/bracers/chain/attack_right(mob/user)

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -489,7 +489,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
-	armor_class = ARMOR_CLASS_LIGHT
+	armor_class = ARMOR_CLASS_MEDIUM
 	var/wrapped = FALSE
 
 /obj/item/clothing/wrists/roguetown/bracers/iron/chain/attack_right(mob/user)
@@ -562,7 +562,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
-	armor_class = ARMOR_CLASS_LIGHT
+	armor_class = ARMOR_CLASS_MEDIUM
 	var/wrapped = FALSE
 
 /obj/item/clothing/wrists/roguetown/bracers/chain/attack_right(mob/user)

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -94,6 +94,7 @@
 	anvilrepair = /datum/skill/craft/armorsmithing
 	sewrepair = FALSE
 	alternate_worn_layer = WRISTS_LAYER
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/wrists/roguetown/bracers/psythorns/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -42,8 +42,8 @@
 
 /datum/outfit/job/roguetown/wretch/berserker/pre_equip(mob/living/carbon/human/H)
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
-	gloves = /obj/item/clothing/gloves/roguetown/plate
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	gloves = /obj/item/clothing/gloves/roguetown/bandages/pugilist
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	backr = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -43,7 +43,7 @@
 /datum/outfit/job/roguetown/wretch/berserker/pre_equip(mob/living/carbon/human/H)
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
 	gloves = /obj/item/clothing/gloves/roguetown/bandages/pugilist
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/fencer
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	backr = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
@@ -216,7 +216,7 @@
 			if("Leather Armor") //OG more or less RT guardsman archer
 				head = /obj/item/clothing/head/roguetown/roguehood/studded/retinue
 				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy
-				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/light
 				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 				H.adjust_skillrank(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
@@ -374,7 +374,7 @@
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	mask = /obj/item/clothing/head/roguetown/roguehood/black
 	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/bailiff
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	beltr = /obj/item/rogueweapon/whip/antique

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
@@ -216,7 +216,7 @@
 			if("Leather Armor") //OG more or less RT guardsman archer
 				head = /obj/item/clothing/head/roguetown/roguehood/studded/retinue
 				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy
-				wrists = /obj/item/clothing/wrists/roguetown/bracers/light
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/fencer
 				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 				H.adjust_skillrank(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
@@ -374,7 +374,7 @@
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	mask = /obj/item/clothing/head/roguetown/roguehood/black
 	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/bailiff
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/fencer
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	beltr = /obj/item/rogueweapon/whip/antique

--- a/code/modules/jobs/job_types/roguetown/other/tester.dm
+++ b/code/modules/jobs/job_types/roguetown/other/tester.dm
@@ -21,7 +21,7 @@
 /datum/outfit/job/roguetown/tester/pre_equip(mob/living/carbon/human/H)
 	..()
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
 	belt = /obj/item/storage/belt/rogue/leather
 	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
 	if(prob(50))

--- a/code/modules/jobs/job_types/roguetown/other/tester.dm
+++ b/code/modules/jobs/job_types/roguetown/other/tester.dm
@@ -21,7 +21,7 @@
 /datum/outfit/job/roguetown/tester/pre_equip(mob/living/carbon/human/H)
 	..()
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/fencer
 	belt = /obj/item/storage/belt/rogue/leather
 	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
 	if(prob(50))

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
@@ -124,7 +124,7 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/atgervi
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 	pants = /obj/item/clothing/under/roguetown/trou/leather/atgervi
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/atgervi
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
@@ -124,7 +124,7 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/atgervi
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 	pants = /obj/item/clothing/under/roguetown/trou/leather/atgervi
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/fencer
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/atgervi
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
@@ -193,7 +193,7 @@
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/heavy
 				H.change_stat(STATKEY_STR, 1) //Without any statpack or racial modifier, this meets the bare minimum for using the Siegebow as a melee weapon.
 				H.change_stat(STATKEY_SPD, -1)
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
 	belt = /obj/item/storage/belt/rogue/leather
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
@@ -255,7 +255,7 @@
 	backl = /obj/item/rogueweapon/woodstaff/implement/greater/blacksteel
 	cloak = /obj/item/clothing/cloak/tabard/stabard/grenzelmage
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
 	head = /obj/item/clothing/head/roguetown/grenzelhofthat

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
@@ -193,7 +193,7 @@
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/heavy
 				H.change_stat(STATKEY_STR, 1) //Without any statpack or racial modifier, this meets the bare minimum for using the Siegebow as a melee weapon.
 				H.change_stat(STATKEY_SPD, -1)
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/fencer
 	belt = /obj/item/storage/belt/rogue/leather
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
@@ -255,7 +255,7 @@
 	backl = /obj/item/rogueweapon/woodstaff/implement/greater/blacksteel
 	cloak = /obj/item/clothing/cloak/tabard/stabard/grenzelmage
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/fencer
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
 	head = /obj/item/clothing/head/roguetown/grenzelhofthat

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
@@ -45,7 +45,7 @@
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun
 	cloak = /obj/item/clothing/cloak/kazengun
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/kazengun
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/fencer
 	gloves = /obj/item/clothing/gloves/roguetown/plate/kote
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun
 	backl = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
@@ -45,7 +45,7 @@
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun
 	cloak = /obj/item/clothing/cloak/kazengun
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/kazengun
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/light
 	gloves = /obj/item/clothing/gloves/roguetown/plate/kote
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun
 	backl = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -241,7 +241,7 @@
 	var/untrained_armor = FALSE
 	if(!H?.check_armor_skill())
 		prob2defend = clamp(prob2defend, 5, 35)			//Caps your max parry to 35 (formerly, 75) if using armor you're not trained in. Bad dexerity.
-		drained = drained + 7							//Increases stamina cost by 7 (formerly, 5). More stamina usage for not being trained in the armor you're using.
+		drained = drained + 10							//Increases stamina cost by 10 (formerly, 5). More stamina usage for not being trained in the armor you're using.
 		untrained_armor = TRUE
 
 	//Dual Wielding

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -240,7 +240,7 @@
 		prob2defend = clamp(prob2defend, 5, 70)
 	var/untrained_armor = FALSE
 	if(!H?.check_armor_skill())
-		prob2defend = clamp(prob2defend, 5, 75)			//Caps your max parry to 75 if using armor you're not trained in. Bad dexerity.
+		prob2defend = clamp(prob2defend, 5, 35)			//Caps your max parry to 35 (formerly, 75) if using armor you're not trained in. Bad dexerity.
 		drained = drained + 5							//More stamina usage for not being trained in the armor you're using.
 		untrained_armor = TRUE
 

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -241,7 +241,7 @@
 	var/untrained_armor = FALSE
 	if(!H?.check_armor_skill())
 		prob2defend = clamp(prob2defend, 5, 35)			//Caps your max parry to 35 (formerly, 75) if using armor you're not trained in. Bad dexerity.
-		drained = drained + 5							//More stamina usage for not being trained in the armor you're using.
+		drained = drained + 7							//Increases stamina cost by 7 (formerly, 5). More stamina usage for not being trained in the armor you're using.
 		untrained_armor = TRUE
 
 	//Dual Wielding

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -1019,6 +1019,13 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/besilked/fencer
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 
+/datum/anvil_recipe/armor/steel/fencingbracers
+	name = "Fencing Bracers, Steel (+1 Steel, +1 Besilked Royal Sleeves)" //needs cooperation with a tailor to make
+	req_bar = /obj/item/ingot/steel
+	additional_items = list(/obj/item/ingot/steel, /obj/item/clothing/wrists/roguetown/royalsleeves) //Quick patchwork to prevent loadouteers from gaming the system.
+	created_item = /obj/item/clothing/wrists/roguetown/bracers/fencer
+	display_category = ITEM_CAT_ARMOR_CHESTPIECES
+
 /datum/anvil_recipe/armor/steel/cuirass/legacy
 	name = "Valorian Cuirass, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel


### PR DESCRIPTION
## About The Pull Request

This is it.
The final threshold.
There's no coming back from this; are you ready?

**(DISCUSS THIS IN THE COMMENTS OR IN #DEV-BALANCE. DO NOT SULLY #DEV-GEN WITH IT, OR I WILL SLAP YOU.)**

This changes the following:
* The maximum parry chance, while wearing untrained armor, has been reduced to _35%_ _(from 70%)_.,
* The added stamina cost for all actions, while wearing untrained armor, has been increased to _10_ _(from 5)_.
* Plated / maille bracers, boots, bevors, mantles and gauntlets _(not gloves)_ now have an armor class of _medium._*
* Adds the _light bracers;_ a grandfathered-in replacement for light roles that had steel bracers. Expensive, slightly more fragile.
* Berserker's plate gauntlets are replaced with high-end pugilist gloves _(for the unarmed damage bonus.)_
* Fixes bronze greaves inhering plate-tier protection.
_* (Roles with no armor training and unique armorpieces, like the Golden Livrasian Pauldrons and Psydonic Thorns, remain light.)_

This is a _lot_, but I am genuinely curious to hear what the community thinks _(either negatively or positively)_ about these proposed changes. I'll likely seperate the more non-contentious ones into smaller pull requests, depending on how this goes.

Hence, I want to ask you all; what do _you_ guys personally think about armor classes on limbs? Some points to consider:
* Since Azure launched, most light-armored roles _(chiefly mages, pugilists, and dodgemasters)_ have been _roughly_ balanced with the idea that they're glass cannons. They can dish out a lot of damage, but usually have little-to-no armor _(or health)_.
* Even so, the lack of AC on most plate equipment _(save for chestpieces and - more recently, helmets)_ means that these roles have been able to essentially obtain the same amount of protection that's traditionally reserved to a plate-armored knight.
* Roles balanced around medium armor aren't as affected, as they tend to usually be centered around melee combat; comparatively, roles balanced around _light armor_ are given a much, _much_ stronger potential boost than intended.
* Even if their benefits are stripped, light-armored roles can still 'rawdog' through the light parry cap _(and remain relatively unaffected, as their improved armor compensates enough for the potential loss in parrying chances.)_
* Medium-armored roles should retain a lot of verticality when it comes to pseudoplating up, _but_ light-armored roles - unless specifically given unique or rare armor to do so - should generally not be able to pseudoplate up.
* Ancient armor was left untouched. Maybe it could have some use?

Likewise, some questions:
* _Should_ maille limb armor have an AC as well, or do you believe that it's fragile and pierceable enough to be acceptable?
* _Is_ the issue of light-armored roles in pseudoplate prominent enough to warrant this in the first place?
* _Would_ it fix anything, or would it possibly do more harm than good?
* _What_ ultimately provides the most fun for both sides?
* _Would_ it just be simpler to add an armor-filter that prevents those roles from wearing certain garb?

## Testing Evidence

Good to go. Allah, forgive me.

## Why It's Good For The Game

It could be good. It could also suck ass. I won't pretend that this is some magic bullet; it's basically smothering a _fairly_ prominent _(if unintended-slash-unhealthy)_ loadout style in the crib.

It _could_, however, also ensure that roles with certain gimmicks aren't able to further empower themselves into being pseudoplated knights _(and are thusly much more likely to contend with their role's intended weaknesses.)_

If the greenlight is given, I'd probably relaunch this with all the appropriate final-term changes.
If not, that's fine; no skin off my back. I do want to hear what all of _you_ think, though, as this is probably super impactful.
_(And like I said; any proper changes here can be divorced into their own pull request for later, if needed.)_

## Changelog

:cl:
balance: Plated and maille limb armor (chiefly gauntlets, bevors, mantles, boots, and bracers) now have an armor class of medium. This means most light-armored roles can no longer properly wear metal coverings without severe downsides.
balance: Reduces the maximum parry cap for untrained armor wearing to 35% (from 70%).
balance: Increases the added stamina cost for untrained armor wearing to 10 (from 5).
fix: Fixes some errant armor values for ancient boots and bronze boots.
/:cl: