### PR TITLE
[FIX] ward stacking over armor

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_arcyne_ward.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_arcyne_ward.dm
@@ -353,7 +353,7 @@
 	if(has_real_armor(H.wear_mask))
 		new_coverage &= ~(NOSE | MOUTH)
 
-	if(has_real_armor(H.wear_shirt) && has_real_armor(H.wear_armor))
+	if(has_real_armor(H.wear_shirt) || has_real_armor(H.wear_armor))
 		new_coverage &= ~(CHEST | GROIN | VITALS)
 
 	if(has_real_armor(H.wear_armor, ARM_LEFT | ARM_RIGHT) || has_real_armor(H.wear_shirt, ARM_LEFT | ARM_RIGHT))


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Should fix #7773, replicates behaviour on arm coverage with a || instead of && for shirt/armour slots.

## Testing Evidence

Spawned in, cast arcyne ward without armour, hit oneself, ward damaged. Put on armour, armour gets damaged now instead. I also tried restoring a ward after putting armour, the behaviour is correct.

If you put an armour and then pull it out, you still need to regen the arcyne ward to gain coverage in the chest again. I left that behaviour untouched as intended.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bugfix.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: armor should no longer stack with ward
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
