### PR TITLE
fix lover's ruin double checks for items with ingest intent

### DIFF
--- a/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -169,15 +169,15 @@
 			if(thing.reagents.holder_full() || (user.devotion.devotion - fatigue_used <= 0))
 				break
 
-			var/water_qty = max(1, holy_skill) + 1
+			var/water_qty = max(2, holy_skill*2)
 			var/list/water_contents = list(/datum/reagent/medicine/loversruin = water_qty)
 			var/datum/reagents/reagents_to_add = new()
 			reagents_to_add.add_reagent_list(water_contents)
-			reagents_to_add.trans_to(thing, reagents_to_add.total_volume, transfered_by = user, method = INGEST)
+			reagents_to_add.trans_to(thing, reagents_to_add.total_volume, transfered_by = user)
 
 			fatigue_spent += fatigue_used
 			user.stamina_add(fatigue_used)
-			user.devotion?.update_devotion(-1.0)
+			user.devotion?.update_devotion(-1.5)
 
 			if(prob(80))
 				playsound(user, 'sound/items/fillcup.ogg', 55, TRUE)


### PR DESCRIPTION
## About The Pull Request

Fixes Lover's ruin item check like i fixed orison's item check

## Testing Evidence

few line changes, it shouldn't blow up

## Why It's Good For The Game

it produced double amount in items that have the ingest intents, barrels doesn't have intents

## Changelog

:cl:
qol: double lover's ruin production rate(effectively changes nothing because people never use lover's ruin on barrel, they always were playing with the double production bugged check), increase devotion cost by 50% to compensate
/:cl:

