### PR TITLE
[Maint] RE: Masks & Goggles

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -913,6 +913,8 @@
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	sewrepair = TRUE
+	salvage_result = /obj/item/natural/hide/cured
+	salvage_amount = 1
 
 /obj/item/clothing/mask/rogue/leather/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, 'sound/foley/equip/rummaging-03.ogg', null, (UPD_HEAD|UPD_MASK))	//Standard mask


### PR DESCRIPTION
## About The Pull Request

Fix for #7850 

Leather masks have no salvage, which is causing the DM Tester to go hogwild. This fixes that.

## Testing Evidence

Compiles. Check the changed files, just something that's missing from that PR that our tsundere of a checker is a strictler about.

## Why It's Good For The Game

I suffered the same problem and learned what causes it, so just covering for my fellow collab. It's green.

## Changelog
:cl:
fix: fixed red thing to become green thing
/:cl: