### PR TITLE
[hotfix] mimic trinket restoration

### DIFF
--- a/code/game/objects/items/rogueitems/magic/mageitems.dm
+++ b/code/game/objects/items/rogueitems/magic/mageitems.dm
@@ -200,7 +200,6 @@
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "mimic_trinket"
 	possible_item_intents = list(/datum/intent/use)
-	dropshrink = 0.6
 	var/duration = 10 MINUTES
 	var/oldicon
 	var/oldicon_state


### PR DESCRIPTION
## About The Pull Request
mimic trinket had a dropshrink applied, which completely broke its functionality of mimicking objects. this just removes that

## Testing Evidence
didn't

## Why It's Good For The Game
funny

