### PR TITLE
nerf  blackblood to the ground

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -226,7 +226,7 @@
 
 	if(HAS_TRAIT(src, TRAIT_CRITICAL_RESISTANCE))	// We apply the major multipliers first.
 		amt *= CRIT_RESISTANCE_EFFECTIVE_BLEEDRATE
-	else if(HAS_TRAIT(src, TRAIT_BLOOD_RESISTANCE) || HAS_TRAIT(src, TRAIT_BLACKBLOOD))
+	else if(HAS_TRAIT(src, TRAIT_BLOOD_RESISTANCE))
 		amt *= BLOOD_RESISTANCE_EFFECTIVE_BLEEDRATE
 
 	//For each CON above 10, we bleed slower.

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -56,16 +56,6 @@
 					if(!istype(wound, /datum/wound/slash/incision))
 						wound.heal_wound(0.4)
 
-	if(!stat && HAS_TRAIT(src, TRAIT_BLACKBLOOD) && !HAS_TRAIT(src, TRAIT_PARALYSIS))
-		if(src.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || src.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
-			return
-		handle_wounds()
-		if(blood_volume > BLOOD_VOLUME_SURVIVE && nutrition > NUTRITION_LEVEL_STARVING) // only hunger dictates here, thirst isn't relevant for regen but it is penalized too. Furthermore, after tests, lmfao, starving mid combat is a death sentence, holy shit.
-			for(var/datum/wound/wound as anything in get_wounds())
-				if(!istype(wound, /datum/wound/slash/incision))
-					wound.heal_wound(1.2)
-					nutrition = max(0, nutrition - (NUTRITION_LEVEL_FULL * 0.005)) // drains 0.5% of your hunger per tick of wound healed. After some testing, holy shit, this drains fast, for being percent-based. Thirst drain was too much to slap on top. Maybe it'll be back after the bite adjustments get polished a lil more.
-
 	if(!stat && HAS_TRAIT(src, TRAIT_LYCANRESILENCE) && !HAS_TRAIT(src, TRAIT_PARALYSIS))
 		if(src.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || src.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
 			return


### PR DESCRIPTION
## About The Pull Request
removed blood res and passive regeneration (regen from consuming food is kept) from newly added blackblood virtue https://github.com/Azure-Peak/Azure-Peak/pull/7650

## Testing Evidence
tested

## Why It's Good For The Game
too op for a virtue

## Changelog
:cl:
balance: blackblood virtue lost bloodresistance
balance: blackblood virtue lost passive regeneration
/:cl:
