### PR TITLE
[Balance] Berserker's Biter Helm

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -253,6 +253,17 @@
 	//dropshrink = 0.75
 	dynamic_hair_suffix = null
 
+/obj/item/clothing/head/roguetown/headband/bloodzerked // the replacement of wolfskull for zerker i guess, crucify me later for dragonhide armor, it's mostly for the drip
+	name = "bloodsoaked headband"
+	desc = "A headband that's been soaked in the blood of many trials. The dried blood has stiffened the cloth, gifting it a texture not unlike malleable steel. Wearing this spiritually motivates your head to grit up and endure its future trials for blood and glory."
+	color = "#851a16"
+	resistance_flags = FIRE_PROOF
+	armor = ARMOR_DRAGONHIDE
+	max_integrity = ARMOR_INT_HELMET_HARDLEATHER + 25
+	body_parts_covered = NECK|NOSE|HAIR|EARS|HEAD
+	sewrepair = TRUE
+	dynamic_hair_suffix = null
+
 /obj/item/clothing/head/roguetown/headband/bloodied
 	name = "bloodied headband"
 	desc = "A headband that's been soaked in the blood of a terrible nitebeast. The coagulative properties of cursed blood has stiffened the cloth, gifting it a texture not unlike spongy leather. Wearing it emboldens you with determination."

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -1153,28 +1153,6 @@
 	desc = "A steel bascinet helmet with a snarling visor that protects the entire head and face. It mimics the \
 	guise of a terrible nitebeast; intimidating to the levyman, inspiring to the hunter."
 
-/obj/item/clothing/head/roguetown/helmet/heavy/volfplate/berserker
-	name = "volfskulle bascinet"
-	desc = "A steel bascinet helmet with a snarling visor that protects the entire head and face. Just like the nitebeasts it mimics, so too does the helmet's teeth glisten with flesh-sundering sharpness."
-	armor_class = ARMOR_CLASS_LIGHT //Pseudoantagonist-exclusive. Gives them an edge over traditional pugilists and barbarians.
-	var/active_item = FALSE
-
-/obj/item/clothing/head/roguetown/helmet/heavy/volfplate/berserker/equipped(mob/living/user, slot)
-	. = ..()
-	if(slot == SLOT_HEAD)
-		active_item = TRUE
-		ADD_TRAIT(user, TRAIT_BITERHELM, TRAIT_GENERIC)
-		to_chat(user, span_red("The bascinet's visor chitters, and your jaw tightens with symbiotic intent.."))
-	return
-
-/obj/item/clothing/head/roguetown/helmet/heavy/volfplate/berserker/dropped(mob/living/user)
-	..()
-	if(!active_item)
-		return
-	active_item = FALSE
-	REMOVE_TRAIT(user, TRAIT_BITERHELM, TRAIT_GENERIC)
-	to_chat(user, span_red("..and like that, the bascinet's visor goes dormant once more - a strange pressure, relieved from your jaw."))
-
 /obj/item/clothing/head/roguetown/helmet/heavy/dwarven
 	name = "grudgebearer dwarven helm"
 	desc = "A hardy dwarven helmet. It lets one's dwarvenly beard to poke out."

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -128,11 +128,11 @@
 						H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
 						beltl = /obj/item/rogueweapon/mace
 
-		var/helmets = list("Berserker's Volfskulle Bascinet","Steel Kettle + Wildguard")
+		var/helmets = list("Bloodsoaked Headband","Steel Kettle + Wildguard")
 		var/helmet_choice = input(H, "Choose your HELMET.", "STEEL YOURSELF.") as anything in helmets
 		switch(helmet_choice)
-			if("Berserker's Volfskulle Bascinet")
-				head = /obj/item/clothing/head/roguetown/helmet/heavy/volfplate/berserker //Pseudoantagonistic-exclusive. Light AC with an on-wear trait for HELMBITING.
+			if("Bloodsoaked Headband")
+				head = /obj/item/clothing/head/roguetown/headband/bloodzerked
 			if("Steel Kettle + Wildguard")
 				head = /obj/item/clothing/head/roguetown/helmet/kettle
 				mask = /obj/item/clothing/mask/rogue/wildguard


### PR DESCRIPTION
## About The Pull Request

- Removes the Volfskull Biter Helm from Berserker Wretch.
- Gives them a cooler, bloodied-er headband that makes their thick skull thicker and preserves their drip.

## Testing Evidence

Just moved the code around, it compiles. Dreaded *alance changes.

## Why It's Good For The Game

Biter Helm was making the one major counterplay to bite spamming, which is punching someone's mouth over and over to dislocate their jaws so they stop biting you, to be a moot point for this one. So instead of getting that snowflake stuff, I give them another flavor of snowflake.

A headband that protects the same as a coif but without hiding your luscious hair and beard. How it works is that I don't fuckin know, the essence of victory permeates out of the blood from a thousand enemies into a strong protective aura or some stuff, lore team back me up here.

It's probably not balanced either, but so wasn't its predecessor. This should not have the defense of Leather or else their heads will be a puncture/unsewn feast when that shouldn't be the case. 

Suggestions are welcome as usual.

## Changelog
:cl:
add: Added Bloodsoaked Headband for Berserker.
del: Removed Volfskulle Helmet (Zerker-Unique) for Berserker.
/:cl: