### PR TITLE
Adds the Ornate Silk Dress to the Triumph loadout menu

### DIFF
--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -117,6 +117,12 @@
 	triumph_cost = 3
 	sort_category = "Triumphs"
 
+/datum/loadout_item/triumph_ornatesilkdress
+	name = "Ornate Silk Dress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/steward
+	triumph_cost = 3
+	sort_category = "Triumphs"
+
 // -5 TRI
 /datum/loadout_item/triumph_shortsatchel
 	name = "Short Satchel"


### PR DESCRIPTION
## About The Pull Request

Adds the Ornate Silk Dress to the Triumph loadout menu.

## Testing Evidence

Do people actually use this section? I swear, half the time it just says something like "It works"
Anyways:
<img width="780" height="600" alt="aJ63W6iHwm" src="https://github.com/user-attachments/assets/fdb8bfa6-21fc-4a6e-aed5-11b6617a7e71" />


## Why It's Good For The Game

It looks good, and some people want it to be available even when there's no tailor or anyone else capable of making it around (which there often isn't).

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added the Ornate Silk Dress to the Triumph loadout menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
