### PR TITLE
[Origin Perk] Sunlight Sensitivity

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -295,6 +295,7 @@
 #define TRAIT_REGROW_LIMBS "Regrow Limbs"
 #define TRAIT_LEVY "Azurean Militia"
 #define TRAIT_MUSES_GRACE	"Muses Grace"
+#define TRAIT_SUNLIGHT_SENSITIVE "Sunlight Sensitivity"
 // ARMOR / CLOTHING GIVEN TRAITS (GIVEN BY WEARING CLOTHES/ARMOR PIECES)
 #define TRAIT_MONK_ROBE	"Holy Vestatures"
 #define TRAIT_BLACKOAK "Heritage Vision"
@@ -611,6 +612,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_DUSTRUNNER = span_info("I run dust for the Thieves' Guild. Those in the trade know how to spot one of their own."),
 	TRAIT_REGROW_LIMBS = span_info("I can regrow my limbs in my sleep, but doing so will make me hungry."),
 	TRAIT_MUSES_GRACE = span_info("I feel a sudden and powerful urge to break out into song."),
+	TRAIT_SUNLIGHT_SENSITIVE = span_danger("Put on those shades and wave to yesterday, 'cause the sunlight hurts my eyes!")
 ))
 
 // trait accessor defines

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -883,11 +883,3 @@ GLOBAL_LIST_INIT(averse_factions, list(
 		addtimer(CALLBACK(src, PROC_REF(apply_bounty_when_ready), H), 5 SECONDS)
 		return
 	wretch_select_bounty(H)
-
-/datum/charflaw/sunlight_sensitive
-	name = "Sunlight Sensitivity"
-	desc = "Due to either an upbringing in the Underdark, Astrata's displeasure or albinism, I get fairly uncomfortable under direct sunlight. My limbs are also a bit more frail too."
-
-/datum/charflaw/sunlight_sensitive/on_mob_creation(mob/user)
-	ADD_TRAIT(user, TRAIT_SUNLIGHT_SENSITIVE, TRAIT_GENERIC)
-	ADD_TRAIT(user, TRAIT_EASYDISMEMBER, TRAIT_GENERIC)

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -884,5 +884,10 @@ GLOBAL_LIST_INIT(averse_factions, list(
 		return
 	wretch_select_bounty(H)
 
+/datum/charflaw/sunlight_sensitive
+	name = "Sunlight Sensitivity"
+	desc = "Due to either an upbringing in the Underdark, Astrata's displeasure or albinism, I get fairly uncomfortable under direct sunlight. My limbs are also a bit more frail too."
 
-
+/datum/charflaw/sunlight_sensitive/on_mob_creation(mob/user)
+	ADD_TRAIT(user, TRAIT_SUNLIGHT_SENSITIVE, TRAIT_GENERIC)
+	ADD_TRAIT(user, TRAIT_EASYDISMEMBER, TRAIT_GENERIC)

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -518,10 +518,15 @@
 	stressadd = 3
 	desc = span_red("I long for the shelter of wall and roofs. The sun and moon are too bright for me to bear!")
 
+/datum/stressevent/sun_sensitivity_dark
+	timer = 2 MINUTES
+	stressadd = 3
+	desc = span_red("<b><i>The sunlight burns my eyes! It's too bright outside!</b></i>")
+
 /datum/stressevent/sun_sensitivity
 	timer = 2 MINUTES
-	stressadd = 4
-	desc = span_red("<b>The sunlight burns my eyes and skin! It's too bright outside!</b>")
+	stressadd = 10
+	desc = span_red("<b><i>The sunlight burns my eyes and skin! It's too bright outside!</b></i>")
 
 /datum/stressevent/lesser_sun_sensitivity
 	timer = 2 MINUTES

--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 	else
 		remove_stress(/datum/stressevent/pallid_outdoors)
 
-	if(HAS_TRAIT(src, TRAIT_BLACKBLOOD))
+	if(HAS_TRAIT(src, TRAIT_SUNLIGHT_SENSITIVE) || HAS_TRAIT(src, TRAIT_BLACKBLOOD))
 		var/turf/T = get_turf(src)
 		if(T.can_see_sky() && GLOB.tod == "day")
 			if(HAS_TRAIT(src, TRAIT_WEATHER_PROTECTED))

--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -104,11 +104,21 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 			if(HAS_TRAIT(src, TRAIT_WEATHER_PROTECTED))
 				add_stress(/datum/stressevent/lesser_sun_sensitivity)
 			else
-				add_stress(/datum/stressevent/sun_sensitivity)
+				if(HAS_TRAIT(src, TRAIT_SUNLIGHT_SENSITIVE))
+					src.set_blurriness(100)
+					apply_status_effect(/datum/status_effect/debuff/badvision)
+					add_stress(/datum/stressevent/sun_sensitivity_dark)
+				else
+					add_stress(/datum/stressevent/sun_sensitivity)
 		else
 			remove_stress(/datum/stressevent/lesser_sun_sensitivity)
 			remove_stress(/datum/stressevent/sun_sensitivity)
+			remove_stress(/datum/stressevent/sun_sensitivity_dark)
+			if(HAS_TRAIT(src, TRAIT_SUNLIGHT_SENSITIVE))
+				src.set_blurriness(0)
+				remove_status_effect(/datum/status_effect/debuff/badvision)
 	else
+		remove_stress(/datum/stressevent/sun_sensitivity_dark)
 		remove_stress(/datum/stressevent/lesser_sun_sensitivity)
 		remove_stress(/datum/stressevent/sun_sensitivity)
 

--- a/code/modules/virtues/origin.dm
+++ b/code/modules/virtues/origin.dm
@@ -258,5 +258,19 @@
 	the surface about their home and culture, believing all things evil crawl out of the very depths they reside in. A stigma that has lessened in \
 	recent yils, but still vastly present nonetheless."
 
+/datum/virtue/origin/underdark/apply_to_human(mob/living/carbon/human/H)
+	..()
+	var/list/choices = list("Normal (Default)", "Strict (Sunlight Sensitivity + Darksight)")
+	var/complex = tgui_input_list(H, "How adapted are you to the Underdark?", "Underdweller Upbringing", choices)
+	if(!complex)
+		complex = "Normal (Default)"
+	switch(complex)
+		if("Strict (Sunlight Sensitivity + Darksight)")
+			ADD_TRAIT(H, TRAIT_SUNLIGHT_SENSITIVE, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_NITEVISION, TRAIT_GENERIC)
+			to_chat(H, span_notice("The sun is irritantly bright for you!"))
+		else
+			to_chat(H, span_notice("You're quick to adapt."))
+
 /datum/virtue/origin/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.dna.species.origin = origin_name

--- a/code/modules/virtues/origin.dm
+++ b/code/modules/virtues/origin.dm
@@ -267,7 +267,7 @@
 	switch(complex)
 		if("Strict (Sunlight Sensitivity + Darksight)")
 			ADD_TRAIT(H, TRAIT_SUNLIGHT_SENSITIVE, TRAIT_GENERIC)
-			ADD_TRAIT(H, TRAIT_NITEVISION, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_DARKVISION, TRAIT_GENERIC)
 			to_chat(H, span_notice("The sun is irritantly bright for you!"))
 		else
 			to_chat(H, span_notice("You're quick to adapt."))


### PR DESCRIPTION
## About The Pull Request

- Underdweller Origin, similar to Naledi, will prompt you to offer if you are Sunlight Sensitive or not. It grants basic Darkvision as a boon.

## Testing Evidence

It compiles, it works.

## Why It's Good For The Game

Got asked for it, and since everything's already there, sure why not.

## Changelog
:cl:
add: Underdweller Origin can choose Sunlight Sensitivity, similar to Naledi Complex.
/:cl: