### PR TITLE
fixes iron militia warpick scaling

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -798,7 +798,7 @@
 	max_blade_int = 140
 	max_integrity = 400
 	slot_flags = ITEM_SLOT_HIP
-	associated_skill = /datum/skill/labor/mining
+	associated_skill = /datum/skill/combat/axes
 	anvilrepair = /datum/skill/craft/carpentry
 	smeltresult = /obj/item/ingot/iron
 	wdefense = 2

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
@@ -139,7 +139,7 @@
 				beltr = /obj/item/rogueweapon/pick/bronze
 
 			if ("THE MINER'S PICKAXE (Pickaxe)")
-				H.adjust_skillrank_up_to(/datum/skill/labor/mining, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/obj/item/rogueweapon/pick/militia::associated_skill, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				r_hand = /obj/item/rogueweapon/pick/militia
 				gloves = /obj/item/clothing/gloves/roguetown/leather
 				beltr = /obj/item/rogueweapon/pick/bronze


### PR DESCRIPTION
## About The Pull Request
now scales with axes skill instead of mining

## Testing Evidence
tested

## Why It's Good For The Game
should prevent **mining: Legendary™** invasion

## Changelog
:cl:
fix: iron militia warpick now uses axes skill
/:cl:

