### PR TITLE
Vizier / Hierophant Decreep / Tweaks

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1150,7 +1150,7 @@
 /datum/status_effect/buff/reversion
 	id = "stasis"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/stasis
-	duration = 15 SECONDS
+	duration = 25 SECONDS
 
 #define CRANKBOX_FILTER "crankboxbuff_glow"
 /atom/movable/screen/alert/status_effect/buff/churnerprotection

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -295,7 +295,6 @@
 		H.mind.AddSpell(new /datum/action/cooldown/spell/vizier/reversion)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/vizier/acceleration)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/guidance)		
-		H.mind.AddSpell(new /datum/action/cooldown/spell/conjure_arcyne_ward/crystalhide)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/bestow_ward)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/mending)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)

--- a/code/modules/spells/spell_types/classunique/hierophant/leyline_circle.dm
+++ b/code/modules/spells/spell_types/classunique/hierophant/leyline_circle.dm
@@ -13,7 +13,8 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_NO_MOVE
 	click_to_activate = FALSE
 	self_cast_possible = TRUE
-	charge_message = "<font color='#ffae00'>Prjperi! Connect! Se-Djed!"
+	invocations = list("Prjperi! Connect! Se-Djed!")
+	invocation_type = INVOCATION_SHOUT
 	charge_required = TRUE
 	charge_time = 1.5 SECONDS
 	charge_slowdown = CHARGING_SLOWDOWN_HEAVY
@@ -50,7 +51,8 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_NO_MOVE
 	click_to_activate = FALSE
 	self_cast_possible = TRUE
-	charge_message = "<font color='#ffae00'>Se-Khep! Return! Khai!"
+	invocation_type = INVOCATION_SHOUT
+	invocations = list("Se-Khep! Return! Khai!")
 	var/obj/structure/leyline_circle/linked_circle
 	var/max_range = 9
 
@@ -177,13 +179,10 @@
 		qdel(src)
 		return
 	if(get_turf(owner) == get_turf(src))
-		if(owner.cmode)
-			if(!owner.has_status_effect(/datum/status_effect/buff/circle_of_power))
-				var/datum/status_effect/buff/circle_of_power/B = owner.apply_status_effect(/datum/status_effect/buff/circle_of_power)
-				if(B)
-					B.source_circle = src
-		else
-			owner.apply_status_effect(/datum/status_effect/buff/invigoration, 5 SECONDS, 25, 15)
+		if(!owner.has_status_effect(/datum/status_effect/buff/circle_of_power))
+			var/datum/status_effect/buff/circle_of_power/B = owner.apply_status_effect(/datum/status_effect/buff/circle_of_power)
+			if(B)
+				B.source_circle = src
 		if(!length(active_beams))
 			create_beams()
 	else

--- a/code/modules/spells/spell_types/classunique/vizier/reversion.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/reversion.dm
@@ -1,15 +1,15 @@
 // Reversion - Origin Magic (Vizier)
 // The Vizier marks an adjacent ally or themselves, snapshotting their state and position.
 // Leaves a mark on the ground - that they can then activate at will to teleport back
-// It expires after 15 seconds
+// It expires after 25 seconds
 
-#define REVERSION_MARK_DURATION (15 SECONDS)
+#define REVERSION_MARK_DURATION (25 SECONDS)
 
 /datum/action/cooldown/spell/vizier/reversion
 	button_icon = 'icons/mob/actions/classuniquespells/vizier.dmi'
 	name = "Reversion"
-	desc = "Marks an adjacent ally's body and position for 15 seconds, allowing them to return to their marked state at will.<br><br>If used on a target that has died within the last minute, the Vizier may instead rewind their death at the cost of their own Lux. Anything beyond that cannot be rewound."
-	fluff_desc = "Among the most demanding applications of Origin Magick, this art does not merely restore a prior state. It preserves one. For a fleeting moment, a Vizier anchors a person's place within the tapestry of time, allowing it to retrace its own history and reclaim a body, position, and condition once held. While it is theoretically possible to use the same principles to reclaim a soul that has only just departed, Naledi's seminaries traditionally frown upon such acts. Death is regarded as a boundary not to be crossed lightly, and those who make a habit of doing so rarely earn the respect of their peers."
+	desc = "Marks an adjacent ally's body and position for 25 seconds, allowing them to return to their marked state at will."
+	fluff_desc = "Among the most demanding applications of Origin Magick, this art does not merely restore a prior state. It preserves one. For a fleeting moment, a Vizier anchors a person's place within the tapestry of time, allowing it to retrace its own history and reclaim a body, position, and condition once held."
 	button_icon_state = "reversion"
 	sound = 'sound/magic/timeforward.ogg'
 	spell_color = GLOW_COLOR_ARCANE
@@ -65,32 +65,6 @@
 	if(!istype(target))
 		return FALSE
 
-	// Reverse a recently departed soul. Must be done within 1 minute. Obs: This interaction will be removed if Death's Door PR is removed.
-	if(target.stat == DEAD)
-		if(!H.has_status_effect(/datum/status_effect/debuff/devitalised))
-			if(target.timeofdeath && (world.time - target.timeofdeath) <= 1 MINUTES)
-				if(alert(owner, "[target] has very recently departed. Sacrifice your Lux to rewind their soul back?", "Origin Restoration", "Restore Them", "Leave Them") == "Restore Them")
-					var/obj/effect/temp_visual/origin_restoration/V = new
-					target.vis_contents += V
-					var/turf/user_turf = get_turf(owner)
-					new /obj/effect/temp_visual/origin_restoration_burst(user_turf, NORTHEAST)
-					new /obj/effect/temp_visual/origin_restoration_burst(user_turf, NORTHWEST)
-					new /obj/effect/temp_visual/origin_restoration_burst(user_turf, SOUTHEAST)
-					new /obj/effect/temp_visual/origin_restoration_burst(user_turf, SOUTHWEST)
-					playsound(target.loc, 'sound/magic/regression1.ogg')				
-					H.apply_status_effect(/datum/status_effect/debuff/devitalised/lesser)
-					target.say("Telos!")
-					target.setOxyLoss(0)
-					if(target.revive(full_heal = FALSE))
-						target.grab_ghost(force = TRUE)
-						target.emote("gasp")
-						target.Jitter(100)
-						if(target.mind)
-							target.mind.remove_antag_datum(/datum/antagonist/zombie)
-						target.apply_status_effect(/datum/status_effect/debuff/revived)
-						target.visible_message(span_blue("[owner]'s Lux is forcefully torn away as [target]'s soul is rewound back into their body!"),	span_blue("A distant darkness releases its grip on me. I wake once more, feeling the remnants of a dying light..."))
-					return TRUE
-
 	// Snapshot the target's current state
 	var/datum/action/cooldown/spell/vizier/reversion_trigger/trigger = new
 	trigger.origin = get_turf(target)
@@ -118,13 +92,16 @@
 	// Audio + visual feedback on the target
 	playsound(target.loc, 'sound/magic/timeforward.ogg', 50, FALSE)
 	target.apply_status_effect(/datum/status_effect/buff/reversion)
+	target.balloon_alert(target, "marked for reversion")
+	if(target != H)
+		target.balloon_alert(H, "marked for reversion")
 
 	// Feedback
 	if(target == H)
-		to_chat(H, span_notice("I mark myself for reversion. I can activate the revert at will."))
+		to_chat(H, span_purple("I mark myself for reversion. I can activate the revert at will."))
 	else
-		to_chat(target, span_warning("I feel a part of me was left behind... I can choose to revert back."))
-		to_chat(H, span_notice("I mark [target] for reversion. They can activate the revert at will."))
+		to_chat(target, span_purple("I feel a part of me was left behind... I can choose to revert back."))
+		to_chat(H, span_purple("I mark [target] for reversion. They can activate the revert at will."))
 
 	return TRUE
 
@@ -146,7 +123,7 @@
 	invocation_type = INVOCATION_NONE
 
 	charge_required = TRUE
-	charge_time = 0.5 SECONDS
+	charge_time = 0 // Instant cuz do after already exists
 	charge_drain = 0
 	charge_slowdown = CHARGING_SLOWDOWN_SMALL
 	charge_sound = 'sound/magic/charging.ogg'
@@ -175,6 +152,8 @@
 	var/expiry_timer
 	/// Ground marker effect at the origin point.
 	var/obj/effect/reversion_marker/ground_marker
+	/// TRUE while the revert channel is running - blocks re-entry and marks us as committed.
+	var/reverting = FALSE
 
 /datum/action/cooldown/spell/vizier/reversion_trigger/Grant(mob/grant_to)
 	. = ..()
@@ -191,6 +170,38 @@
 	var/mob/living/carbon/target = owner
 	if(!istype(target))
 		return FALSE
+
+	if(reverting)
+		return FALSE
+	reverting = TRUE
+
+	if(expiry_timer)
+		deltimer(expiry_timer)
+		expiry_timer = null
+
+
+	target.balloon_alert(target, "reverting...")
+	target.visible_message(span_purple("[target]'s body begins to flicker, slipping out of the present moment..."))
+	var/datum/progressbar/progbar = new(target, 2 SECONDS, target)
+	var/endtime = world.time + 2 SECONDS
+	var/starttime = world.time
+	while(world.time < endtime)
+		stoplag(1)
+		if(QDELETED(src) || QDELETED(target))
+			break
+		progbar.update(world.time - starttime)
+	qdel(progbar)
+
+
+	if(QDELETED(src) || QDELETED(target) || target != owner)
+		reverting = FALSE
+		return FALSE
+
+	var/turf/departure = get_turf(target)
+	target.visible_message(span_purple("[target] flickers and warps away, snapping backwards through time!"), span_purple("Time reverses - my body snaps back!"))
+	if(departure)
+		departure.balloon_alert_to_viewers("warps away!")
+		playsound(departure, 'sound/magic/timereverse.ogg', 100, FALSE)
 
 	// Teleport back
 	do_teleport(target, origin, no_effects = TRUE)
@@ -217,8 +228,9 @@
 		else
 			target.simple_remove_wound(wound)
 
+	// Announce the arrival at the return point
 	playsound(target.loc, 'sound/magic/timereverse.ogg', 100, FALSE)
-	to_chat(target, span_warning("Time reverses - my body snaps back!"))
+	target.balloon_alert_to_viewers("snaps into place!", "I snap back!")
 
 	// Remove the status effect and clean up
 	target.remove_status_effect(/datum/status_effect/buff/reversion)
@@ -227,10 +239,13 @@
 
 /// Called when the mark expires without being used.
 /datum/action/cooldown/spell/vizier/reversion_trigger/proc/expire()
+	// A revert is already committed and channeling - let it finish, don't tear down under it.
+	if(reverting)
+		return
 	if(!owner)
 		qdel(src)
 		return
-	to_chat(owner, span_notice("The reversion mark fades."))
+	to_chat(owner, span_purple("The reversion mark fades."))
 	var/mob/living/L = owner
 	L.remove_status_effect(/datum/status_effect/buff/reversion)
 	cleanup()


### PR DESCRIPTION
## About The Pull Request
Remove some Vizier decreep / tweaks from the Naledi PR as people thinks it is overpowered and I looked at the abilities and it makes sense. Especially as they have Lesser Augmentation which gives them additional toolkit on top anyway.: 

- Vizier no longer get a free Crystalhide Ward on top of what they are getting
- Vizier's Reversion can no longer revive anyone. Please, no revival on a merc. 
- Increased the duration of Reversion from 15 seconds to 25 seconds to emphasize usage of their unique abilities. Revert now have no charge time, however, it has an uninterruptible 2 seconds doafter and balloon alerts where appropriate to indicate to people wailing on the target what just happened.
- Leylines now use invocation shout properly, and no longer grants blue regeneration. It no longer has a cmode gate for its signature effects.
 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1109" height="1176" alt="dreamseeker_j2FgDyWg8s" src="https://github.com/user-attachments/assets/71e3f443-064c-425b-af44-c3d731c11e0a" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's not healthy for a class to be powercrept this much. Both from the game health and the "Not getting someone to come in and gut it entirely" perspective.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Vizier no longer get a free Crystalhide Ward on top of what they are getting
balance: Vizier's Reversion can no longer revive anyone. Please, no revival on a merc. 
balance: Increased the duration of Reversion from 15 seconds to 25 seconds to emphasize usage of their unique abilities. Revert now have no charge time, however, it has an uninterruptible 2 seconds doafter and balloon alerts where appropriate to indicate to people wailing on the target what just happened.
add: Leylines now use invocation shout properly, and no longer grants blue regeneration. It no longer has a cmode gate for its signature effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
