### PR TITLE
corset ac fix + some loadout items

### DIFF
--- a/code/datums/loadout/loadout_accessories.dm
+++ b/code/datums/loadout/loadout_accessories.dm
@@ -166,6 +166,11 @@
 	path = /obj/item/storage/belt/rogue/leather/black
 	sort_category = "Accessories"
 
+/datum/loadout_item/suspenders
+	name = "Suspenders"
+	path = /obj/item/storage/belt/rogue/leather/suspenders
+	sort_category = "Accessories"
+
 /datum/loadout_item/chaperon
 	name = "Chaperon (Normal)"
 	path = /obj/item/clothing/head/roguetown/chaperon

--- a/code/datums/loadout/loadout_pants.dm
+++ b/code/datums/loadout/loadout_pants.dm
@@ -14,6 +14,11 @@
 	path = /obj/item/clothing/under/roguetown/trou/leathertights
 	sort_category = "Pants"
 
+/datum/loadout_item/trousershorts
+	name = "Trouser Shorts"
+	path = /obj/item/clothing/under/roguetown/tights/shorts
+	sort_category = "Pants"
+
 /datum/loadout_item/trou
 	name = "Work Trousers"
 	path = /obj/item/clothing/under/roguetown/trou

--- a/code/datums/loadout/loadout_shirts.dm
+++ b/code/datums/loadout/loadout_shirts.dm
@@ -199,3 +199,8 @@
 	name = "Maid Dress"
 	path = /obj/item/clothing/suit/roguetown/shirt/dress/maid
 	sort_category = "Shirts"
+
+/datum/loadout_item/corset
+	name = "Corset"
+	path = /obj/item/clothing/suit/roguetown/armor/corset
+	sort_category = "Shirts"

--- a/code/modules/clothing/rogueclothes/armor/misc.dm
+++ b/code/modules/clothing/rogueclothes/armor/misc.dm
@@ -4,7 +4,6 @@
 	name = "corset"
 	desc = "A leather binding to constrict one's figure... and lungs."
 	icon_state = "corset"
-	armor_class = ARMOR_CLASS_LIGHT
 	body_parts_covered = CHEST
 	salvage_result = /obj/item/natural/hide/cured
 	sewrepair = TRUE


### PR DESCRIPTION
## About The Pull Request
Removes the light AC from corsets (as in the item called corsets, not the armored corset variants), which have no actual armor rating. Also adds them, suspenders, and trouser shorts (all of which are fairly cheap universally-available jman recipes and not overly fancy) to loadout in their respective categories, by request.

## Testing Evidence
<img width="855" height="265" alt="image" src="https://github.com/user-attachments/assets/53325443-b4cb-4d67-ae75-df4fb6df8ff1" />


## Why It's Good For The Game
You shouldn't be punished (even if the penalties for light AC over no AC are very minor) for wearing something that doesn't give armor. Loadout expansion was requested, but having access to more generic (not access restricted in any way besides "grind to apprentice and then sew it up") drip seems good.

## Changelog

:cl:
fix: Unarmored corset is no longer erroneously considered armor
/:cl: