### PR TITLE
Failing contracts no longer clear threat.

### DIFF
--- a/code/modules/roguetown/roguemachine/questing/questing_components.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_components.dm
@@ -147,6 +147,8 @@
 		return
 	var/datum/quest/kill/KQ = Q
 	if(istype(KQ))
+		if(KQ.failed)
+			return
 		KQ.on_guardian_killed()
 		if(!KQ.kills_count_progress)
 			return

--- a/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
@@ -12,6 +12,7 @@
 	/// progress_required to match spawn count. Recovery sets this FALSE — kills are just the gate,
 	/// the parcel delivery is the real progress driver.
 	var/kills_count_progress = TRUE
+	var/failed = FALSE
 	var/hunt_timer_id
 	var/hunt_warn_2m_id
 	var/hunt_warn_30s_id
@@ -59,6 +60,7 @@
 	if(complete)
 		return
 	hunt_timer_id = null
+	failed = TRUE
 	announce_to_bearer("<b>The quarry has slipped away.</b> The writ smolders and crumbles in your grip.")
 	despawn_live_hunt_mobs()
 	var/obj/item/quest_writ/S = quest_scroll

--- a/code/modules/roguetown/roguemachine/questing/types/kill/quest_blockade_defense.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/quest_blockade_defense.dm
@@ -12,7 +12,6 @@
 	var/wave_warn_30s_id
 	var/datum/weakref/wave_landmark_ref
 	var/datum/weakref/blockade_ref
-	var/failed = FALSE
 	/// TRUE after materialize() arms the quest and before the bearer has triggered wave 1
 	/// by entering the landmark's proximity. Prevents double-fire via check_arrival.
 	var/armed = FALSE


### PR DESCRIPTION
## About The Pull Request
Failing contracts no longer clear threat.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
(None)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Failing contracts no longer clear threat.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Failing contracts no longer clear threat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
