### PR TITLE
Skeleton Stylening + Balance Tuneups

### DIFF
--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -264,6 +264,10 @@
 	. = ..()
 	set_quantity(rand(4,19))
 
+/obj/item/roguecoin/aalloy/pile/rich/Initialize()
+	. = ..()
+	set_quantity(rand(8,19)) //Hilarious
+
 /obj/item/roguecoin/copper/pile/Initialize()
 	. = ..()
 	set_quantity(rand(4,19))

--- a/code/modules/clothing/rogueclothes/storage/pouch.dm
+++ b/code/modules/clothing/rogueclothes/storage/pouch.dm
@@ -284,6 +284,21 @@
 		if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_INSERT, A, null, TRUE, TRUE))
 			SSwardrobe.recycle_object(A)
 
+/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich
+
+/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich/get_types_to_preload()
+	var/list/to_preload = list() 
+	to_preload += /obj/item/roguecoin/aalloy/pile
+	return to_preload
+
+/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich/PopulateContents()
+	. = ..()
+	for(var/i in 1 to 3) //hilarious
+		var/obj/item/roguecoin/aalloy/pile/A = SSwardrobe.provide_type(/obj/item/roguecoin/aalloy/pile, loc)
+		if(istype(A))
+			if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_INSERT, A, null, TRUE, TRUE))
+				SSwardrobe.recycle_object(A)
+
 /obj/item/storage/belt/rogue/pouch/food/PopulateContents()
 	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
@@ -115,7 +115,7 @@
 		/obj/item/rogueweapon/huntingknife/idagger/steel/padagger = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/natural/feather = 1, //For your helm
-		/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich = 1, //Hilarious
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1, //Hilarious
 	)
 
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
@@ -29,7 +29,7 @@
 		/datum/skill/combat/shields = SKILL_LEVEL_EXPERT,
 	)
 
-	adv_stat_ceiling = list(STAT_INTELLIGENCE = 8, STAT_CONSTITUTION = 10, STAT_WILLPOWER = 12) //infinite fatigue + decent skills vs vamp
+	adv_stat_ceiling = list(STAT_INTELLIGENCE = 8, STAT_SPEED = 9, STAT_CONSTITUTION = 10, STAT_WILLPOWER = 12) //infinite fatigue + decent skills vs vamp
 	extra_context = "This class is unable to be revived and all forms of death will dust you."
 
 /datum/outfit/job/roguetown/wretch/ancient_deathknight/pre_equip(mob/living/carbon/human/H)
@@ -46,14 +46,13 @@
 
 	H.cmode_music = 'sound/music/combat_weird.ogg'
 
-	// Equipment — gilbranze loadout loosely matching lich skeleton death knight
+	// Equipment — gilbranze loadout loosely matching lich skeleton death knight/bulwark -> helm picks and stuff come later
 	belt = /obj/item/storage/belt/rogue/leather/black
 	pants = /obj/item/clothing/under/roguetown/platelegs/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/plate/paalloy
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
-	backr = /obj/item/storage/backpack/rogue/satchel
+	backr = /obj/item/storage/backpack/rogue/satchel/black
 
 	H.taints_loot = TRUE //For that shitty-ass reanimated corpse gear look.
 
@@ -72,12 +71,15 @@
 		if("Halfplate")
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/paalloy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
 		if("Cuirass & Haulberk")
 			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/paalloy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
 		if("Heavy Haulberk")
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy/heavy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy/chain
 			
 	var/weapon_choice = input(H, "Choose your WEAPON.", "RAGE AGAINST THE LYVING.") as anything in list("Longsword + Shield", "Ancient Greatsword", "Ancient Axe + Shield", "Ancient Mace + Shield", "Ancient Warhammer + Shield", "Bardiche", "Grand Mace")
 	switch(weapon_choice)
@@ -113,7 +115,7 @@
 		/obj/item/rogueweapon/huntingknife/idagger/steel/padagger = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/natural/feather = 1, //For your helm
-		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1, //Hilarious
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich = 1, //Hilarious
 	)
 
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
@@ -63,7 +63,7 @@
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy/chain
 	mask = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/lich //Stands out
-	backr = /obj/item/rogueweapon/shield/bronze/paalloy //As a treat, single its single-slotted now
+	backr = /obj/item/rogueweapon/shield/bronze/paalloy
 	backl = /obj/item/storage/backpack/rogue/satchel
 
 	H.taints_loot = TRUE //For that shitty-ass reanimated corpse gear look.

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
@@ -6,7 +6,7 @@
 	outfit = /datum/outfit/job/roguetown/wretch/ancient_spellblade
 	class_select_category = CLASS_CAT_ACCURSED
 	category_tags = list(CTAG_WRETCH)
-	maximum_possible_slots = 2 // Two so that the gimmick isn't overdone
+	maximum_possible_slots = 2 // Two, so the gimmic isn't overdone. Keep in mind these are, very. very. strong.
 	applies_post_equipment = TRUE
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_SHATTER_KILL, TRAIT_ARCYNE, TRAIT_DUSTABLE, TRAIT_BLOODLOSS_IMMUNE)
 	subclass_stats = list(
@@ -25,7 +25,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 	)
-	adv_stat_ceiling = list(STAT_INTELLIGENCE = 12, STAT_CONSTITUTION = 10, STAT_WILLPOWER = 12) //infinite fatigue + spellblade fuckery vs vamp
+	adv_stat_ceiling = list(STAT_INTELLIGENCE = 12, STAT_SPEED = 9, STAT_CONSTITUTION = 10, STAT_WILLPOWER = 12) //infinite fatigue + spellblade fuckery vs vamp
 	extra_context = "This class is unable to be revived and all forms of death will dust you."
 
 /datum/outfit/job/roguetown/wretch/ancient_spellblade
@@ -61,9 +61,9 @@
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy/chain
 	mask = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/lich //Stands out
-	backr = /obj/item/rogueweapon/shield/heater
+	backr = /obj/item/rogueweapon/shield/bronze/paalloy //As a treat, single its single-slotted now
 	backl = /obj/item/storage/backpack/rogue/satchel
 
 	H.taints_loot = TRUE //For that shitty-ass reanimated corpse gear look.

--- a/code/modules/jobs/job_types/roguetown/other/greater_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/greater_skeleton.dm
@@ -246,7 +246,7 @@ NECRO SKELETONS
 	H.STAINT = 1
 
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron/chain
 	pants = /obj/item/clothing/under/roguetown/chainlegs/iron/kilt
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron/heavy
 	shirt = prob(50) ? /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant : /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant/l

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -259,7 +259,6 @@ LICH SKELETONS
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy
 	pants = /obj/item/clothing/under/roguetown/chainlegs/kilt/paalloy //Intended as non-plate, stands out from knights this way.
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/paalloy
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
@@ -315,9 +314,11 @@ LICH SKELETONS
 		if("Sayovard + Cuirass & Hauberk")
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/paalloy
 			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/paalloy
 		if("Bascinet + Heavy Hauberk")
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/paalloy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy/chain
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy/heavy
 	var/tabards = list("Black Tabard", "Black Jupon", "Black Cloak + Greathood", "Black Toga")
@@ -560,7 +561,7 @@ LICH SKELETONS
 
 	backpack_contents = list(
 		/obj/item/natural/feather = 1, //For your helm
-		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1 //Hilarious
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich = 1 //Hilarious
 	)
 
 	H.adjust_blindness(-3)
@@ -612,9 +613,10 @@ LICH SKELETONS
 /datum/outfit/job/roguetown/greater_skeleton/lich/spellblade/pre_equip(mob/living/carbon/human/H)
 	..()
 
+	//1:1 almost w/unbound not including statpacks
 	H.STASTR = 9
-	H.STASPD = 8
-	H.STACON = 10 //Nessessary to keep up with wretches (1 slot only)
+	H.STASPD = 9
+	H.STACON = 10
 	H.STAWIL = 12
 	H.STAINT = 14
 	H.STAPER = 12
@@ -639,7 +641,7 @@ LICH SKELETONS
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/paalloy
 	pants = /obj/item/clothing/under/roguetown/chainlegs/kilt/paalloy
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy/chain
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
@@ -648,7 +650,7 @@ LICH SKELETONS
 
 	backpack_contents = list(
 		/obj/item/natural/feather = 1, //For your helm
-		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1 //Hilarious
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy/rich = 1 //Hilarious
 	)
 
 

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -588,6 +588,10 @@ LICH SKELETONS
 		if("Black Toga")
 			cloak = /obj/item/clothing/cloak/tabard/toga/lich
 
+	if(H.mind) //2 slot, irreplacable skeletons.
+		H.mind.AddSpell(new /datum/action/cooldown/spell/mending) //Gets replaced w/weaker version w/rituos armor, balances out.
+		H.mind.AddSpell(new /datum/action/cooldown/spell/bonemend)
+
 	H.energy = H.max_energy
 
 // Spellblade skeleton. Rarest of the bunch - a true Azurcaephan from the ancient era.

--- a/code/modules/jobs/job_types/roguetown/other/siege_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/siege_skeleton.dm
@@ -154,7 +154,7 @@
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 
 	//intentionally decrepit gear, you're going to die rapidly. You're just here to start some fights and do some shennagions.
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/aalloy
+	head = /obj/item/clothing/head/roguetown/helmet/kettle/aalloy
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 	pants = /obj/item/clothing/under/roguetown/chainlegs/kilt/aalloy
@@ -215,10 +215,6 @@
 
 	//intentionally decrepit gear, you're going to die rapidly. You're just here to start some fights and do some shennagions.
 	cloak = /obj/item/clothing/cloak/tabard/blkknight
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/aalloy
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/aalloy
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 	pants = /obj/item/clothing/under/roguetown/platelegs/aalloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/aalloy
 	neck = /obj/item/clothing/neck/roguetown/gorget/aalloy
@@ -234,6 +230,19 @@
 		if("Grand Mace")
 			r_hand = /obj/item/rogueweapon/mace/goden/aalloy
 			H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+	var/armors = list("Sayovard + Cuirass & Hauberk", "Bascinet + Heavy Hauberk")
+	var/armor_choice = input(H, "Choose your PLATE.", "SHRUG OFF THINE BLOWS.") as anything in armors
+	switch(armor_choice)
+		if("Sayovard + Cuirass & Hauberk")
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/aalloy
+			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/aalloy
+		if("Bascinet + Heavy Hauberk")
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/aalloy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain
+			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
+			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy/heavy
 	var/tabards = list("Black Jupon", "Black Tabard", "Black Cloak", "Black Toga")
 	var/tabard_choice = input(H, "Choose your CLOAK.", "BARE YOUR HERALDRY.") as anything in tabards
 	switch(tabard_choice)

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
@@ -223,7 +223,7 @@
 				id = /obj/item/clothing/neck/roguetown/psicross/noc/aalloy
 			if(4 to 6)
 				id = /obj/item/clothing/neck/roguetown/psicross/abyssor
-	if(prob(70))
+	if(prob(50))
 		r_hand = /obj/item/rogueweapon/huntingknife/idagger/adagger
 		l_hand = /obj/item/rogueweapon/huntingknife/idagger/adagger
 		ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC) //Rapid knives build

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
@@ -246,13 +246,15 @@
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/aalloy
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/aalloy
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 	pants = /obj/item/clothing/under/roguetown/chainlegs/kilt/aalloy
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron/aalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/aalloy
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	if(prob(20)) //20% chance to have overpowered levels of aurafarming
 		mask = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/lich
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain
+	else
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 	if(prob(15))
 		beltl = /obj/item/repair_kit/bad
 	if(prob(10))

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
@@ -205,12 +205,15 @@
 	name = "Skeleton Pirate"
 	head =  /obj/item/clothing/head/roguetown/helmet/tricorn
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/sailor
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy
 	pants = /obj/item/clothing/under/roguetown/tights/sailor
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/aalloy
-	if(prob(10))
-		var/amulet_choice = rand(1, 4)
+	if(prob(20))
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain //DO WHAT YOU WANT BECAUSE A PIRATE IS FREE
+	else
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
+	if(prob(30))
+		var/amulet_choice = rand(1, 6)
 		switch(amulet_choice)
 			if(1)
 				id = /obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy //ZIZO. ZIZO. ZIZO.
@@ -218,7 +221,7 @@
 				id = /obj/item/clothing/neck/roguetown/psicross/aalloy
 			if(3)
 				id = /obj/item/clothing/neck/roguetown/psicross/noc/aalloy
-			if(4)
+			if(4 to 6)
 				id = /obj/item/clothing/neck/roguetown/psicross/abyssor
 	if(prob(50))
 		r_hand = /obj/item/rogueweapon/huntingknife/idagger/adagger

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
@@ -201,13 +201,13 @@
 	H.STASPD = 8
 	H.STACON = 3
 	H.STAWIL = 6
-	H.STAINT = 1
 	name = "Skeleton Pirate"
 	head =  /obj/item/clothing/head/roguetown/helmet/tricorn
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/sailor
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy
 	pants = /obj/item/clothing/under/roguetown/tights/sailor
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/aalloy
+	gloves = /obj/item/clothing/gloves/roguetown/knuckles/decrepit
 	if(prob(20))
 		wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain //DO WHAT YOU WANT BECAUSE A PIRATE IS FREE
 	else
@@ -223,16 +223,21 @@
 				id = /obj/item/clothing/neck/roguetown/psicross/noc/aalloy
 			if(4 to 6)
 				id = /obj/item/clothing/neck/roguetown/psicross/abyssor
-	if(prob(50))
+	if(prob(70))
 		r_hand = /obj/item/rogueweapon/huntingknife/idagger/adagger
+		l_hand = /obj/item/rogueweapon/huntingknife/idagger/adagger
+		ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC) //Rapid knives build
+		H.STAINT = 1
 	else
-		gloves = /obj/item/clothing/gloves/roguetown/knuckles/decrepit
+		r_hand = /obj/item/rogueweapon/sword/sabre/alloy //Its the closet thing to an ancient cutlass, matie
+		H.STAINT = 5 //Not able to do specials, but slightly harder to fient
+
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+	//Uniquely, no shield skill
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE) //YARR
@@ -317,6 +322,7 @@
 
 /datum/outfit/job/roguetown/skeleton/npc/hard/pre_equip(mob/living/carbon/human/H)
 	..()
+	ADD_TRAIT(H, TRAIT_NORUN, TRAIT_GENERIC) //I think the AI respects this, should stop them leaping or w/e which can cause them to lose their weapons.
 	H.STACON = 6
 	H.STAWIL = 10
 	H.STAINT = 1

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
@@ -205,7 +205,7 @@
 	name = "Skeleton Pirate"
 	head =  /obj/item/clothing/head/roguetown/helmet/tricorn
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/sailor
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy
 	pants = /obj/item/clothing/under/roguetown/tights/sailor
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/aalloy
@@ -255,6 +255,8 @@
 		mask = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/lich
 	if(prob(15))
 		beltl = /obj/item/repair_kit/bad
+	if(prob(10))
+		beltr = /obj/item/storage/belt/rogue/pouch/coins/aalloy
 	if(prob(10))
 		var/amulet_choice = rand(1, 3)
 		switch(amulet_choice)
@@ -324,7 +326,6 @@
 		cloak = /obj/item/clothing/cloak/hierophant
 		mask = /obj/item/clothing/mask/rogue/facemask/aalloy
 		head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/lich
-		wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 		pants = /obj/item/clothing/under/roguetown/platelegs/aalloy
 		shoes = /obj/item/clothing/shoes/roguetown/boots/aalloy
 		neck = /obj/item/clothing/neck/roguetown/gorget/aalloy
@@ -332,6 +333,10 @@
 		gloves = /obj/item/clothing/gloves/roguetown/chain/aalloy
 		r_hand = /obj/item/rogueweapon/sword/sabre/alloy
 		l_hand = /obj/item/rogueweapon/sword/sabre/alloy
+		if(prob(20))
+			beltl = /obj/item/repair_kit/bad
+		if(prob(15))
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/aalloy
 		var/amulet_choice = rand(1, 2) //Cultist look so, no Psydon choice
 		switch(amulet_choice)
 			if(1)
@@ -341,8 +346,10 @@
 		if(prob(60))
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/aalloy
 			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 		else
 			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy/heavy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 	else // Withered Dreadknight
 		H.STASPD = 8
@@ -354,6 +361,10 @@
 		neck = /obj/item/clothing/neck/roguetown/gorget/aalloy
 		gloves = /obj/item/clothing/gloves/roguetown/plate/aalloy
 		belt = /obj/item/storage/belt/rogue/leather
+		if(prob(20))
+			beltl = /obj/item/repair_kit/bad
+		if(prob(15))
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/aalloy
 		if(prob(60))
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/aalloy
 		else
@@ -361,8 +372,10 @@
 		if(prob(60))
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/aalloy
 			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 		else
 			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy/heavy
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy/chain
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 		if(prob(15))
 			beltl = /obj/item/repair_kit/metal/bad


### PR DESCRIPTION
## About The Pull Request

Does some minor balance tweaks + Ancient hoplon shield -> wretch unbound spellblade + minor balance tuneups like speed capping unbound skeles maximal to what they spawn w/.

Also adds chain sleaves to certain skeleton loadouts + NPCs. (even greater necromancer skeletons get em)

Venerated deathknights get mending + bonemend akin to their unbound varients, since they're irreplacable 2 slot roles that can't sprint/climb away from conflict as-is.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

*notably pirate skeles were guarrenteed in this screenshot w/chain sleaves* but its a 20% chance.

<img width="806" height="511" alt="ChainSydes" src="https://github.com/user-attachments/assets/aa7f7052-e02b-4965-be82-81b142049093" />

<img width="345" height="336" alt="Spellblades" src="https://github.com/user-attachments/assets/4ea02bd0-c6fc-4b30-90a1-c1b1d6aafa91" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Using assets we have is nice, this should make a bit of skeleton varience.

The bracers should help spellblade skeletons stand out a bit more from the legionnaries beyond the hijab and actively using their powers until we've proper traditional Tirachean armor for undead spellblades like different helms.

Skeleton pirates shouldn't randomly break in their AI because they lack a weapon, now they will + they'll be scary again because their knife choice is rougher.

Skele pirates have abyssor amulets more often than other ones, immurshion. YARRGH.

---

Deathknights should be a bit trickier to kill when they're amongst numbers as-intended w/out the need of rituos, while still being easy to overwhelm and destroy if they're caught alone.

They still can't sprint/climb at all, so its more of a matter of letting them get some swings in and back up behind numbers with the hope nobody snipes their chest w/blunt weaponry while they're recovering.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added chain sleaves to certain skeleton + NPC skeleton loadouts that didn't use them before.
add: Pirate skeletons sometimes take swords instead of unarmed (this can be reverted when the AI doesn't break and runtime w/out weapons)
balance: Pirate skeletons have more chance of amulets, these will usually be Abyssorian amulets.
balance: certain unbound deathknight/bulwark/siege bulwark armor choices have chain sleaves instead of bracers.
balance: siege feral bulwarks can pick armor choice like lich skele ones (the armor is still absolutely awful, you're a disposable antagonist sire.)
balance: unbound spellblade uses the slightly weaker gilbranze hoplon shield, it has slightly better ranged resist (5%ish) in exchange for less durability.
balance: unbound skeletons are speed-capped to their starting speed level at maximal.
balance: elite lich skeletons get a rich-varient of the palloy coin pouches for kicks and giggles, these ones have 3 piles of higher-mincapped ancient alloy coins.
balance: NPC skeleton knights can no longer sprint (hopefully) this should stop them leaping and falling over losing their weapons.
balance: NPC skele knights can carry armor repair kits sometimes.
balance: NPC skeletons randomly have pouches of ancient alloy coin.
balance: Venerated lich deathknights have mending + bonemending.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
