### PR TITLE
Makes Carp Statues visible again.

### DIFF
--- a/code/game/objects/items/rogueitems/gem_items.dm
+++ b/code/game/objects/items/rogueitems/gem_items.dm
@@ -237,7 +237,8 @@
 /obj/item/carvedgem/rose/carp
 	name = "rosestone carp statue"
 	desc = "A medium-sized carving of a carp made out of rosestone. The fish have been selectively bred by Eorans to bring out beautiful patterns in their scales, but have become invasive in some regions due to carelessness."
-	icon_state = "carp_rose"
+	icon_state = "fish_rose"
+	dropshrink = 1.5
 	grid_height = 64
 	grid_width = 64
 


### PR DESCRIPTION
## About The Pull Request


Fix for #7831

Also makes them 50% bigger than fish statues using dropshrink, so they aren't exactly the same looking. Reasoning is that the carp takes more bagspace to store, though if someone wanted to make a proper sprite for this item, that'd be great.

If someone knows a better way to handle the sizing than using dropshrink, please let me know, since currently, the Carp will still look small in your hand, and in your bags, even if it does still take up 4 sprites, instead of just one.


## Testing Evidence

<img width="235" height="197" alt="grafik" src="https://github.com/user-attachments/assets/4067af41-d0e2-489f-a999-cc659f2adf22" />


## Why It's Good For The Game

Makes the item not invisible, since it was asking for an icon_state that didn't exist, also makes it stick out to the otherwise identical rose/fish.

## Changelog
:cl:
restores sprite.
scales dropped sprite up.
/:cl: