### PR TITLE
extremely minor pathing bug

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -414,7 +414,7 @@
 		This one used to be in the hands of a pale elf and may be fitted with a great plume atop, to bear heraldic colors."
 	icon_state = "armetowl"
 
-/obj/item/clothing/head/roguetown/helmet/heavy/knight/armet/eiren_helmet/attackby(obj/item/W, mob/living/user, params)
+/obj/item/clothing/head/roguetown/helmet/heavy/knight/armet/owl/attackby(obj/item/W, mob/living/user, params)
 	..()
 	if(!(istype(W, /obj/item/natural/feather) && !detail_tag))
 		return


### PR DESCRIPTION
## About The Pull Request
looks like /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet/eiren_helmet was renamed to /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet/owl, but whoever did it forgot to change the code that allowed it to be feathered to match

## Testing Evidence
it's 1 path fix

## Why It's Good For The Game
bug

## Changelog

:cl:
Strigidae armet can now properly have a feather applied
/:cl:
