### PR TITLE
disables VL from rolling

### DIFF
--- a/code/modules/events/antagonist/solo/vampires.dm
+++ b/code/modules/events/antagonist/solo/vampires.dm
@@ -27,6 +27,9 @@
 
 	restricted_roles = DEFAULT_ANTAG_BLACKLISTED_ROLES
 
+/datum/round_event_control/antagonist/solo/vampires/canSpawnEvent(players_amt, gamemode, fake_check)
+	return FALSE
+
 /datum/round_event_control/antagonist/solo/vampires/preRunEvent()
 	if(is_storyteller_villain_blocked())
 		return EVENT_CANT_RUN


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin. Other hard antags will roll instead

## Testing Evidence
you can understand why this is hard to test. but like it's 1 "return false" so

## Why It's Good For The Game
I know this is going to be controversial, and my goal here is not to start a flamewar. Every analysis of VL's design, which have happened many a time in the discord, has concluded that the antag's design is not healthy, in several ways, which I will collate here:
- first, vampires in general are a very strange system that doesn't really fit our lore _or_ gameplay. it's some weird VtM stuff that is very unintuitive in a lot of ways and really should be replaced with something more fitting, but nobody seems to want to do that, and with transfix being fixed the loudest pain point has at least been relieved. for normal lyckers, anyway. when it comes down to VL specifically, all the problems are amplified by their massively increased power level
- they are actively encouraged to not engage with the round. their scaling requires forcibly converting other players (an iffy concept at best; conversion antags are very unpopular) and grinding vitae (which, because this is something they have to do to _gain_ strength, they're encouraged to farm it on NPCs or pick on weak players that can't fight back, until they can steamroll pvp). this also means that VLs are encouraged to grind for 2 hours and then show up hyperstatted, post sunrip/ascension, to sweep through the keep. it's not a fun gameplay experience for anyone involved, and it usually means most players just don't see the round's major antag until the round is nearly over!
- they are 'overpowered' in two directions at once. their conversion, summoning, and ascension mechanics mean that once they grind, they have a powerful army; however, with their clan abilities and especially ascension, _they themselves_ are monstrosities with 40 force punches, celerity, and all the weird vampire mental abilities that they share with lyckers. they turn up all the issues with lyckers (being too snowflakey/weird/hard to know how to counter) to eleven with more potent forms of everything and a genuinely insane high end. if an antag is meant to build an army, like lich, they should be comparatively weak if fought alone... but they aren't. they get the best of both worlds, which isn't fun for anyone
- the lack of defining lore for the class, since all the abilities just tell you about VtM stuff that isn't applicable, means most people play them in a way that stonewalls RP in favor of 'hahaha i'm 3000 years old i don't have to listen to you'. Even if we stick with the VtM themeing of "they should at least try to blend in and do intrigue", VL players that try that approach report it is incredibly weak compared to just powergaming the vitae grind and potencestacking. VL has thus ended up as a sort of "lich+", down to being patronlocked to zizo despite our lore having vampires as a firmly astratan thing

every time you end up with the prospect of fighting a VL, most people will just actively avoid engaging with the antag - which is a sure sign of an unhealthy design - but because they can just celerity + grab you + punch/stab through your plate in 3 shots and force you to convert or die, you don't even have that option most of the time (even on a mage with fortitude+haste+etc you can't really run from a celerity-using vampire)

so, what we have is an antagonist that can build armies like lich, is actively encouraged to not engage with the round and powergame, has all the problems associated with a conversion antag (see: every "i hate werevolf" conversation), all the problems associated with lyckers but amplified by their higher threat level, _and_ all the problems involved with an antag with basically zero integration with our lore (= it attracts only fraggers instead of roleplayers). 

the solution? rework VL into something that leans into the masquerade aspect, by giving them tools related to army-building and intrigue, the diplomat to lich's skeleton hyperwar fragger. however, nobody is working on that yet (and i definitely won't be able to until at least MGL3 and mage 3 are done), so in the meantime, i do not think we should keep this unhealthy antagonist in the game. one might say "just rework it instead of removing it", but the time investment required would be quite a lot and in the meantime we will have people burning out and actively avoiding rounds with the antag because it's just not well-designed. better for everyone, i think, to just turn it off until someone fixes it

## Changelog
:cl:
del: Vampire Lords can no longer roll without admin intervention. 
/:cl: