### PR TITLE
Lykcer cannot be Naledi Refugee or Antiquarian anymore

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -183,7 +183,8 @@
 	cmode_music = 'sound/music/warscholar.ogg'
 	traits_applied = list(TRAIT_STEELHEARTED)
 	forbidden_races = list()
-	
+	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
+
 	subclass_stats = list(STATKEY_SPD = 2, STATKEY_PER = 1, STATKEY_WIL = 1)
 	
 	subclass_skills = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -255,6 +255,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/antiquarian
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
 	traits_applied = list(TRAIT_SEEPRICES, TRAIT_GRAVEROBBER, TRAIT_INTELLECTUAL, TRAIT_ALCHEMY_EXPERT)
+	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
 	subclass_stats = list(
 		STATKEY_STR = -1,
 		STATKEY_INT = 2,


### PR DESCRIPTION
## About The Pull Request
Lykcer cannot be Naledi Refugee or Antiquarian anymore

This is done by removing the lycker CTAG from these two roles

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yes

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No lycker mage, thank you

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Lycker cannot be mages (Naledi Refugee / Antiquarian) anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
