### PR TITLE
Ctrl key no longer halt movement

### DIFF
--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -2,54 +2,53 @@
 // Only way to do that is to tie the behavior into the focus's keyLoop().
 
 /atom/movable/keyLoop(client/user)
-	if(!user.keys_held["Ctrl"])
-		var/movement_dir = NONE
-		for(var/_key in user.keys_held)
-			movement_dir = movement_dir | user.movement_keys[_key]
-		if(user.next_move_dir_add)
-			movement_dir |= user.next_move_dir_add
-		if(user.next_move_dir_sub)
-			movement_dir &= ~user.next_move_dir_sub
-		if(!(movement_dir & (movement_dir - 1))) //Cardinal move
-			lastcardpress = movement_dir
-		else
-			if(movement_dir & NORTH)
-				if(movement_dir & EAST)
-					if(lastcardpress == NORTH)
-						movement_dir = EAST
-					else if(lastcardpress == EAST)
-						movement_dir = NORTH
-					else
-						movement_dir = pick(NORTH,EAST)
-						lastcardpress = movement_dir
-				else if(movement_dir & WEST)
-					if(lastcardpress == NORTH)
-						movement_dir = WEST
-					else if(lastcardpress == WEST)
-						movement_dir = NORTH
-					else
-						movement_dir = pick(NORTH,WEST)
-						lastcardpress = movement_dir
-			else if(movement_dir & SOUTH)
-				if(movement_dir & EAST)
-					if(lastcardpress == SOUTH)
-						movement_dir = EAST
-					else if(lastcardpress == EAST)
-						movement_dir = SOUTH
-					else
-						movement_dir = pick(SOUTH,EAST)
-						lastcardpress = movement_dir
-				else if(movement_dir & WEST)
-					if(lastcardpress == SOUTH)
-						movement_dir = WEST
-					else if(lastcardpress == WEST)
-						movement_dir = SOUTH
-					else
-						movement_dir = pick(WEST,SOUTH)
-						lastcardpress = movement_dir
-		// Sanity checks in case you hold left and right and up to make sure you only go up
-		if((movement_dir & NORTH) && (movement_dir & SOUTH))
-			movement_dir &= ~(NORTH|SOUTH)
-		if((movement_dir & EAST) && (movement_dir & WEST))
-			movement_dir &= ~(EAST|WEST)
-		user.Move(get_step(src, movement_dir), movement_dir)
+	var/movement_dir = NONE
+	for(var/_key in user.keys_held)
+		movement_dir = movement_dir | user.movement_keys[_key]
+	if(user.next_move_dir_add)
+		movement_dir |= user.next_move_dir_add
+	if(user.next_move_dir_sub)
+		movement_dir &= ~user.next_move_dir_sub
+	if(!(movement_dir & (movement_dir - 1))) //Cardinal move
+		lastcardpress = movement_dir
+	else
+		if(movement_dir & NORTH)
+			if(movement_dir & EAST)
+				if(lastcardpress == NORTH)
+					movement_dir = EAST
+				else if(lastcardpress == EAST)
+					movement_dir = NORTH
+				else
+					movement_dir = pick(NORTH,EAST)
+					lastcardpress = movement_dir
+			else if(movement_dir & WEST)
+				if(lastcardpress == NORTH)
+					movement_dir = WEST
+				else if(lastcardpress == WEST)
+					movement_dir = NORTH
+				else
+					movement_dir = pick(NORTH,WEST)
+					lastcardpress = movement_dir
+		else if(movement_dir & SOUTH)
+			if(movement_dir & EAST)
+				if(lastcardpress == SOUTH)
+					movement_dir = EAST
+				else if(lastcardpress == EAST)
+					movement_dir = SOUTH
+				else
+					movement_dir = pick(SOUTH,EAST)
+					lastcardpress = movement_dir
+			else if(movement_dir & WEST)
+				if(lastcardpress == SOUTH)
+					movement_dir = WEST
+				else if(lastcardpress == WEST)
+					movement_dir = SOUTH
+				else
+					movement_dir = pick(WEST,SOUTH)
+					lastcardpress = movement_dir
+	// Sanity checks in case you hold left and right and up to make sure you only go up
+	if((movement_dir & NORTH) && (movement_dir & SOUTH))
+		movement_dir &= ~(NORTH|SOUTH)
+	if((movement_dir & EAST) && (movement_dir & WEST))
+		movement_dir &= ~(EAST|WEST)
+	user.Move(get_step(src, movement_dir), movement_dir)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -45,7 +45,7 @@
 		keys_held.Cut(1,2)
 	keys_held[_key] = TRUE
 	var/movement = movement_keys[_key]
-	if(!(next_move_dir_sub & movement) && !keys_held["Ctrl"])
+	if(!(next_move_dir_sub & movement))
 		next_move_dir_add |= movement
 
 	// Client-level keybindings are ones anyone should be able to do at any time


### PR DESCRIPTION
## About The Pull Request
Ctrl Key no longer halts your movement

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested locally, works.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This is a legacy feature from eons ago and greatly restrict my usage of Ctrl as the default combo keybind.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Ctrl Key no longer halts your movement.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
