### PR TITLE
Mage Lord gets Expert Arcyne Combat

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -270,6 +270,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 
 /datum/outfit/job/roguetown/lord/mage/pre_equip(mob/living/carbon/human/H)
 	..()
+	l_hand = /obj/item/rogueweapon/lordscepter
 	backr = /obj/item/storage/backpack/rogue/satchel
 
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rogueweapon/spellbook = 1, /obj/item/blueprint/mace_mushroom = 1, /obj/item/chalk = 1, /obj/item/hunting_map/white_stag = 1,)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -248,7 +248,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 1, "utilities" = 4, "ward" = TRUE)
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/arcyne = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/arcyne = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

Mage Lord subclass gets Expert arcyne combat from Jman.

edit: also returns them the master's rod.

## Testing Evidence

Address me

## Why It's Good For The Game

Arcyne Combat largely only really impacts the shiny new Ferramancy rework. Personal thoughts on its performance aside, I think it's okay to have them be on-par in that regard with the warrior Lord subclass, which is essentially a fully-statted heavy armor martial with only a lack of weapon diversity compared to their Knights. Either can still easily ask their Knights for a single spar if they intend to fight, but even on a 3hr round tedious legwork is usually felt.

They could get expert Staves, too, but those already get phat wdef and aren't really used for hitting things as much as spacing.

## Changelog
balance: Mage Lord Grand Duke subclass now starts with Expert in Arcyne Combat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
