### PR TITLE
ignition now leaves an admin log

### DIFF
--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -75,6 +75,7 @@
 			return TRUE
 		spelltarget.adjust_fire_stacks(2)
 		spelltarget.ignite_mob()
+		log_combat(owner, spelltarget, "ignited", addition="with the miracle [name]")
 		return TRUE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -128,7 +129,7 @@
 	.=..()
 
 /datum/status_effect/buff/astrata_gaze/on_apply()
-	// Reset base values because the miracle can 
+	// Reset base values because the miracle can
 	// now actually be recast at high enough skill and during day time
 	// This is a safeguard because buff code makes my head hurt
 	var/per_bonus = 0
@@ -311,7 +312,7 @@
 	if(!target || !target.Enter(owner) || is_type_in_list(target, turf_blacklist))
 		to_chat(owner, span_warning("This turf can't be on fiyaaaah! (It's blocked sire.)"))
 		return FALSE
-	
+
 	new /obj/machinery/light/rogue/campfire/miracle_pyre(target)
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

ignition now leaves an admin log

## Testing Evidence

works, forgot to take a pic

## Why It's Good For The Game

i got straight-up no esc'd by an astratan templar and it left no logs lmao

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
admin: astratan ignition now leaves logs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
