### PR TITLE
hotfix: deadites and werevolfs should not be teleporting

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -341,7 +341,7 @@ GLOBAL_LIST(teleport_runes)
 	. = ..()
 
 /obj/effect/decal/cleanable/roguerune/arcyne/proc/can_use_arcyne_rune(mob/living/user)
-	return HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT)
+	return HAS_TRAIT(user, TRAIT_LEYLINE_ATTUNEMENT) && !HAS_TRAIT(user, TRAIT_CHUNKYFINGERS)
 
 
 


### PR DESCRIPTION
## About The Pull Request
no more teleporting or enchanting etc for deadites and werevolfs if they somehow have arcyne trait (like dead mages)

## Testing Evidence
it's a trait check

## Why It's Good For The Game
as funny as it is, uh, no. don't do this

## Changelog

:cl:
fix: Deadites and werevolfs can no longer use teleportation runes (or any other mage runes)
/:cl: