### PR TITLE
OOPS - fixes triumph-purchasasble shoulderguard's filepath in the loadout

### DIFF
--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -647,6 +647,6 @@
 
 /datum/loadout_item/shoulderguardstandalone
 	name = "Standalone Decoration, Shoulderguard"
-	path = /datum/loadout_item/donator/universal/armorpiece_shoulderguard
+	path = /obj/item/clothing/cloak/tabard/stabard/donator_shoulderguard
 	triumph_cost = 3
 	sort_category = "Triumphs"


### PR DESCRIPTION
## About The Pull Request

g

## Testing Evidence

a

## Why It's Good For The Game

s ter

## Changelog

fix: Shoulderguards in the Triumph Loadout section should no longer inexplicably cease to exist.

/:cl: