### PR TITLE
Unarmed Parry / Spellfist Tweaks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -291,7 +291,7 @@
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 4, ward = TRUE)
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -1,6 +1,6 @@
 // Unarmed base weapon defense equivalents — fed into the same (skill * 20) + (wdef * 10) formula as weapons
 #define UNARMED_BASE_WDEF_BARE 2		// Bare fists — still bad, but not hopeless
-#define UNARMED_BASE_WDEF_EQUIPPED 9	// Bracers / knuckles / bandages — 90 base parry for expert pugilists
+#define UNARMED_BASE_WDEF_EQUIPPED 8	// Bracers / knuckles / bandages — 80 base parry for expert pugilists
 
 /mob/living/proc/attempt_parry(datum/intent/intenty, mob/living/user)
 	var/prob2defend = user.defprob

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -1,6 +1,6 @@
 // Unarmed base weapon defense equivalents — fed into the same (skill * 20) + (wdef * 10) formula as weapons
 #define UNARMED_BASE_WDEF_BARE 2		// Bare fists — still bad, but not hopeless
-#define UNARMED_BASE_WDEF_EQUIPPED 7	// Bracers / knuckles / bandages — matches a rapier
+#define UNARMED_BASE_WDEF_EQUIPPED 9	// Bracers / knuckles / bandages — 90 base parry for expert pugilists
 
 /mob/living/proc/attempt_parry(datum/intent/intenty, mob/living/user)
 	var/prob2defend = user.defprob

--- a/code/modules/spells/spell_types/classunique/spellblade/anime_spells_helper.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/anime_spells_helper.dm
@@ -2,7 +2,7 @@
 These mirror the species.dm melee attack flow (armor check -> apply_damage -> bodypart_attacked_by)
 without going through the click pipeline, so spells can deliver weapon-style strikes. */
 
-/proc/arcyne_strike(mob/living/carbon/human/user, mob/living/target, obj/item/weapon, damage, def_zone, blade_class_override, armor_penetration = 0, spell_name = "Arcyne Strike", skip_animation = FALSE, skip_message = FALSE, allow_shield_check = FALSE, damage_type = BRUTE, npc_simple_damage_mult = 1, intdamage_factor)
+/proc/arcyne_strike(mob/living/carbon/human/user, mob/living/target, obj/item/weapon, damage, def_zone, blade_class_override, armor_penetration = 0, spell_name = "Arcyne Strike", skip_animation = FALSE, skip_message = FALSE, allow_shield_check = FALSE, damage_type = BRUTE, npc_simple_damage_mult = 1, intdamage_factor, exact_zone = FALSE)
 	if(!user || !target || QDELETED(user) || QDELETED(target))
 		return FALSE
 
@@ -36,7 +36,8 @@ without going through the click pipeline, so spells can deliver weapon-style str
 	// Base accuracy from PER/INT: 60 base + 10 per point of PER above 10 + 10 per point of INT above 10
 	// Below 10 penalizes instead. A class-intended spellblade (PER ~12, INT ~12) gets ~100 base accuracy.
 	// This feeds into bullet_hit_accuracy_check which caps ultra-precise at 50%, precise at 75%, face at 30%.
-	if(def_zone != BODY_ZONE_CHEST && isliving(target))
+	// exact_zone bypasses the roll entirely, striking precisely where the caster aimed.
+	if(!exact_zone && def_zone != BODY_ZONE_CHEST && isliving(target))
 		var/base_accuracy = 60
 		base_accuracy += (user.STAPER - 10) * 10
 		base_accuracy += (user.STAINT - 10) * 10

--- a/code/modules/spells/spell_types/classunique/spellfist/storm_of_psydon.dm
+++ b/code/modules/spells/spell_types/classunique/spellfist/storm_of_psydon.dm
@@ -7,7 +7,7 @@
 		Requires 7 Momentum: 3 punches + 1 kick (20 damage each). \
 		Overcharged at 10 Momentum: 9 punches + 1 kick (20 damage each). \
 		Cannot be parried or dodged - only Defend stance can interrupt. \
-		Consumes all momentum. If you miss, half cooldown is applied.\n\n\
+		Consumes all momentum only on a successful hit. If you miss, your momentum is kept and half cooldown is applied.\n\n\
 		'Temper the storm within, and unleash it only upon those who stray from His ways.'"
 	sound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
 	spell_color = GLOW_COLOR_BUFF
@@ -23,7 +23,7 @@
 
 	charge_required = TRUE
 	weapon_cast_penalized = FALSE
-	charge_time = 2 SECONDS
+	charge_time = 1 SECONDS
 	hold_drain = 0
 	charge_slowdown = CHARGING_SLOWDOWN_NONE
 	charge_sound = 'sound/magic/charging.ogg'
@@ -76,8 +76,6 @@
 
 	var/stacks = M.stacks
 	var/is_full = stacks >= empowered_momentum
-	M.consume_all_stacks()
-	to_chat(H, span_notice("All [stacks] momentum released into the storm!"))
 
 	var/mob/living/preferred_target
 	if(isliving(cast_on))
@@ -106,6 +104,7 @@
 			StartCooldown(get_adjusted_cooldown() / 2)
 			return TRUE
 		H.visible_message(span_danger("<b>[H] latches onto [preferred_target], unleashing a flurry of blows!</b>"))
+		release_momentum(H, M, stacks)
 		if(is_full)
 			oraora(H, preferred_target)
 		else
@@ -175,12 +174,18 @@
 		StartCooldown(get_adjusted_cooldown() / 2)
 		return TRUE
 
+	release_momentum(H, M, stacks)
 	if(is_full)
 		oraora(H, hit_target)
 	else
 		oraora_lame(H, hit_target)
 	StartCooldown(get_adjusted_cooldown())
 	return TRUE
+
+/datum/action/cooldown/spell/storm_of_psydon/proc/release_momentum(mob/living/carbon/human/H, datum/status_effect/buff/arcyne_momentum/M, stacks)
+	if(M)
+		M.consume_all_stacks()
+	to_chat(H, span_notice("All [stacks] momentum released into the storm!"))
 
 /datum/action/cooldown/spell/storm_of_psydon/proc/combo_valid(mob/living/carbon/human/user, mob/living/target)
 	if(QDELETED(user) || QDELETED(target))
@@ -237,6 +242,8 @@
 /datum/action/cooldown/spell/storm_of_psydon/proc/oraora(mob/living/carbon/human/user, mob/living/target)
 	user.changeNext_move(CLICK_CD_MELEE * 3)
 
+	var/target_zone = user.zone_selected || BODY_ZONE_CHEST	// Every punch lands where the caster aimed.
+
 	var/list/shadows = create_shadows(user, target)
 	var/obj/effect/after_image/shadow_left = shadows[1]
 	var/obj/effect/after_image/shadow_right = shadows[2]
@@ -274,7 +281,7 @@
 				combo_broken = TRUE
 				break
 			hit_num++
-			arcyne_strike(user, target, null, punch_damage, pick(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM), BCLASS_BLUNT, spell_name = "Storm of Psydon (Punch [hit_num])")
+			arcyne_strike(user, target, null, punch_damage, target_zone, BCLASS_BLUNT, spell_name = "Storm of Psydon (Punch [hit_num])", exact_zone = TRUE)
 			playsound(get_turf(target), pick('sound/combat/hits/punch/punch_hard (1).ogg','sound/combat/hits/punch/punch_hard (2).ogg','sound/combat/hits/punch/punch_hard (3).ogg'), 80, TRUE)
 			animate(shadow_left, pixel_x = -10 + lunge_px, pixel_y = 4 + lunge_py, time = 0.5, easing = EASE_OUT)
 			animate(pixel_x = -10, pixel_y = 4, time = 0.5, easing = EASE_IN)
@@ -286,7 +293,7 @@
 	if(!combo_broken && cling(user, target) && combo_valid(user, target))
 		if(!spell_guard_check(target, FALSE, deflected ? null : user))
 			user.emote("attack", forced = TRUE)
-			arcyne_strike(user, target, null, kick_damage, BODY_ZONE_CHEST, BCLASS_BLUNT, spell_name = "Storm of Psydon (Kick)")
+			arcyne_strike(user, target, null, kick_damage, target_zone, BCLASS_BLUNT, spell_name = "Storm of Psydon (Kick)", exact_zone = TRUE)
 			playsound(get_turf(target), pick('sound/combat/hits/blunt/genblunt (1).ogg','sound/combat/hits/blunt/genblunt (2).ogg','sound/combat/hits/blunt/genblunt (3).ogg'), 100, TRUE)
 			var/atom/throw_target = get_edge_target_turf(user, get_dir(user, target))
 			target.throw_at(throw_target, 3, 4)
@@ -296,6 +303,8 @@
 
 /datum/action/cooldown/spell/storm_of_psydon/proc/oraora_lame(mob/living/carbon/human/user, mob/living/target)
 	user.changeNext_move(CLICK_CD_MELEE * 2)
+
+	var/target_zone = user.zone_selected || BODY_ZONE_CHEST
 
 	var/deflected = FALSE
 	var/combo_broken = FALSE
@@ -309,14 +318,14 @@
 			deflected = TRUE
 			combo_broken = TRUE
 			break
-		arcyne_strike(user, target, null, punch_damage, pick(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM), BCLASS_BLUNT, spell_name = "Storm of Psydon (Punch [i])")
+		arcyne_strike(user, target, null, punch_damage, target_zone, BCLASS_BLUNT, spell_name = "Storm of Psydon (Punch [i])", exact_zone = TRUE)
 		playsound(get_turf(target), pick('sound/combat/hits/punch/punch_hard (1).ogg','sound/combat/hits/punch/punch_hard (2).ogg','sound/combat/hits/punch/punch_hard (3).ogg'), 80, TRUE)
 
 	sleep(1)
 	if(!combo_broken && cling(user, target) && combo_valid(user, target))
 		if(!spell_guard_check(target, FALSE, deflected ? null : user))
 			user.emote("attack", forced = TRUE)
-			arcyne_strike(user, target, null, kick_damage, BODY_ZONE_CHEST, BCLASS_BLUNT, spell_name = "Storm of Psydon (Kick)")
+			arcyne_strike(user, target, null, kick_damage, target_zone, BCLASS_BLUNT, spell_name = "Storm of Psydon (Kick)", exact_zone = TRUE)
 			playsound(get_turf(target), pick('sound/combat/hits/blunt/genblunt (1).ogg','sound/combat/hits/blunt/genblunt (2).ogg','sound/combat/hits/blunt/genblunt (3).ogg'), 100, TRUE)
 			var/atom/throw_target = get_edge_target_turf(user, get_dir(user, target))
 			target.throw_at(throw_target, 3, 4)


### PR DESCRIPTION
## About The Pull Request
- Brings bracers parry to 8 instead of 7 WDEF so people stop asking for +1 Skill Level over armed classes.
- Spellfist Expert -> Jman
- Storm of Psydon charge time reduced to 1s from 2s charge time, no longer eat your momentum on whiff, and **aims for the targeted zone you use it on**

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="949" height="617" alt="dreamseeker_bfmKBlgPsg" src="https://github.com/user-attachments/assets/34974b3c-5dae-493e-9516-94d72169d145" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Having to constantly creep unarmed class +1 over weapon class because of lack of 90% is problematic, this ends the root cause. 

Spellfist's Storm of PSydon is their signature spell yet often feels disastrous to use in a real fight. No more. This also reduces the Adventurer's skill level to Jman to compensate now that there's proper WDef.

Not touching the adventurers counterpart, yet.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Brings bracers parry to 8 instead of 7 WDEF so people stop asking for +1 Skill Level over armed classes.
add: Spellfist Unarmed Expert -> Jman
add: Storm of Psydon charge time reduced to 1s from 2s charge time, no longer eat your momentum on whiff, and **aims for the targeted zone you use it on**
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
