### PR TITLE
[FIX ? ] - Bad Trainer Logic + Bad Trainer Skill Level Target

### DIFF
--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -312,7 +312,7 @@
 					if(!HAS_TRAIT(U, TRAIT_GOODTRAINER))
 						skill_target -= SKILL_LEVEL_NOVICE
 					if(HAS_TRAIT(U, TRAIT_BADTRAINER))
-						skill_target -= SKILL_LEVEL_APPRENTICE
+						skill_target -= SKILL_LEVEL_NOVICE
 					if (can_train_combat_skill(src, used_weapon.associated_skill, skill_target))
 						mind.add_sleep_experience(used_weapon.associated_skill, max(round(STAINT*exp_multi), 0), FALSE)
 
@@ -322,8 +322,8 @@
 						var/skill_target = defender_skill
 						if(!HAS_TRAIT(src, TRAIT_GOODTRAINER))
 							skill_target -= SKILL_LEVEL_NOVICE
-						if(HAS_TRAIT(U, TRAIT_BADTRAINER))
-							skill_target -= SKILL_LEVEL_APPRENTICE
+						if(HAS_TRAIT(src, TRAIT_BADTRAINER))
+							skill_target -= SKILL_LEVEL_NOVICE
 						if (can_train_combat_skill(U, attacker_skill_type, skill_target))
 							U.mind.add_sleep_experience(attacker_skill_type, max(round(STAINT*exp_multi), 0), FALSE)
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
So downstream I have been trying to figure out how intentional it was for Knights to be able to hit Legendary weapons by fighting a Veteran (EDIT: which might have been a false positive I am finding out, yippeeeee....)

In the process, it was pointed out that the current logic behind Bad Trainer seems to have a misplaced check.

If any of this is faulty assumptions I do apologize! But figured I'd send this upstream just to be safe given much of the trainer-check is 10 months untouched.

BEFORE
Defender Side
!HAS_TRAIT U
HAS_TRAIT U
can_train_combat_skill (src)

Attacker Side
!HAS_TRAIT src
HAS_TRAIT U
can_train_combat_skill (U)

AFTER
Attacker Side
!HAS_TRAIT src
HAS_TRAIT src
can_train_combat_skill (U)

In tandem, I also changed it so Bad Trainer properly adds -2 to the skill_target, given it stacks with the previous lack of Good Trainer.

Should now pan out that:
Good Trainer = Same Skill Level
No Good Trainer = Skill Level -1
Bad Trainer = Skill Level -2

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
BEFORE
<img width="555" height="278" alt="image" src="https://github.com/user-attachments/assets/35e77135-b91f-40e8-8a93-fb010c2f9c0b" />

AFTER
<img width="582" height="413" alt="image" src="https://github.com/user-attachments/assets/826504c4-65c1-41ef-98db-ac67795bfe0d" />

Code used for text checks included for review
<img width="1042" height="607" alt="image" src="https://github.com/user-attachments/assets/c8cc0d79-3779-4d13-8f58-4c6694545d7a" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Bad Trainer now properly targets a skill level TWO LEVELS BELOW the starting skill level, as it states in text
Should also properly configure Bad Trainer on the attacker side? Let myself get beaten up by white stag and a Master Level NPC as a Journeyman Advent and the most I reached was Expert Swords vs the White Stag

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fixed Bad trainer Trait check to src instead of user
fix: fixed Bad trainer Trait targeting -3 levels below instead of -2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
