### PR TITLE
Vampire Guard tuneups

### DIFF
--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -465,7 +465,7 @@
 	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp/hoodvamp
 	head = /obj/item/clothing/head/roguetown/witchhat/vamp //EVERY PALLY IN THE KINGDOM ON MA TAIL
 	mask = /obj/item/clothing/mask/rogue/facemask //Nessessary to hide face
-	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/black
+	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/white
 	armor = /obj/item/clothing/cloak/tabard/stabard/vamp
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy //No head armor but good anti-decap armor, intended.

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -26,7 +26,7 @@
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/whipsflails = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT, //No starting weapon specialisations, thusly they uniquely always have this at expert
 		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN, //Despite town MAAs getting this at expert, I want duelist to be better in this
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
@@ -46,14 +46,14 @@
 	..()
 	to_chat(H, span_warning("You are a professional soldier, clad in maille, with years of experience in warfare and battle under your belt, far more than most mortals could claim. Your lord's will be done."))
 	if(H.mind)
-		var/weapons = list("Warhammer & Shield","Sabre & Shield","Axe & Shield","Billhook","Greataxe","Halberd")
+		var/weapons = list("Warhammer & Shield","Sabre & Shield","Arming Sword & Shield","Axe & Shield","Battleaxe","Billhook","Greataxe","Halberd")
 		var/weapon_choice = input(H, "Choose your weapon.", "ARMS TO HERALD THE NITE") as anything in weapons
 		H.set_blindness(0)
 		switch(weapon_choice)
-			if("Warhammer & Shield")
+			if("Warhammer & Shield") //Steel warhammer for armor + skull shatterer
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
-				beltr = /obj/item/rogueweapon/mace/warhammer
+				beltr = /obj/item/rogueweapon/mace/warhammer/steel
 				backl = /obj/item/rogueweapon/shield/iron
 			if("Sabre & Shield")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
@@ -61,11 +61,20 @@
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword/sabre
 				backl = /obj/item/rogueweapon/shield/wood
-			if("Axe & Shield")
+			if("Arming Sword & Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword
+				backl = /obj/item/rogueweapon/shield/wood
+			if("Axe & Shield") //Shield + axe for armor shatterer
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
 				backl = /obj/item/rogueweapon/shield/iron
+			if("Battleaxe") //Hack intent for no shield
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/stoneaxe/battle
 			if("Billhook")
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/rogueweapon/spear/billhook
@@ -74,25 +83,36 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/rogueweapon/halberd
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
-			if("Greataxe")
+			if("Greataxe") //Two tile for no shield + Hack intent
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
-				r_hand = /obj/item/rogueweapon/greataxe
+				r_hand = /obj/item/rogueweapon/greataxe/steel
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
+		//The Spice of Lyfe
+		var/helmets = list(
+		"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+		"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+		"Bascinet Helmet"	= /obj/item/clothing/head/roguetown/helmet/bascinet,
+		"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+		"None"
+		)
+		var/helmchoice = input(H, "Choose your Helm.", "A VISAGE IN THE NITE") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
 	add_verb(H, /mob/proc/haltyell_exhausting) //Soldier gets to halt people
 
 	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp
 	mask = /obj/item/clothing/mask/rogue/facemask/steel //so they don't get sundered in the face
-	head = /obj/item/clothing/head/roguetown/helmet/sallet
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/paalloy
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
-	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
+	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	gloves = /obj/item/clothing/gloves/roguetown/plate/iron //Intended semi-weakspot 4 more unarmed damage
 
-	backr = /obj/item/storage/backpack/rogue/satchel
+	backr = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/flashlight/flare/torch/lantern //we don't need it, but might as well play into the masquerade of a strange foreign retinue
 	backpack_contents = list(
@@ -153,7 +173,7 @@
 
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltr = /obj/item/rogueweapon/stoneaxe/woodcut //demolishing fortifications or setting them up.
-	backl = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/rope/chain = 1
@@ -251,7 +271,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
-	backl = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
@@ -305,14 +325,14 @@
 
 	mask = /obj/item/clothing/mask/rogue/ragmask/black
 	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp
-	head = /obj/item/clothing/head/roguetown/helmet/kettle/minershelm //I can see it getting ditched but sovlful
+	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard //ancient-esc look
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/paalloy
 	pants = /obj/item/clothing/under/roguetown/brigandinelegs
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy //Weaker to chest stabs, intentional, go upgrade your armor
-	backl = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/storage/backpack/rogue/satchel/black
 	backr = /obj/item/twstrap/bombstrap/firebomb
-	gloves = /obj/item/clothing/gloves/roguetown/plate/iron //weaker, intended
+	gloves = /obj/item/clothing/gloves/roguetown/plate //stronger vs footman, intended
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron //Ditto
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
 	belt = /obj/item/storage/belt/rogue/leather //A little bit of difference to other guards
@@ -367,7 +387,7 @@
 	beltl = /obj/item/rogueweapon/scabbard/sword
 	backr = /obj/item/rogueweapon/sword //OG sword
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
-	backl = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/storage/backpack/rogue/satchel/black
 	cloak = /obj/item/clothing/cloak/half/vamp //stays, obligary.
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
@@ -404,7 +424,7 @@
 			if("Flute")
 				l_hand = /obj/item/rogue/instrument/flute //You know what must be done.
 
-// Armored mage, basically vampire magos for the lord. Specialises in faster casting, as a sort of step-in replacement for the grenzelhoftian seige mage. They may be buffed, nerfed or replaced depending how they perform.
+// No-Armor mage, basically vampire magos for the lord. Specialises in faster casting, as a sort of step-in replacement for the grenzelhoftian seige mage. They may be buffed, nerfed or replaced depending how they perform.
 /datum/advclass/vampseigemage
 	name = "Vampiric Battlemage"
 	tutorial = "You were a magos of old, ever since the embrace you've never had more time to practice your persuit of arcayne magicks, let alone revel in your taste for blood; now your master arises once more and your arcayne research shall see fruitation. Your lord's will be done."
@@ -413,11 +433,11 @@
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 2, "utilities" = 6, "ward" = TRUE)
 	category_tags = list(CTAG_VAMPGUARD)
 	subclass_stats = list(
-		STATKEY_INT = 3, //You've had long to study, a lot to study as well
+		STATKEY_INT = 4, //You've had long to study, a lot to study as well
 		STATKEY_STR = -1,
 		STATKEY_WIL = 2,
 		STATKEY_PER = 3,
-		// 7 point statline, mostly put into perception + int, they lack on their baseline speed being slightly higher unlike most mages on top of weaker martal talent
+		// 8 point statline, mostly put into perception + int, they lack on their baseline speed being slightly higher unlike most mages on top of weaker martal talent
 	)
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
@@ -439,22 +459,24 @@
 	H.dna.species.soundpack_m = GLOB.voice_packs[/datum/voicepack/male/wizard] //Every wizzard gotta have the evyl laugh, I don't make the rules, sire.
 	add_verb(H, /mob/proc/haltyell_exhausting) //Halting the charred corpse is too funny, we're keeping it. sovl.
 
+	//UNIQUELY relies on WARDS off-the-bat, vs wretches/advs/mercenaries. Has NO chest armor, or head armor, save for neck. Legs/Feet remain armored by intent.
 	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp
-	head = /obj/item/clothing/head/roguetown/witchhat //EVERY PALLY IN THE KINGDOM ON MA TAIL
-	mask = /obj/item/clothing/mask/rogue/facemask/
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson //Less protection, due to casting ability
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+	head = /obj/item/clothing/head/roguetown/witchhat/vamp //EVERY PALLY IN THE KINGDOM ON MA TAIL
+	mask = /obj/item/clothing/mask/rogue/facemask //Nessessary to hide face
+	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/black
+	armor = /obj/item/clothing/cloak/tabard/stabard/vamp
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy //Makes up for no gloves
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy //No head armor but good anti-decap armor, intended.
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	belt = /obj/item/storage/belt/rogue/leather/battleskirt
 	beltl = /obj/item/book/spellbook
-	backl = /obj/item/storage/backpack/rogue/satchel
-	backr = /obj/item/rogueweapon/woodstaff/implement/greater
+	backl = /obj/item/storage/backpack/rogue/satchel/black
+	backr = choose_implement(H, "greater")
 
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/chalk = 1, //Fast travel/wall runes. If advs can get it, if wretches can, if town can, if bandits can, fuck it the full antag vamp gets it too.
 		/obj/item/rope/chain = 1
 		)
 
@@ -463,6 +485,20 @@
 	color = CLOTHING_WHITE
 	detail_tag = "_quad"
 	detail_color = CLOTHING_RED
+
+/obj/item/clothing/head/roguetown/witchhat/vamp
+	color = CLOTHING_WHITE
+	detail_color = CLOTHING_RED
+
+/obj/item/clothing/cloak/tabard/stabard/hoodvamp
+	name = "silken magos mantle"
+	desc = "A fashionable Mantle in a checkered pattern of white fabrics and red silks, inlined seamlessly within with silks befit for one under a lord with true opulance, not any mere dull-blooded or otherwise, branded with a crest of a forgotten empire."
+	color = CLOTHING_WHITE
+	detail_color = CLOTHING_RED
+	detail_tag = "_spl"
+	icon_state = "guard_hood" // The same as the guard hood however to break it from using the lords colors it has been given its own item path
+	item_state = "guard_hood"
+	body_parts_covered = CHEST
 
 /obj/item/clothing/head/roguetown/duelhat/vamp
 	color = CLOTHING_WHITE

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -26,7 +26,7 @@
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT, //No starting weapon specialisations, thusly they uniquely always have this at expert
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_JOURNEYMAN
 		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN, //Despite town MAAs getting this at expert, I want duelist to be better in this
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
@@ -55,18 +55,23 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/mace/warhammer/steel
 				backl = /obj/item/rogueweapon/shield/iron
+			if("Flail & Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/rogueweapon/flail/sflail
+				backl = /obj/item/rogueweapon/shield/iron
 			if("Sabre & Shield")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword/sabre
-				backl = /obj/item/rogueweapon/shield/wood
+				backl = /obj/item/rogueweapon/shield/iron
 			if("Arming Sword & Shield")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword
-				backl = /obj/item/rogueweapon/shield/wood
+				backl = /obj/item/rogueweapon/shield/iron
 			if("Axe & Shield") //Shield + axe for armor shatterer
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
@@ -222,7 +227,7 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE, //Vampire duelists are okay trackers, less so to account for speed loss.
-		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_EXPERT, //Assassin potental W/ the climbing.
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, //Keeping captives, alive. We're not a lich's army, we have standards.
 	)
 
@@ -290,8 +295,8 @@
 
 // Puglist arson experiment class, replacement for adventurer bombardier. Still despite going all-in they actually perform worst as a puglist class when fighting themselves over just using bombs, this is intended.
 /datum/advclass/vampbomber
-	name = "Vampiric Arsonist"
-	tutorial = "There has been nothing more enchanting in unlyfe than the dance of flames upon an inferno of your alchemical mixes and the taste of blood. Now your master arises once more and your talents shall see use again. Your lord's will be done."
+	name = "Vampiric Fyre-Pugilist"
+	tutorial = "There has been nothing more enchanting in unlyfe than the dance of flames upon an inferno of your alchemical mixes and the taste of blood freshly beaten out of a victim with your bare hands. Now your master arises once more and your talents shall see use again. Your lord's will be done."
 	outfit = /datum/outfit/job/roguetown/other/vampbomber
 	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_ALCHEMY_EXPERT, TRAIT_EXPLOSIVE_SUPPLY, TRAIT_MEDIUMARMOR, TRAIT_CIVILIZEDBARBARIAN,  TRAIT_BOMBER_EXPERT)
 	category_tags = list(CTAG_VAMPGUARD)
@@ -318,7 +323,7 @@
 
 /datum/outfit/job/roguetown/other/vampbomber/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning("There has been nothing more enchanting in unlyfe than the dance of flames upon an inferno of your alchemical mixes and the taste of blood. Now your master arises once more and your talents shall see use again. Your lord's will be done."))
+	to_chat(H, span_warning("There has been nothing more enchanting in unlyfe than the dance of flames upon an inferno of your alchemical mixes and the taste of blood freshly beaten out of a victim with your bare hands. Now your master arises once more and your talents shall see use again. Your lord's will be done."))
 	H.set_blindness(0)
 
 	add_verb(H, /mob/proc/haltyell_exhausting) //Halting the charred corpse is too funny, we're keeping it. sovl.
@@ -461,7 +466,7 @@
 	H.dna.species.soundpack_m = GLOB.voice_packs[/datum/voicepack/male/wizard] //Every wizzard gotta have the evyl laugh, I don't make the rules, sire.
 	add_verb(H, /mob/proc/haltyell_exhausting) //Halting the charred corpse is too funny, we're keeping it. sovl.
 
-	//UNIQUELY relies on WARDS off-the-bat, vs wretches/advs/mercenaries. Has NO chest armor, or head armor, save for neck. Legs/Feet remain armored by intent.
+	//UNIQUELY relies on WARDS off-the-bat, vs wretches/advs/mercenaries. Has NO chest armor, or head armor, save for neck. Legs/Feet remain decently armored by intent. Go for their arms instead.
 	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp/hoodvamp
 	head = /obj/item/clothing/head/roguetown/witchhat/vamp //EVERY PALLY IN THE KINGDOM ON MA TAIL
 	mask = /obj/item/clothing/mask/rogue/facemask //Nessessary to hide face

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -425,7 +425,7 @@
 				l_hand = /obj/item/rogue/instrument/flute //You know what must be done.
 
 // No-Armor mage, basically vampire magos for the lord. Specialises in faster casting, as a sort of step-in replacement for the grenzelhoftian seige mage. They may be buffed, nerfed or replaced depending how they perform.
-// Despite decent wards, stabbing them w/silver should make them fall over to pain pretty fast or straight dust them on the spot after a few critical sunders.
+// Despite decent wards, stabbing them w/silver should make them fall over to pain pretty fast or straight dust them on the spot after a few critical sunders. Expect them to lose a fair bit of blue w/ reliance on wards + spam casting.
 /datum/advclass/vampseigemage
 	name = "Vampiric Battlemage"
 	tutorial = "You were a magos of old, ever since the embrace you've never had more time to practice your persuit of arcayne magicks, let alone revel in your taste for blood; now your master arises once more and your arcayne research shall see fruitation. Your lord's will be done."
@@ -462,7 +462,7 @@
 	add_verb(H, /mob/proc/haltyell_exhausting) //Halting the charred corpse is too funny, we're keeping it. sovl.
 
 	//UNIQUELY relies on WARDS off-the-bat, vs wretches/advs/mercenaries. Has NO chest armor, or head armor, save for neck. Legs/Feet remain armored by intent.
-	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp
+	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp/hoodvamp
 	head = /obj/item/clothing/head/roguetown/witchhat/vamp //EVERY PALLY IN THE KINGDOM ON MA TAIL
 	mask = /obj/item/clothing/mask/rogue/facemask //Nessessary to hide face
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/black

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -46,7 +46,7 @@
 	..()
 	to_chat(H, span_warning("You are a professional soldier, clad in maille, with years of experience in warfare and battle under your belt, far more than most mortals could claim. Your lord's will be done."))
 	if(H.mind)
-		var/weapons = list("Warhammer & Shield","Sabre & Shield","Arming Sword & Shield","Axe & Shield","Battleaxe","Billhook","Greataxe","Halberd")
+		var/weapons = list("Warhammer & Shield","Sabre & Shield","Longsword & Shield","Axe & Shield","Battleaxe","Billhook","Greataxe","Halberd")
 		var/weapon_choice = input(H, "Choose your weapon.", "ARMS TO HERALD THE NITE") as anything in weapons
 		H.set_blindness(0)
 		switch(weapon_choice)
@@ -66,10 +66,10 @@
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword/sabre
 				backl = /obj/item/rogueweapon/shield/iron
-			if("Arming Sword & Shield")
+			if("Longsword & Shield")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
-				beltr = /obj/item/rogueweapon/scabbard/sword
+				beltr = /obj/item/rogueweapon/sword/long
 				r_hand = /obj/item/rogueweapon/sword
 				backl = /obj/item/rogueweapon/shield/iron
 			if("Axe & Shield") //Shield + axe for armor shatterer

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -425,6 +425,7 @@
 				l_hand = /obj/item/rogue/instrument/flute //You know what must be done.
 
 // No-Armor mage, basically vampire magos for the lord. Specialises in faster casting, as a sort of step-in replacement for the grenzelhoftian seige mage. They may be buffed, nerfed or replaced depending how they perform.
+// Despite decent wards, stabbing them w/silver should make them fall over to pain pretty fast or straight dust them on the spot after a few critical sunders.
 /datum/advclass/vampseigemage
 	name = "Vampiric Battlemage"
 	tutorial = "You were a magos of old, ever since the embrace you've never had more time to practice your persuit of arcayne magicks, let alone revel in your taste for blood; now your master arises once more and your arcayne research shall see fruitation. Your lord's will be done."
@@ -435,15 +436,16 @@
 	subclass_stats = list(
 		STATKEY_INT = 4, //You've had long to study, a lot to study as well
 		STATKEY_STR = -1,
-		STATKEY_WIL = 2,
+		STATKEY_WIL = 2, //1 less than Grenzel magos
 		STATKEY_PER = 3,
 		// 8 point statline, mostly put into perception + int, they lack on their baseline speed being slightly higher unlike most mages on top of weaker martal talent
+		// Yeah vampire mages are pretty insanely strong with some clan potencies but rule of cool honestly.
 	)
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
-		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER, //You've had a long, time to practice
+		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE, //Weaker vs grapples, compared to everyone else
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
@@ -466,7 +468,6 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/black
 	armor = /obj/item/clothing/cloak/tabard/stabard/vamp
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy //Makes up for no gloves
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy //No head armor but good anti-decap armor, intended.
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	belt = /obj/item/storage/belt/rogue/leather/battleskirt

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -328,7 +328,6 @@
 
 	add_verb(H, /mob/proc/haltyell_exhausting) //Halting the charred corpse is too funny, we're keeping it. sovl.
 
-	mask = /obj/item/clothing/mask/rogue/ragmask/black
 	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard //ancient-esc look
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
@@ -469,7 +468,7 @@
 	//UNIQUELY relies on WARDS off-the-bat, vs wretches/advs/mercenaries. Has NO chest armor, or head armor, save for neck. Legs/Feet remain decently armored by intent. Go for their arms instead.
 	cloak = /obj/item/clothing/cloak/tabard/stabard/hoodvamp
 	head = /obj/item/clothing/head/roguetown/witchhat/vamp //EVERY PALLY IN THE KINGDOM ON MA TAIL
-	mask = /obj/item/clothing/mask/rogue/facemask //Nessessary to hide face
+	mask = /obj/item/clothing/mask/rogue/ragmask/black
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/white
 	armor = /obj/item/clothing/cloak/tabard/stabard/vamp
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -467,7 +467,7 @@
 	add_verb(H, /mob/proc/haltyell_exhausting) //Halting the charred corpse is too funny, we're keeping it. sovl.
 
 	//UNIQUELY relies on WARDS off-the-bat, vs wretches/advs/mercenaries. Has NO chest armor, or head armor, save for neck. Legs/Feet remain decently armored by intent. Go for their arms instead.
-	cloak = /obj/item/clothing/cloak/tabard/stabard/vamp/hoodvamp
+	cloak = /obj/item/clothing/cloak/tabard/stabard/hoodvamp
 	head = /obj/item/clothing/head/roguetown/witchhat/vamp //EVERY PALLY IN THE KINGDOM ON MA TAIL
 	mask = /obj/item/clothing/mask/rogue/facemask //Nessessary to hide face
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/white

--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -26,7 +26,7 @@
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/whipsflails = SKILL_LEVEL_JOURNEYMAN
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN, //Despite town MAAs getting this at expert, I want duelist to be better in this
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,


### PR DESCRIPTION
## About The Pull Request

Vampire magos loses its chest armor + drops a level in arcayne in exchange for:
- new look, its much more stylish than before w/ less chest/head armor:
<img width="119" height="185" alt="new vampyre magos" src="https://github.com/user-attachments/assets/8f69723e-7357-496c-8f7e-af4c581999bd" />

- ability to pick greater staff choice
- +1 to int, in exchange for -1 arcayne level
- gets a chalk because frankly with enchanter virtue existing I'm tired chief, they can have their mage gameplay loop.
- this'll hopefully just be used for leyline teleportation, forcerunes and w/e, but even if they spam out enchants you can't enchant the vlord set. It'll just be a waste of time they could get victims.
- during drinking blood they're far more vulnerable than other vampires since they have to dispell the ward to drink, thusly losing their arm/head/chest armor.
- the previous vamp magos set was ugly as sin.
- not featured (they also lose iron mask -> black rag mask)

---

Vampire footmen have recieved:
- A few new weaponry choices (arming sword w/shield, steel greataxe vs the iron one before, battleaxe w/out shield)
- A flail + shield choice, finally
- All choices now have iron shields, instead of wooden on the warhammer + sabre.
- All weapon choices are steel varients
- Ancient chain gloves -> Iron plate gauntlets for weaker hand armor but higher unarmed punching
- You can pick from MAA choice of helmets MINUS the skullcap.

(This should encourage playing as one a little bit more w/the bite changes making them no longer clutch as hard on combat-drinking.)

Vampire Arsonist has recieved
- Iron plate gloves -> Steel grade plate gloves
- A heavy guard helmet vs the kettle miner one before
- Rename `Arsonist` -> `Fyre Pugllist` more in line with the firebomber/fistfighter hybrid this class is.

Duelist
Apprentice -> Expert Sneaking (Now that light-step stab is less suffering to fight) this should give them some assassination potental w/ their current expert climbing.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

It builds (it did let me fix that shit RQ)
It works ingame

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

- Vampire mages should probably just have the gameplay loop w/ chalks if every other mage gets it, genuinely yes. Especally since the enchanter skilled virtue is still a thing that lets anyone do that.
- Removing their chest armor layers proper and making them rely on wards more w/less arcayne skill off-the-bat should make vampire mages a little less insanely overbaring to fight.
- Using leyline runes to move vamps around the map is actually kind of cool when you can draw runes for this.
- Vampire Footmen were a bit of an experiment gone wrong being too weak in their starting weaponry to really make an impact lategame. They still have upgrade room for their armor kit as intended + Gilbranze peices w/ iron/steel
- Vampire Duelist could use some love.

- I don't think anyone has genuinely gone Arsonist as a vampire because it sounded like a terrible class, no more! It should stand out and be a little more present then before.
- Less reilance on a forgemaster for a decent shield + weapon as a footman is good, cause ATM bowmen/mages/arsonists were better than half of your weapon choices off-the-bat
- IDK why you'd want an arming sword by intent but I guess have one?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: redone most vamp guard subclasses again.
balance: vampire magos rely on wards instead of starting w/ chest/head/arm armor
fix: vampire magos could not pick a staff unlike every single other class that could
balance: vamp magos gets a chalk now
balance: vamp footmen have more weapon choices + iron shields always + steel weapon varients
balance: vamp duelist apprentice -> expert sneak in line w/ their climbing skill
balance: vamp arsonist has a heavy helm vs its miner helm before + different class name now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
