### PR TITLE
Adds sitting down and caw to Zad form

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -82,9 +82,7 @@
 	set name = "Change Stance"
 	sitting = !sitting
 	update_icon()
-	// BYOND only re-renders this mob's base sprite on a dir change, so the new icon_state won't show
-	// until the player looks/moves. Settle the bird to face forward on each stance change to force
-	// the refresh immediately - the EAST nudge guarantees dir actually changes even if already facing SOUTH.
+	//Hack to make sprite update after hitting the verb
 	setDir(EAST)
 	setDir(SOUTH)
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -69,6 +69,41 @@
 	remains_type = /obj/effect/decal/remains/crow
 	fly_time = 3 SECONDS // slowing down crow for witches
 	sight = 0
+	/// Whether the zad is perched (stationary sprite, cannot move) rather than flying.
+	var/sitting = FALSE
+
+/mob/living/simple_animal/hostile/retaliate/bat/crow/Initialize()
+	. = ..()
+	add_verb(src, list(/mob/living/simple_animal/hostile/retaliate/bat/crow/proc/change_stance,
+	/mob/living/simple_animal/hostile/retaliate/bat/crow/proc/emote_caw))
+
+/mob/living/simple_animal/hostile/retaliate/bat/crow/proc/change_stance()
+	set category = "RoleUnique.Winged Form"
+	set name = "Change Stance"
+	sitting = !sitting
+	update_icon()
+	// BYOND only re-renders this mob's base sprite on a dir change, so the new icon_state won't show
+	// until the player looks/moves. Settle the bird to face forward on each stance change to force
+	// the refresh immediately - the EAST nudge guarantees dir actually changes even if already facing SOUTH.
+	setDir(EAST)
+	setDir(SOUTH)
+
+/mob/living/simple_animal/hostile/retaliate/bat/crow/update_icon_state()
+	icon_state = sitting ? "crow" : "crow_flying"
+
+/mob/living/simple_animal/hostile/retaliate/bat/crow/Move()
+	if(sitting)
+		return FALSE
+	return ..()
+
+/mob/living/simple_animal/hostile/retaliate/bat/crow/proc/emote_caw()
+	set category = "RoleUnique.Winged Form"
+	set name = "Caw"
+	emote("caw", intentional = TRUE, animal = TRUE)
+
+/mob/living/simple_animal/hostile/retaliate/bat/crow/get_sound(input)
+	if(input == "caw")
+		return pick('sound/vo/mobs/bird/CROW_01.ogg', 'sound/vo/mobs/bird/CROW_02.ogg', 'sound/vo/mobs/bird/CROW_03.ogg')
 
 /obj/effect/decal/remains/crow
 	name = "zad remains"


### PR DESCRIPTION
## About The Pull Request

Ported from https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1118

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/478c6693-fe93-4ae1-8971-e99c19b13b80


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

You can caw and sit down in Zad form, idk, feels good.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Zad form can now sit down and caw
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
