### PR TITLE
[Tweak] Butcher time is taking too LONG

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -210,9 +210,11 @@
 			if(skeletonized)
 				to_chat(user, span_warning("There's not even a sliver of flesh on this!"))
 				return
-			var/used_time = 210
+			var/used_time = 5 SECONDS
 			if(user.mind)
-				used_time -= (user.get_skill_level(/datum/skill/labor/butchering) * 30)
+				used_time -= (user.get_skill_level(/datum/skill/labor/butchering))
+			if(used_time < 1 SECONDS)
+				used_time = 1 SECONDS
 			visible_message("[user] begins to butcher \the [src].")
 			playsound(src, 'sound/foley/gross.ogg', 100, FALSE)
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -212,7 +212,7 @@
 				return
 			var/used_time = 5 SECONDS
 			if(user.mind)
-				used_time -= (user.get_skill_level(/datum/skill/labor/butchering))
+				used_time -= (user.get_skill_level(/datum/skill/labor/butchering) * 1 SECONDS)
 			if(used_time < 1 SECONDS)
 				used_time = 1 SECONDS
 			visible_message("[user] begins to butcher \the [src].")


### PR DESCRIPTION
## About The Pull Request

- Streamlines mono-butchering to a min. of 1 second, max of 5 seconds.

## Testing Evidence

Value changes.

## Why It's Good For The Game

https://www.youtube.com/watch?v=XK6Bu12zq2c

## Changelog
:cl:
balance: Mono-butchering was taking quadruple as long as whole simplemob butchering with no skill.
/:cl: