### PR TITLE
oguhgh... ouuuugh.. - caps untrained armor parrying chance to 35% (from 70%), increases extra stamina usage to 10 (from 5)

### DIFF
--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -240,8 +240,8 @@
 		prob2defend = clamp(prob2defend, 5, 70)
 	var/untrained_armor = FALSE
 	if(!H?.check_armor_skill())
-		prob2defend = clamp(prob2defend, 5, 75)			//Caps your max parry to 75 if using armor you're not trained in. Bad dexerity.
-		drained = drained + 5							//More stamina usage for not being trained in the armor you're using.
+		prob2defend = clamp(prob2defend, 5, 35)			//Caps your max parry to 35 (formerly, 75) if using armor you're not trained in. Bad dexerity.
+		drained = drained + 10							//Increases stamina cost by 10 (formerly, 5). More stamina usage for not being trained in the armor you're using.
 		untrained_armor = TRUE
 
 	//Dual Wielding


### PR DESCRIPTION
## About The Pull Request

* Wearing armor that you're not trained in now reduces your maximum parrying chance to 35%, instead of 70%.
* The added stamina cost for actions undertaken while wearing untrained armor has been doubled, from 5 to 10.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Ensures that the downsides for wearing armor not in your weight class are _very_ tangible and unignorable.
* Maybe.

## Changelog

:cl:
balance: Wearing untrained armor now caps your parrying chance to 35% and increases your stamina cost by +10.
/:cl: