### PR TITLE
second-chance & revs have gross blood

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -222,6 +222,7 @@
 #define TRAIT_LEPROSY "Leprosy"
 #define TRAIT_NUDE_SLEEPER "Nude Sleeper"
 #define TRAIT_SILVER_BLESSED "Silverblessed"
+#define TRAIT_TOXIC_BLOOD "Cursed Blood"
 #define TRAIT_UNLYCKERABLE "Lycker Immunity"
 #define TRAIT_OUTLAW "Outlaw"
 #define TRAIT_ALDERMAN "Alderman of the Assembly"
@@ -468,6 +469,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_LESSER_REVERSE_GUIDANCE = span_warning("Something faintly hinders me in battle, my strikes and defenses feel slightly imprecise."),
 	TRAIT_DEPRAVED = span_info("The languid scent of Her debauchery is known to me."),
 	TRAIT_SILVER_BLESSED = span_info("I have been baptized in fire. Blessed silverdust flows through my blood, protecting me from both vampyrism and lycanthropy."),
+	TRAIT_TOXIC_BLOOD = span_info("The curse nestled deep within my lux has rendered my vitae toxic."),
 	TRAIT_UNLYCKERABLE = span_info("My kind cannot bear the Sun curse for it already has another."),
 	TRAIT_GOODTRAINER = span_info("I am a good teacher, and when it comes to weaponry I can train others to be just as skilled as I am."),
 	TRAIT_BADTRAINER = span_info("I've spent yils studying the art of a single weapon, but unfortunately I've no patience to train anyone else. Everyone learning from me will only learn up to two skill levels below mine."),

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -721,6 +721,9 @@
 					else
 						. += "<font size = 3><i>[skilldiff_report(skilldiff)] in my wielded skill than they are in theirs.</i></font>"
 
+	if(user != src && user.mind?.has_antag_datum(/datum/antagonist/vampire) && (HAS_TRAIT(src, TRAIT_TOXIC_BLOOD) || mind?.has_antag_datum(/datum/antagonist/werewolf) || mind?.has_antag_datum(/datum/antagonist/zombie)))
+		. += span_warning("[p_their(TRUE)] vitae is tainted. Consuming it is likely unwise.")
+
 	if(lip_style)
 		switch(lip_color)
 			if("red")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
@@ -26,7 +26,7 @@
 	is_subrace = TRUE
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,MUTCOLORS)
 	default_features = MANDATORY_FEATURE_LIST
-	inherent_traits = list(TRAIT_EASYDECAPITATION, TRAIT_NOHUNGER, TRAIT_NOBREATH, TRAIT_DEATHLESS, TRAIT_ZOMBIE_IMMUNE) //Given the deathless traits inherently as part of their nature as pseudo-undead.
+	inherent_traits = list(TRAIT_EASYDECAPITATION, TRAIT_NOHUNGER, TRAIT_NOBREATH, TRAIT_DEATHLESS, TRAIT_ZOMBIE_IMMUNE, TRAIT_TOXIC_BLOOD) //Given the deathless traits inherently as part of their nature as pseudo-undead.
 	use_skintones = TRUE
 	disliked_food = NONE
 	liked_food = NONE

--- a/code/modules/vampire_neu/bloodsuck.dm
+++ b/code/modules/vampire_neu/bloodsuck.dm
@@ -63,10 +63,14 @@
 			addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon, vomit), 0, TRUE), rand(8 SECONDS, 15 SECONDS))
 		return
 
-	if(HAS_TRAIT(victim, TRAIT_TOXIC_BLOOD) || victim.mind?.has_antag_datum(/datum/antagonist/werewolf) || (victim.stat != DEAD && victim.mind?.has_antag_datum(/datum/antagonist/zombie)))
+	if(HAS_TRAIT(victim, TRAIT_BLACKBLOOD) || victim.mind?.has_antag_datum(/datum/antagonist/werewolf) || (victim.stat != DEAD && victim.mind?.has_antag_datum(/datum/antagonist/zombie)))
 		to_chat(src, span_danger("I'm going to puke..."))
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon, vomit), 0, TRUE), rand(8 SECONDS, 15 SECONDS))
 		return
+	
+	if(HAS_TRAIT(victim, TRAIT_TOXIC_BLOOD)) // lesser aversion - blood's gross, but doesn't stop you from drinking/turning
+		to_chat(src, span_danger("I'm going to puke..."))
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon, vomit), 0, TRUE), rand(8 SECONDS, 15 SECONDS))
 
 	src.adjust_hydration(10) // da sippy
 

--- a/code/modules/vampire_neu/bloodsuck.dm
+++ b/code/modules/vampire_neu/bloodsuck.dm
@@ -63,7 +63,7 @@
 			addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon, vomit), 0, TRUE), rand(8 SECONDS, 15 SECONDS))
 		return
 
-	if(HAS_TRAIT(victim, TRAIT_BLACKBLOOD) || victim.mind?.has_antag_datum(/datum/antagonist/werewolf) || (victim.stat != DEAD && victim.mind?.has_antag_datum(/datum/antagonist/zombie)))
+	if(HAS_TRAIT(victim, TRAIT_TOXIC_BLOOD) || victim.mind?.has_antag_datum(/datum/antagonist/werewolf) || (victim.stat != DEAD && victim.mind?.has_antag_datum(/datum/antagonist/zombie)))
 		to_chat(src, span_danger("I'm going to puke..."))
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon, vomit), 0, TRUE), rand(8 SECONDS, 15 SECONDS))
 		return

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -201,6 +201,8 @@
 			QDEL_NULL(src)
 			return
 
+		ADD_TRAIT(recipient, TRAIT_TOXIC_BLOOD, TRAIT_VIRTUE) // you're either undead or some other nite-creechur, if deadites can't be drained for vitae neither can you
+
 		for(var/choice in picked_choices)
 			switch(choice)
 				if(SC_ROTCURED)


### PR DESCRIPTION
## About The Pull Request
Vampire blood-sucking had a check for, specifically: deadites, werevolfs, and blackblooded subvirtue, that caused the blood to be toxic (you can't get vitae out of it + it makes you vomit if you try). This really should be extended to the other second chance subvirtues, rotcured (effectively a deadite), pallid (your blood's full of otavan anti-vamp chemical warfare), and revenants (you're just a weirder deadite). However, given concerns over balance, this doesn't actually prevent vamps from gaining vitae or turning you - your blood's just supernaturally gross (corpse blood/otavan chemicalslop), so they vomit.

also added an examine so vampires can tell this, where previously they couldn't - the examine text is the same for both lesser (second chance+rev) and greater (blackblood, werevolf, actual deadite) blood toxicity (again, only the latter actually prevents blood drinking)

## Testing Evidence
<img width="521" height="50" alt="image" src="https://github.com/user-attachments/assets/2bdf7498-abe4-4636-a8e2-cdcc8e7f39d2" />
<img width="509" height="193" alt="image" src="https://github.com/user-attachments/assets/07941903-4395-4ec0-be16-425fa2925b28" />
<img width="435" height="128" alt="image" src="https://github.com/user-attachments/assets/52d39255-2142-49e3-805d-526b583bec6b" />


## Why It's Good For The Game
It makes no sense to try to extract vitae from any of the "basically some form of deadite" characters, but the fact that there's no mechanical enforcement for that (except blackblood and in-round-turned deadites specifically) means everyone ignores it and pretends it's fine. This makes the mechanic work consistently and should be more immersive, while also not stonewalling vampires entirely.

## Changelog

:cl:
fix: Rotcured, pallid, and revenants now have toxic blood - vamps can still drink it and turn you and such, but it'll probably make you throw up.
/:cl: