### PR TITLE
why the FUCK was this 99 drams

### DIFF
--- a/modular/Neu_Food/code/cookware/pot.dm
+++ b/modular/Neu_Food/code/cookware/pot.dm
@@ -104,7 +104,7 @@
 	icon_state = "teapot"
 	fill_icon_thresholds = null
 	dropshrink = 1.0
-	volume = 99
+	volume = 120
 
 /obj/item/reagent_containers/glass/bucket/pot/carved/getonmobprop(tag)
 	if(tag)


### PR DESCRIPTION
## About The Pull Request
makes gemcarved teapots hold 120 drams like normal teapots, so you can actually fucking make tea in them

## Testing Evidence
var change

## Why It's Good For The Game
why would you ever make a container hold *99 drams* especially one specifically meant to hold a recipe that is done in 30 dram batches????

## Changelog

:cl:
fix: Gemcarved teapots now hold 120 drams instead of 99
/:cl:
