### PR TITLE
[FIX] order:repair miracle stripping armor values.

### DIFF
--- a/code/modules/spells/roguetown/acolyte/malum.dm
+++ b/code/modules/spells/roguetown/acolyte/malum.dm
@@ -503,7 +503,8 @@
 		if(cost != 0)
 			to_chat(user, "<font color='purple'>I lose [cost] devotion!</font>")
 		if(I.max_integrity <= I.obj_integrity)
-			I.obj_fix()
+			if(I.obj_broken) // obj_fix() strips armor ratings/class when called on intact armor; only call it on items that were actually broken.
+				I.obj_fix()
 			I.repair_coverage()
 			I.visible_message(span_info("[I] mend together, completely."))
 			continue


### PR DESCRIPTION
## About The Pull Request

Fixes discord bug report, basically order: repair miracle stripped the armor values of any clothing if they weren't broken because obj_fix() was called unconditionally. The proc comments explicitly states not to call it unless the item is actually broken to avoid this.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Spawned locally, hit a coif a couple of times so it's damaged, activate the miracle. Item is repaired and with correct armour values. Before the fix it stripped said values.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bugfix.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Stops repair miracle from malum from stripping armour values.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
