### PR TITLE
Yoink! Mob Pickup System

### DIFF
--- a/code/game/objects/items/rogueitems/magic/magic_resources.dm
+++ b/code/game/objects/items/rogueitems/magic/magic_resources.dm
@@ -41,16 +41,6 @@
 	icon_state = "abberant"
 	desc = "The vestige of a planar creature, departed from this plane. Likely worth a lot to the magos that summoned them!"
 
-// familiar (item form): familiars can transform into this for portability and sovl
-/obj/item/magic/familiar/familiar_spirit
-	name = "Familiar Spirit"
-	icon = 'icons/roguetown/mob/familiars.dmi'
-	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK|ITEM_SLOT_RING // little pendant-esque thing
-
-/obj/item/magic/familiar/familiar_spirit/Initialize()
-	. = ..()
-	src.filters += filter(type = "drop_shadow", x=0, y=0, size=1, offset = 2, color = GLOW_COLOR_ARCANE)
-
 //mapfetchable items
 /obj/item/magic/obsidian
 	name = "obsidian fragment"

--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -146,6 +146,9 @@
 	var/obj/item/ssaddle
 	var/simple_detect_bonus = 0 // A flat percentage bonus to our ability to detect sneaking people only. Use in lieu of giving mobs huge STAPER bonuses if you want them to be observant.
 
+/mob/living/simple_animal/can_be_held(mob/by)
+	return mob_size <= MOB_SIZE_SMALL
+
 /obj/item/natural/bone
 	name = "bone"
 	icon_state = "bone"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -279,6 +279,8 @@
 		playsound(get_turf(src), used_sound, 60, FALSE)
 
 /mob/living/carbon/restrained(ignore_grab = TRUE)
+	if(..())
+		return TRUE
 //	. = (handcuffed || (!ignore_grab && pulledby && pulledby.grab_state >= GRAB_AGGRESSIVE))
 	if(handcuffed)
 		return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -725,6 +725,9 @@
 			say(word_input)
 		death()
 
+/mob/living/restrained(ignore_grab)
+	return ..() || istype(loc, /obj/item/mob_item)
+
 /mob/living/incapacitated(ignore_restraints = FALSE, ignore_grab = TRUE, check_immobilized = FALSE, ignore_stasis = FALSE)
 	if(stat || IsUnconscious() || IsStun() || IsParalyzed() || (!ignore_restraints && restrained(ignore_grab)))
 		return TRUE
@@ -1979,16 +1982,19 @@
 
 /mob/living/MouseDrop(mob/over)
 	. = ..()
-	var/mob/living/user = usr
-	if(!istype(over) || !istype(user))
+	var/mob/living/user = over
+	if(!istype(user))
 		return
-	if(!over.Adjacent(src) || (user != src) || !canUseTopic(over))
+	if(user.incapacitated())
 		return
-	if(can_be_held)
-		mob_try_pickup(over)
+	if(can_be_held(user))
+		mob_try_pickup(user)
 
 /mob/living/proc/mob_pickup(mob/living/L)
-	return
+	var/obj/item/mob_item/orb = become_item()
+	if(!istype(orb))
+		return
+	L.put_in_active_hand(orb)
 
 /mob/living/proc/mob_try_pickup(mob/living/user)
 	if(!ishuman(user))
@@ -2006,6 +2012,9 @@
 		return FALSE
 	mob_pickup(user)
 	return TRUE
+
+/mob/living/proc/can_be_held(mob/by)
+	return FALSE
 
 /mob/living/reset_perspective(atom/A)
 	if(..())

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -124,7 +124,7 @@
 
 	var/list/obj/effect/proc_holder/abilities = list()
 
-	var/can_be_held = FALSE	//whether this can be picked up and held.
+	var/item_state // iconstate for when we get turned into an item
 
 	var/ventcrawl_layer = PIPING_LAYER_DEFAULT
 	var/losebreath = 0

--- a/code/modules/mob/living/mob_pickup.dm
+++ b/code/modules/mob/living/mob_pickup.dm
@@ -3,7 +3,7 @@
 	var/mob/living/stored_mob
 	slot_flags = ITEM_SLOT_HEAD
 	w_class = WEIGHT_CLASS_HUGE // this should never exist outside your hand/head/shoulder
-	can_container = FALSE // if this is true, we won't revert you when you get put in a bag - for familiars only atm
+	var/can_container = FALSE // if this is true, we won't revert you when you get put in a bag - for familiars only atm
 
 /obj/item/mob_item/Initialize()
 	. = ..()

--- a/code/modules/mob/living/mob_pickup.dm
+++ b/code/modules/mob/living/mob_pickup.dm
@@ -3,6 +3,7 @@
 	var/mob/living/stored_mob
 	slot_flags = ITEM_SLOT_HEAD
 	w_class = WEIGHT_CLASS_HUGE // this should never exist outside your hand/head/shoulder
+	can_container = FALSE // if this is true, we won't revert you when you get put in a bag - for familiars only atm
 
 /obj/item/mob_item/Initialize()
 	. = ..()
@@ -14,7 +15,9 @@
 
 /obj/item/mob_item/dropped(mob/user, silent)
 	. = ..()
-	if(!istype(loc, /mob)) // don't revert if we're just being handed to someone else or put in a hand slot
+	if(isturf(loc))
+		revert() // always revert when you're actually dropped on the floor
+	if(!can_container && !istype(loc, /mob)) // if we're allowing containers, or just being handed to someone else/put in a hand slot, don't revert
 		revert()
 
 /obj/item/mob_item/proc/revert()

--- a/code/modules/mob/living/mob_pickup.dm
+++ b/code/modules/mob/living/mob_pickup.dm
@@ -1,0 +1,48 @@
+/obj/item/mob_item
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	var/mob/living/stored_mob
+	slot_flags = ITEM_SLOT_HEAD
+	w_class = WEIGHT_CLASS_HUGE // this should never exist outside your hand/head/shoulder
+
+/obj/item/mob_item/Initialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_QDELETING, PROC_REF(revert))
+
+/obj/item/mob_item/container_resist(mob/living/user)
+	. = ..()
+	revert()
+
+/obj/item/mob_item/dropped(mob/user, silent)
+	. = ..()
+	if(!istype(loc, /mob)) // don't revert if we're just being handed to someone else or put in a hand slot
+		revert()
+
+/obj/item/mob_item/proc/revert()
+	if(!stored_mob)
+		return
+	var/turf/to_move = get_turf(stored_mob)
+	if(to_move) // this can be false in the case of qdels but the mob is moved properly without this call in that case
+		stored_mob.forceMove(get_turf(stored_mob))
+	stored_mob.status_flags &= ~GODMODE
+	stored_mob.reset_perspective()
+	if(!QDELING(src))
+		qdel(src)
+	return TRUE
+
+/mob/living/proc/become_item()
+	var/obj/item/mob_item/orb = new /obj/item/mob_item(loc)
+	orb.stored_mob = src
+	if(movement_type & (FLOATING|FLYING)) // zads and such can perch on your shoulder
+		orb.slot_flags |= ITEM_SLOT_BACK
+	loc = orb
+	status_flags |= GODMODE
+	set_item_sprite(orb)
+	orb.name = name
+	orb.desc = desc
+	reset_perspective(orb)
+	return orb
+
+// by default, just sets the icon and icon_state. some mobs might also want to set mob overlays, so they actually appear when you wear them
+/mob/living/proc/set_item_sprite(obj/item/mob_item/orb)
+	orb.icon = icon
+	orb.icon_state = (item_state ? item_state : icon_state)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -85,7 +85,6 @@
 	childtype = list(/mob/living/simple_animal/pet/dog/corgi/puppy = 95, /mob/living/simple_animal/pet/dog/corgi/puppy/void = 5)
 	animal_species = /mob/living/simple_animal/pet/dog
 	gold_core_spawnable = FRIENDLY_SPAWN
-	can_be_held = TRUE
 	var/obj/item/inventory_head
 	var/obj/item/inventory_back
 	var/shaved = FALSE

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -107,7 +107,7 @@
 	var/obj/item/mob_item/orb = ..()
 	orb.slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK|ITEM_SLOT_RING // little pendant-esque thing
 	orb.filters += filter(type = "drop_shadow", x=0, y=0, size=1, offset = 2, color = GLOW_COLOR_ARCANE)
-	orb.desc = "A small orb, containing the spirit of [user.name]."
+	orb.desc = "A small orb, containing the spirit of [name]."
 	orb.can_container = TRUE
 	orb.w_class = WEIGHT_CLASS_SMALL
 	return orb

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -103,6 +103,15 @@
 /mob/living/simple_animal/pet/familiar/restrained(ignore_grab)
 	return !isturf(src.loc)
 
+/mob/living/simple_animal/pet/familiar/become_item()
+	var/obj/item/mob_item/orb = ..()
+	orb.slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK|ITEM_SLOT_RING // little pendant-esque thing
+	orb.filters += filter(type = "drop_shadow", x=0, y=0, size=1, offset = 2, color = GLOW_COLOR_ARCANE)
+	orb.desc = "A small orb, containing the spirit of [user.name]."
+	orb.can_container = TRUE
+	orb.w_class = WEIGHT_CLASS_SMALL
+	return orb
+
 /mob/living/simple_animal/pet/familiar/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NOFALLDAMAGE1, TRAIT_GENERIC)

--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -7,6 +7,9 @@
 	var/obj/item/clothing/neck/petcollar/pcollar
 	var/collar_type //if the mob has collar sprites, define them.
 
+/mob/living/simple_animal/pet/can_be_held(mob/by)
+	return TRUE
+
 /mob/living/simple_animal/pet/handle_atom_del(atom/A)
 	if(A == pcollar)
 		pcollar = null

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -75,6 +75,7 @@
 // lets you wear them on your HEAD...
 /mob/living/simple_animal/hostile/retaliate/bat/crow/set_item_sprite(obj/item/mob_item/orb)
 	..()
+	orb.mob_overlay_icon = orb.icon
 	orb.worn_offsets = list("x" = 0, "y" = 22)
 	orb.alternate_worn_layer = BODY_UNDER_LAYER // so it looks like they're perching on your head and not clipping through
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -2,6 +2,7 @@
 	name = "bat"
 	desc = ""
 	icon_state = "bat"
+	item_state = "bat_dead" // looks enough like a bat just chilling out that it makes more sense than the animated one
 	icon_living = "bat"
 	icon_dead = "bat_dead"
 	icon_gib = "bat_dead"
@@ -58,6 +59,7 @@
 	desc = ""
 	icon = 'icons/roguetown/mob/monster/crow.dmi'
 	icon_state = "crow_flying"
+	item_state = "crow"
 	icon_living = "crow_flying"
 	icon_dead = "crow1"
 	icon_gib = "crow1"
@@ -69,6 +71,12 @@
 	remains_type = /obj/effect/decal/remains/crow
 	fly_time = 3 SECONDS // slowing down crow for witches
 	sight = 0
+
+// lets you wear them on your HEAD...
+/mob/living/simple_animal/hostile/retaliate/bat/crow/set_item_sprite(obj/item/mob_item/orb)
+	..()
+	orb.worn_offsets = list("x" = 0, "y" = 22)
+	orb.alternate_worn_layer = BODY_UNDER_LAYER // so it looks like they're perching on your head and not clipping through
 
 /obj/effect/decal/remains/crow
 	name = "zad remains"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -49,6 +49,9 @@
 /mob/living/simple_animal/hostile/retaliate
 	var/aggressive = 0
 
+/mob/living/simple_animal/hostile/retaliate/can_be_held(mob/by)
+	return ..() && !aggressive && !(WEAKREF(by) in enemies)
+
 /mob/living/simple_animal/hostile/retaliate/ListTargets()
 	if(!(AIStatus == NPC_AI_OFF))
 		if(aggressive)

--- a/code/modules/mob/living/simple_animal/hostile/roguetown/crow.dm
+++ b/code/modules/mob/living/simple_animal/hostile/roguetown/crow.dm
@@ -17,6 +17,7 @@
 	rotprocess = null
 	static_debris = list(/obj/item/natural/feather=1)
 	fried_type = /obj/item/reagent_containers/food/snacks/rogue/friedcrow
+	slot_flags = SLOT_BACK
 
 /obj/item/reagent_containers/food/snacks/rogue/friedcrow
 	name = "fried zad"

--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -552,7 +552,6 @@ GLOBAL_LIST(teleport_runes)
 			fam.client?.init_verbs()
 			mind_datum.RemoveAllSpells()
 			mind_datum.AddSpell(new /datum/action/cooldown/spell/message_summoner())
-			mind_datum.AddSpell(new /datum/action/cooldown/spell/familiar_transform())
 			user.mind?.AddSpell(new /datum/action/cooldown/spell/message_familiar())
 
 			if(fam.inherent_spell)

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -103,45 +103,6 @@
 	log_game("[key_name(user)] sent a message to [key_name(summoner)] with contents [message]")
 	return TRUE
 
-/datum/action/cooldown/spell/familiar_transform
-	name = "Spirit Transformation"
-	desc = "Draw your form into itself, becoming a small orb that is wearable as a pendant, or revert to your original form."
-	button_icon_state = "rune2"
-
-	click_to_activate = FALSE
-	self_cast_possible = TRUE
-	charge_required = FALSE
-	cooldown_time = 1 SECONDS
-
-	primary_resource_type = SPELL_COST_NONE
-	spell_requirements = NONE
-	spell_impact_intensity = SPELL_IMPACT_NONE
-
-/datum/action/cooldown/spell/familiar_transform/cast(mob/living/simple_animal/pet/familiar/user)
-	. = ..()
-	if(!istype(user))
-		return FALSE
-	if(isturf(user.loc))
-		// we're on the ground somewhere, so we should become orb
-		var/obj/item/magic/familiar/familiar_spirit/spirit = new /obj/item/magic/familiar/familiar_spirit(user.loc)
-		spirit.icon = user.icon
-		spirit.icon_state = user.icon_living
-		spirit.name = user.name
-		spirit.desc = "A small orb, containing the spirit of [user.name]."
-		user.forceMove(spirit)
-		user.status_flags |= GODMODE
-		return TRUE
-	else
-		if(user.health<=0) // you shouldn't be able to cast this while dead, but just in case
-			return FALSE
-		var/obj/item/magic/familiar/familiar_spirit/spirit = user.loc
-		if(!istype(spirit)) // we might be inside another item like warden tools
-			return FALSE
-		user.forceMove(get_turf(user))
-		user.status_flags &= ~GODMODE
-		qdel(spirit)
-		return TRUE
-
 /datum/action/cooldown/spell/fae_brew
 	name = "Alchemical Stomach"
 	desc = "Toggle your brewing ability; while enabled, and you have a stock of reagents inside yourself, you will attempt to brew them into a potion using your summoner's alchemical skill."

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2369,6 +2369,7 @@
 #include "code\modules\mob\living\login.dm"
 #include "code\modules\mob\living\logout.dm"
 #include "code\modules\mob\living\misc.dm"
+#include "code\modules\mob\living\mob_pickup.dm"
 #include "code\modules\mob\living\overhead_effects.dm"
 #include "code\modules\mob\living\rolecheck.dm"
 #include "code\modules\mob\living\say.dm"


### PR DESCRIPTION
## About The Pull Request
imagine the following. you have just found a cat. you want to pick up the cat. you grab the cat and click-drag it to yourself, but because they're not firemannable, nothing happens. you are now sad

well, no longer! this PR adds a system, similar to how it remembers this working on bay (although it did not look at their code, this is all custom), for picking up mobs. it is currently only accessible for small sized, non-hostile simplemobs, such as pets, but the framework is there so that any mob can override /mob/living/proc/can_be_held(mob/by) to allow the system to work for them.

how it works is nearly identical to the existing familiar transformation system, in that internally, the mob transforms into an item, and the item copies over the name, description, icon, etc of the mob. while within an item, the mob is restrained, and resisting (hitting x) will revert them to mob form and put them on the ground. the item cannot be placed in any containers, and dropping it will also revert the mob - so it is seamless.

mobs can be put on your head by default. flying mobs like zads can be put on your shoulder. there is a system to allow mobs to set onmob overlays for the resulting item, but only zads use it because it could only get zads to look good without adding new sprites. but again, system's there if we do get sprites for it.

familiars themselves, being the basis for how this system worked but overall far more snowflakey, have been migrated to this system. spirit transformation is no longer a spell, you can just be picked up like any other animal and you get put in your orb; the orb retains its snowflakey aspects (magic item glow, small item size that can be put in containers and worn on the hip, etc) but otherwise it works the same

## Testing Evidence
note that this video was taken earlier in development, when the mousedrop system was broken (it's no longer broken), but it gives a good idea of how the process works

https://github.com/user-attachments/assets/aeb7e052-533a-4103-bf86-c552c2514cb5

<img width="198" height="160" alt="image" src="https://github.com/user-attachments/assets/0c3a84ac-4a44-4dd2-80c0-43f0250ad851" />

<img width="149" height="174" alt="image" src="https://github.com/user-attachments/assets/1e28bcba-2b17-4115-a861-87016ddfea8f" />


## Why It's Good For The Game
letting people pick up pets and such is a big flavor win, and is especially applicable for cases like familiars; familiar transformation was done in a needlessly-complicated way, so this fixes that by migrating them to the generic system while keeping their snowflakey aspects

## Changelog

:cl:
add: Small, non-hostile animals can now be picked up; they can be worn on the head or, for flying mobs, perch on your shoulder.
del: Familiar transform ability has been removed, as they have been migrated to the new mob pickup system
/:cl:
