### PR TITLE
[Miracles] - Declaws dendor cleric kneestingers

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -39,14 +39,8 @@
 			if(world.time > L.last_client_interact + 0.2 SECONDS)
 				return FALSE
 
-		var/electrodam = 30
-		if(world.time < (L.mob_timers["kneestinger"] + 30 SECONDS))
-			electrodam = 15
-
-		if(L.electrocute_act(electrodam, src))
-			L.mob_timers["kneestinger"] = world.time
-			src.take_damage(30)
-			L.consider_ambush(always = TRUE)
+		if(can_zap(mover))
+			do_zap(mover)
 			if(L.throwing)
 				L.throwing.finalize(FALSE)
 			if(mover.loc != loc && L.stat == CONSCIOUS)
@@ -135,13 +129,26 @@
 	qdel(src)
 
 /obj/structure/glowshroom/dendorite
-	var/timeleft = null //5 MINUTES //balancing factor no longer relevant, uncommoent if gay.
+	var/timeleft = 5 MINUTES
 
 /obj/structure/glowshroom/dendorite/Initialize()
 	. = ..()
 	if(timeleft)
-		QDEL_IN(src, timeleft)
+		addtimer(CALLBACK(src, PROC_REF(timed_out)), timeleft)
 
 /obj/structure/glowshroom/dendorite/attackby(obj/item/W, mob/user, params)
 	// Dendorite glowshrooms don't electrocute when hit
 	. = ..()
+
+/obj/structure/glowshroom/dendorite/do_zap(atom/movable/movable_victim)
+	visible_message(span_warning("[src] shocks [movable_victim]!"))
+	if(isliving(movable_victim))
+		var/mob/living/L = movable_victim
+		L.lightning_shock(src)
+	else if(isatom(movable_victim))
+		var/atom/A = movable_victim
+		A.fire_act()
+	qdel(src)
+
+/obj/structure/glowshroom/dendorite/proc/timed_out()
+	qdel(src)

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -163,7 +163,7 @@
 	for(var/X in GLOB.cardinals)
 		var/turf/TT = get_step(T, X)
 		if(!isclosedturf(TT) && !locate(/obj/structure/glowshroom) in TT)
-			new /obj/structure/glowshroom(TT)
+			new /obj/structure/glowshroom/dendorite(TT)
 	return TRUE
 
 


### PR DESCRIPTION
## About The Pull Request
- Makes Dendor kneestingers shock instead of hardstun.
- Kneestingers created by miracles time out after 5 minutes

## Testing Evidence
<img width="1237" height="567" alt="image" src="https://github.com/user-attachments/assets/d7dae25e-a2d3-418a-a147-281482368a8f" />

## Why It's Good For The Game
Same effect as Fulmen! Lightningbolts.
Aka just a 6 second slowing debuff that nukes 6 statpoints and makes it so you can't swing properly.
Planting a ton of kneestingers, especially behind vines, isn't exactly interesting, so now they despawn after five minutes.

## Changelog

:cl:
balance: Miracle kneestingers time out, and don't hardstun when shocking.
/:cl:
