### PR TITLE
Remove Chaos Storm, Voidtouched Enchantment, nerf Phoenix Guard

### DIFF
--- a/code/datums/magic_items/greater_items/greater.dm
+++ b/code/datums/magic_items/greater_items/greater.dm
@@ -1,3 +1,5 @@
+#define PHOENIX_GUARD_COOLDOWN 60 SECONDS
+
 ///T3 Enchantmentsdatum
 /datum/magic_item/greater/lifesteal
 	name = "life steal"
@@ -93,7 +95,7 @@
 	var/last_used
 
 /datum/magic_item/greater/phoenixguard/on_hit_response(var/obj/item/I, var/mob/living/carbon/human/owner, var/mob/living/carbon/human/attacker)
-	if(world.time < src.last_used + 20 SECONDS)
+	if(world.time < src.last_used + PHOENIX_GUARD_COOLDOWN)
 		return
 	if(isliving(attacker) && attacker != owner)
 		attacker.adjust_fire_stacks(5)
@@ -252,3 +254,5 @@
 		if(possible_turfs.len)
 			L.forceMove(pick(possible_turfs))
 		last_used[source] = world.time
+
+#undef PHOENIX_GUARD_COOLDOWN

--- a/code/datums/magic_items/mythical_items/mythic.dm
+++ b/code/datums/magic_items/mythical_items/mythic.dm
@@ -1,7 +1,6 @@
 #define INFERNAL_FLAME_COOLDOWN 1 MINUTES
 #define FREEZING_COOLDOWN 20 SECONDS
 #define REWIND_COOLDOWN 20 SECONDS
-#define CHAOS_COOLDOWN 10 SECONDS
 
 //T4 Enchantments
 /datum/magic_item/mythic/infernalflame
@@ -141,44 +140,6 @@
 		src.last_used = world.time
 		active_item = FALSE
 
-
-/datum/magic_item/mythic/chaos_storm
-	name = "chaos storm"
-	description = "It crackles with unpredictable chaotic energy."
-	glow_color = "#9400D3"
-	var/last_used
-
-/datum/magic_item/mythic/chaos_storm/on_hit(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
-	.=..()
-	if(!proximity_flag)
-		return
-	if(world.time < (src.last_used + CHAOS_COOLDOWN))
-		return
-	if(isliving(target))
-		var/mob/living/L = target
-		switch(rand(1,5))
-			if(1)
-				L.apply_damage(15, BURN)
-				L.adjust_fire_stacks(5)
-				L.ignite_mob()
-				to_chat(L, span_warning("Chaotic flames engulf you!"))
-			if(2)
-				L.apply_damage(10, BRUTE)
-				L.Knockdown(20)
-				L.drop_all_held_items()
-				to_chat(L, span_warning("Chaotic force slams into you!"))
-			if(3)
-				L.electrocute_act(12, source, 1)
-				to_chat(L, span_warning("Chaotic lightning courses through you!"))
-			if(4)
-				L.OffBalance(2.5 SECONDS)
-				to_chat(L, span_warning("Chaotic energy disrupts your coordination!"))
-			if(5)
-				L.confused += 2 SECONDS
-				to_chat(L, span_warning("Chaotic energy scrambles your thoughts!"))
-		src.last_used = world.time
-
 #undef INFERNAL_FLAME_COOLDOWN
 #undef FREEZING_COOLDOWN
 #undef REWIND_COOLDOWN
-#undef CHAOS_COOLDOWN

--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -256,23 +256,6 @@ T1 Enchantments below here*/
 	else
 		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
 
-/obj/item/enchantmentscroll/greater/voidtouched
-	name = "enchanting scroll of voidtouched"
-	desc = "A scroll imbued with an enchantment of voidtouched. This enchantment pulls foes briefly into the void, and spits them out nearby."
-	component = /datum/magic_item/greater/void
-
-/obj/item/enchantmentscroll/greater/voidtouched/attack_obj(obj/item/O, mob/living/user)
-	if(!..())
-		return
-	if(istype(O,/obj/item/rogueweapon))
-		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
-		var/magiceffect= new component
-		O.AddComponent(/datum/component/magic_item, magiceffect)
-		O.name += " of voidtouched"
-		qdel(src)
-	else
-		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
-
 /obj/item/enchantmentscroll/greater/frostveil
 	name = "enchanting scroll of lesser freezing"
 	desc = "A scroll imbued with an enchantment of lesser freezing. Slows enemies that hit you when applied on armor, or enemies that you hit when applied on weapons."
@@ -418,23 +401,6 @@ T1 Enchantments below here*/
 		var/magiceffect= new component
 		O.AddComponent(/datum/component/magic_item, magiceffect)
 		O.name += " of briar's curse"
-		qdel(src)
-	else
-		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
-
-/obj/item/enchantmentscroll/mythic/chaos_storm
-	name = "enchanting scroll of chaos storm"
-	desc = "A scroll imbued with an enchantment of chaos. A weapon with this enchantment causes random effects."
-	component = /datum/magic_item/mythic/chaos_storm
-
-/obj/item/enchantmentscroll/mythic/chaos_storm/attack_obj(obj/item/O, mob/living/user)
-	if(!..())
-		return
-	if(istype(O,/obj/item/rogueweapon))
-		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
-		var/magiceffect= new component
-		O.AddComponent(/datum/component/magic_item, magiceffect)
-		O.name += " of chaos storm"
 		qdel(src)
 	else
 		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))

--- a/code/modules/roguetown/roguejobs/mages/rituals/enchanting.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/enchanting.dm
@@ -8,8 +8,6 @@
  *   T3: 1x T3 realm mat + cinnabar + scroll + leyline shard
  *   T4: 1x T4 realm mat + cinnabar + scroll + leyline shard
  *
- * Void-themed enchantments (Voidtouched, Chaos Storm) use voidstone
- * instead of a realm mat.
  *
  * Rune requirements:
  *   Imbuement Array — T1 through T3 enchantments.
@@ -137,13 +135,6 @@
 	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/leyline = 1, /obj/item/magic/elemental/fragment = 1)
 	result_atoms = list(/obj/item/enchantmentscroll/greater/lightning)
 
-/datum/runeritual/enchanting/voidtouched
-	name = "voidtouched"
-	desc = "Teleports the target nearby."
-	blacklisted = FALSE
-	tier = 3
-	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/leyline = 1, /obj/item/magic/voidstone = 1)
-	result_atoms = list(/obj/item/enchantmentscroll/greater/voidtouched)
 
 /datum/runeritual/enchanting/frostveil
 	name = "Lesser Freezing"
@@ -202,11 +193,3 @@
 	tier = 4
 	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/leyline = 1, /obj/item/magic/fae/sylvanessence = 1)
 	result_atoms = list(/obj/item/enchantmentscroll/mythic/rewind)
-
-/datum/runeritual/enchanting/chaosstorm
-	name = "Chaos Storm"
-	desc = "Causes random powerful effects."
-	blacklisted = FALSE
-	tier = 4
-	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/leyline = 1, /obj/item/magic/voidstone = 1)
-	result_atoms = list(/obj/item/enchantmentscroll/mythic/chaos_storm)


### PR DESCRIPTION
## About The Pull Request
As per title

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Chaos Storm is the last high frequency hard stun enchantments that doesn't really suit our balance and it is time it is gone.

Voidtouched is also removed because teleporting you randomly is funny for one person.

Phoenix Guard CD has been nerfed to 60 seconds instead of 20 seconds CBT.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Removed Chaos Storm Enchantment.
del: Removed Voidtouched Enchantment.
balance: Phoenix Guard now have a 60 seconds instead of 20 seconds cooldown so you can't just keep setting your opponennt on fire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
