### PR TITLE
arming sword + shield loadout for knight-errant

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -454,13 +454,19 @@
 	H.dna.species.soundpack_m = GLOB.voice_packs[/datum/voicepack/male/knight]
 	H.set_blindness(0)
 	if(H.mind)
-		var/weapons = list("Longsword","Mace + Shield","Flail + Shield","Lance + Shield","Billhook","Battle Axe","Greataxe","Greatflail")
+		var/weapons = list("Longsword","Arming Sword + Shield","Mace + Shield","Flail + Shield","Lance + Shield","Billhook","Battle Axe","Greataxe","Greatflail")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Longsword")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				beltr = /obj/item/rogueweapon/sword/long
 				r_hand = /obj/item/rogueweapon/scabbard/sword/noble
+			if("Arming Sword + Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/sword
+				r_hand = /obj/item/rogueweapon/scabbard/sword/noble
+				backr = /obj/item/rogueweapon/shield/tower/metal
 			if("Mace + Shield")
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)


### PR DESCRIPTION
## About The Pull Request
adds an arming sword + shield loadout for knight-errant. worse (?) sword than the longsword-only loadout but you get a shield to go with it

## Testing Evidence
<img width="357" height="293" alt="image" src="https://github.com/user-attachments/assets/55772840-7c09-4c21-a7d2-b6f899d68fbb" />
<img width="291" height="490" alt="image" src="https://github.com/user-attachments/assets/b3551257-c13a-445e-bfec-3b7c78007ace" />


## Why It's Good For The Game
are you telling me our knight offrole can't larp as sword+shield users? unacceptable. even if i hate arming swords, it's better than trying to one-hand a lance for some reason

## Changelog

:cl:
add: Knight-errant can now pick an arming sword + shield weapon set
/:cl: