### PR TITLE
handy - fixes orphaned chainmail filepath, returning the besilked haubergeon to the hand

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/hand.dm
@@ -31,7 +31,7 @@
 /datum/outfit/job/roguetown/hand
 	backr = /obj/item/storage/backpack/rogue/satchel/short
 	shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/light //regular
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/besilked
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/hand
 	belt = /obj/item/storage/belt/rogue/leather/steel
 	neck = /obj/item/storage/belt/rogue/pouch/coins/mid


### PR DESCRIPTION
## About The Pull Request

* Hands originally got the besilked haubergeon, but this was changed - unintentionally - after the filepath for besilked haubergeons was altered to _'/besilked'_ from _'/light'_. This fixes that.

## Testing Evidence

Yead.

## Why It's Good For The Game

Ensures it works as intended.

## Changelog

:cl:
fix: The Hand properly inherits their besilked haubergeon, once more.
/:cl: