### PR TITLE
[FIX] Potions no longer react inside potion seller

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -460,11 +460,11 @@
 	return is_type_in_list(B, A.conflicting_reagent_types) || is_type_in_list(A, B.conflicting_reagent_types)
 
 /datum/reagents/proc/handle_reactions()
-	// Anti-stacking check, runs before NO_REACT so it works on kegs too.
-	handle_conflicting_reagents()
-
 	if(flags & NO_REACT)
 		return //Yup, no reactions here. No siree.
+
+	// Anti-stacking check for conflicting potions.
+	handle_conflicting_reagents()
 
 	var/list/cached_reagents = reagent_list
 	var/list/cached_reactions = GLOB.chemical_reactions_list


### PR DESCRIPTION
## About The Pull Request

In my PR for potion stacking, I didnt' take into account potion seller is also a container with the NO_REACT flag. I changed logic so handle_conficting_reagents takes this into account; even if kegs won't react the reagents, they will react once poured into a bottle so, it still works as designed.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Tested locally, works fine.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bugfix.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Potion seller won't have conflicting reagents reacting now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
