### PR TITLE
Muse's Grace - Fluff bardic inspiration song (Geeves helped)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -293,6 +293,7 @@
 #define TRAIT_EQUESTRIAN "Equestrian"
 #define TRAIT_REGROW_LIMBS "Regrow Limbs"
 #define TRAIT_LEVY "Azurean Militia"
+#define TRAIT_MUSES_GRACE	"Muses Grace"
 // ARMOR / CLOTHING GIVEN TRAITS (GIVEN BY WEARING CLOTHES/ARMOR PIECES)
 #define TRAIT_MONK_ROBE	"Holy Vestatures"
 #define TRAIT_BLACKOAK "Heritage Vision"
@@ -607,6 +608,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_EDIT_DESCRIPTORS = span_info("I can change my appearance at a magic mirror in a thorough manner."),
 	TRAIT_DUSTRUNNER = span_info("I run dust for the Thieves' Guild. Those in the trade know how to spot one of their own."),
 	TRAIT_REGROW_LIMBS = span_info("I can regrow my limbs in my sleep, but doing so will make me hungry."),
+	TRAIT_MUSES_GRACE = span_info("My steps are light and swift. I make less noise while sneaking and wearing armor, and can sneak much quicker."),
 ))
 
 // trait accessor defines

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -608,7 +608,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_EDIT_DESCRIPTORS = span_info("I can change my appearance at a magic mirror in a thorough manner."),
 	TRAIT_DUSTRUNNER = span_info("I run dust for the Thieves' Guild. Those in the trade know how to spot one of their own."),
 	TRAIT_REGROW_LIMBS = span_info("I can regrow my limbs in my sleep, but doing so will make me hungry."),
-	TRAIT_MUSES_GRACE = span_info("My steps are light and swift. I make less noise while sneaking and wearing armor, and can sneak much quicker."),
+	TRAIT_MUSES_GRACE = span_info("I feel a sudden and powerful urge to break out into song."),
 ))
 
 // trait accessor defines

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -127,14 +127,18 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			client.dsay(message)
 		return
 
-	if(message_mode == MODE_SING)
+	// autopunctuation
+	if(!client?.prefs?.no_autopunctuate)
+		message = autopunct_bare(message)
+
+	if(message_mode == MODE_SING || HAS_TRAIT(src, TRAIT_MUSES_GRACE))
 	#if DM_VERSION < 513
 		var/randomnote = "~"
 	#else
 		var/randomnote = pick("&#9835;", "&#9834;", "&#9836;")
 	#endif
 		spans |= SPAN_SINGING
-		message = "[randomnote] [message] [randomnote]"
+		message = "[randomnote] [capitalize(message)] [randomnote]"
 
 	if(stat == DEAD)
 		say_dead(original_message)
@@ -245,10 +249,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		message = uppertext(message)
 	if(!message)
 		return
-
-	// autopunctuation
-	if(!client?.prefs?.no_autopunctuate)
-		message = autopunct_bare(message)
 
 	if(D.flags & SIGNLANG)
 		send_speech_sign(message, message_range, src, bubble_type, spans, language, message_mode, original_message)
@@ -666,7 +666,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		. = "stammers"
 	else if(derpspeech)
 		. = "gibbers"
-	else if(message_mode == MODE_SING)
+	else if(message_mode == MODE_SING || HAS_TRAIT(src, TRAIT_MUSES_GRACE))
 		. = verb_sing
 	else
 		. = ..()

--- a/code/modules/spells/spell_types/bardic/muses_grace.dm
+++ b/code/modules/spells/spell_types/bardic/muses_grace.dm
@@ -1,0 +1,31 @@
+/datum/action/cooldown/spell/song/muses_grace
+	name = "Muse's Grace"
+	desc = "A gentle melody, compelling audience members to sing."
+	button_icon_state = "melody_t1_base"
+	invocations = list("plays a graceful, gentle tune. The world feels compelled to respond in song.")
+	song_effect = /datum/status_effect/buff/playing_melody/muses_grace
+
+/datum/status_effect/buff/playing_melody/muses_grace
+	effect = /obj/effect/temp_visual/songs/inspiration_bardsongt1
+	buff_to_apply = /datum/status_effect/buff/song/muses_grace
+
+
+/atom/movable/screen/alert/status_effect/buff/song/muses_grace
+	name = "Muse's Grace"
+	desc = "A Muse's Grace commands words into melody!"
+	icon_state = "buff"
+
+/datum/status_effect/buff/song/muses_grace
+	id = "musesgrace"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/song/muses_grace
+	duration = 15 SECONDS
+
+/datum/status_effect/buff/song/muses_grace/on_apply()
+	. = ..()
+	to_chat(owner, span_warning("As that music plays I feel a very powerful compulsion to... Sing?"))
+	ADD_TRAIT(owner, TRAIT_MUSES_GRACE, id)
+
+/datum/status_effect/buff/song/muses_grace/on_remove()
+	. = ..()
+	to_chat(owner, span_warning("The compulsion to sing suddenly ends, I feel like I can speak without melody again."))
+	REMOVE_TRAIT(owner, TRAIT_MUSES_GRACE, id)

--- a/code/modules/spells/spell_types/bardic/songbook.dm
+++ b/code/modules/spells/spell_types/bardic/songbook.dm
@@ -13,6 +13,8 @@ GLOBAL_LIST_INIT(learnable_songs, list(
 	/datum/action/cooldown/spell/song/discordant_dirge,
 	/datum/action/cooldown/spell/song/enervating_elegy,
 	/datum/action/cooldown/spell/song/rattling_requiem,
+	// Fluff Songs
+	/datum/action/cooldown/spell/song/muses_grace
 ))
 
 /mob/living/carbon/human/proc/open_songbook()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3125,6 +3125,7 @@
 #include "code\modules\spells\spell_types\bardic\inspiration.dm"
 #include "code\modules\spells\spell_types\bardic\intellectual_interval.dm"
 #include "code\modules\spells\spell_types\bardic\melody-dirges.dm"
+#include "code\modules\spells\spell_types\bardic\muses_grace.dm"
 #include "code\modules\spells\spell_types\bardic\rattling_requiem.dm"
 #include "code\modules\spells\spell_types\bardic\recovery_song.dm"
 #include "code\modules\spells\spell_types\bardic\rejuvenation_song.dm"


### PR DESCRIPTION
## About The Pull Request

Introduces a new bardic inspiration song to the list, called "Muse's Grace," a purely roleplay option that does not provide any stat buffs or debuffs, instead it forces the audience members to use the singing prompt already in the game (say %)

Inspired by the game Stray Gods, where the main character, Grace, a Muse, has this ability. If you don't like the pun bite me.

Had to move the punctuation code that adds periods and capitalisation of 'I' to before the code for the singing, so that it actually procs. Furthermore made it so when you sing it auto capitalises the first word, which it didn't before, so this is also technically a fix.

A lot of kodus goes to Geeves for helping me through this entire PR. If you need to blame someone for a fault in the code please refer to her. :)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9c5c6ac6-fbbf-4732-9344-72be3339114b" />
The choice being available.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3a4702f0-e88f-4446-b0e7-796dd1f75575" />
The inspiration showing correctly.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4e36dc88-948f-4a33-a5f1-1490e6400b50" />
The inspiration working.

<img width="934" height="77" alt="image" src="https://github.com/user-attachments/assets/79846f79-8998-4e99-93fd-f48d58333f07" />

Autopunctuation working, didn't start with capitalisation nor with a period.


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

It adds a cute little ability for bards, spellsingers, and anyone else who has access to bardic inspiration, adding in a new avenue for roleplay through magical abilities. Not every bardic inspiration needs to be about stats, afterall.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added a new fluff bardic inspiration ability called Muse's Grace, forcing audience members to sing while it plays.
fix: Fixes capitalisation and punctuation while singing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
