### PR TITLE
Minor vamp battlemage change

### DIFF
--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -466,13 +466,13 @@
 	H.dna.species.soundpack_m = GLOB.voice_packs[/datum/voicepack/male/wizard] //Every wizzard gotta have the evyl laugh, I don't make the rules, sire.
 	add_verb(H, /mob/proc/haltyell_exhausting) //Halting the charred corpse is too funny, we're keeping it. sovl.
 
-	//UNIQUELY relies on WARDS off-the-bat, vs wretches/advs/mercenaries. Has NO chest armor, or head armor, save for neck. Legs/Feet remain decently armored by intent. Go for their arms instead.
+	//UNIQUELY relies on WARDS off-the-bat, vs wretches/advs/mercenaries. Has NO armor, save for neck/feet, this is intended so you can't speedrun decapitate them on swift intent.
 	cloak = /obj/item/clothing/cloak/tabard/stabard/hoodvamp
 	head = /obj/item/clothing/head/roguetown/witchhat/vamp //EVERY PALLY IN THE KINGDOM ON MA TAIL
 	mask = /obj/item/clothing/mask/rogue/ragmask/black
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/white
 	armor = /obj/item/clothing/cloak/tabard/stabard/vamp
-	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	pants = /obj/item/clothing/under/roguetown/skirt/vamp
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy //No head armor but good anti-decap armor, intended.
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	belt = /obj/item/storage/belt/rogue/leather/battleskirt
@@ -516,3 +516,8 @@
 
 /obj/item/clothing/head/roguetown/roguehood/studded/vamp
 	color = CLOTHING_RED
+
+/obj/item/clothing/under/roguetown/skirt/vamp
+	name = "silken magos kilt"
+	desc = "A lightly-enchanted fashionable Kilt-like skirting designed to slide under a tabard. Despite seeming impractical as if it would get caught on something, it weaves around it as the fabric moves like it has a lyfe of its own and never gets caught."
+	color = CLOTHING_WHITE


### PR DESCRIPTION
## About The Pull Request

Heavy trousers -> Silken magos kilt (Its a white skirt with unique flavor text)

I intended to do this back in https://github.com/Azure-Peak/Azure-Peak/pull/7842 I just couldn't find anything that fit at the time so I left their current leg armor.

The boots/gorget are balance-wise intended as-is. They look good or serve the purpose of making them distinctively obvious until they get a steel changeover smithed.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

A few lines of code sire, it'll work.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Finally loosens off the last bit of starting gear that makes them a bit too hard to incapacitate since they have vampire potencies on top of magics. Which IS intended to be strong.

It also just goes better with their fit anyway.

---

Boots/Gorget remain by intent, you aren't cheesing them with mantraps or swift intent on neck if they fall over, unless they aren't paying attention and their gorget breaks.

Your staff can still keep you upright until they rid both of your legs, it just makes running off a bit harder if people go for the legs and your ward fails. Until you invest in armor, vamps are intended to interact w/town before unleashing their calamity.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added silken magos kilt -> vamp magos guard - no more leg armor off-the-bat for style, your ward will suffice anyway + vamp potencies
balance: Vampire battlemages now lose their leg armor for a swanky kilt, knocking them down to finish off should be a bit easier until they invest into armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
