### PR TITLE
Reversion Improvements + Remove Stygian from Poke Spells

### DIFF
--- a/code/datums/actions/action_cooldown.dm
+++ b/code/datums/actions/action_cooldown.dm
@@ -327,7 +327,7 @@
 			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/soulshot/lesser)
 
 /proc/grant_poke_spell_ex(mob/living/carbon/human/user) // unified proc because atm this is spread across like 5-6 places, uughhghghghgh
-	var/list/poke_options = list("Spitfire", "Frost Bolt", "Arc Bolt", "Greater Arcyne Bolt", "Stygian Efflorescence", "Arcyne Lance", "Gravel Blast", "Soulshot")
+	var/list/poke_options = list("Spitfire", "Frost Bolt", "Arc Bolt", "Greater Arcyne Bolt", "Arcyne Lance", "Gravel Blast", "Soulshot")
 	var/poke_choice = tgui_input_list(user, "Choose your offensive cantrip.", "Arcyne Awakening", poke_options)
 	if(!poke_choice || !user.mind)
 		return
@@ -340,8 +340,6 @@
 			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arc_bolt)
 		if("Greater Arcyne Bolt")
 			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/greater_arcyne_bolt)
-		if("Stygian Efflorescence")
-			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/stygian_efflorescence)
 		if("Arcyne Lance")
 			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arcyne_lance)
 		if("Gravel Blast")

--- a/code/modules/spells/spell_types/classunique/vizier/reversion.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/reversion.dm
@@ -1,14 +1,16 @@
 // Reversion - Origin Magic (Vizier)
-// The Vizier marks an adjacent ally or themselves, snapshotting their state and position.
-// Leaves a mark on the ground - that they can then activate at will to teleport back
-// It expires after 25 seconds
+// The Vizier marks anyone - or themselves - snapshotting their state and position, and grants the
+// marked target a spell that lets THEM revert back to that state and position at will.
+// If the target is a fellowship member, the Vizier also gains a spell to pull them back directly,
+// without asking. Anyone who is not a fellow can only be reverted by their own hand.
+// The mark expires after 25 seconds.
 
 #define REVERSION_MARK_DURATION (25 SECONDS)
 
 /datum/action/cooldown/spell/vizier/reversion
 	button_icon = 'icons/mob/actions/classuniquespells/vizier.dmi'
 	name = "Reversion"
-	desc = "Marks an adjacent ally's body and position for 25 seconds, allowing them to return to their marked state at will."
+	desc = "Marks a target's body and position for 25 seconds, granting them the power to revert to their marked state at will. If the target shares a fellowship, I may also pull them back myself, without asking."
 	fluff_desc = "Among the most demanding applications of Origin Magick, this art does not merely restore a prior state. It preserves one. For a fleeting moment, a Vizier anchors a person's place within the tapestry of time, allowing it to retrace its own history and reclaim a body, position, and condition once held."
 	button_icon_state = "reversion"
 	sound = 'sound/magic/timeforward.ogg'
@@ -86,8 +88,14 @@
 	// Snapshot current wounds so we can remove new ones on revert
 	trigger.snapshot_wounds = target.get_wounds()
 
-	// Grant the trigger spell to the target
+	// Grant the self-revert trigger to the marked target
 	trigger.Grant(target)
+
+	if(target != H && shares_fellowship(H, target))
+		var/datum/action/cooldown/spell/vizier/reversion_pull/pull = new
+		pull.linked_trigger = trigger
+		trigger.linked_pull = pull
+		pull.Grant(H)
 
 	// Audio + visual feedback on the target
 	playsound(target.loc, 'sound/magic/timeforward.ogg', 50, FALSE)
@@ -98,17 +106,20 @@
 
 	// Feedback
 	if(target == H)
-		to_chat(H, span_purple("I mark myself for reversion. I can activate the revert at will."))
+		to_chat(H, span_purple("I mark myself for reversion. I can revert to this moment at will."))
+	else if(shares_fellowship(H, target))
+		to_chat(target, span_purple("I feel a part of me anchored to this place... I may revert myself at will."))
+		to_chat(H, span_purple("I mark [target] for reversion. As my fellow, I may also pull them back myself, without asking."))
 	else
-		to_chat(target, span_purple("I feel a part of me was left behind... I can choose to revert back."))
-		to_chat(H, span_purple("I mark [target] for reversion. They can activate the revert at will."))
+		to_chat(target, span_purple("I feel a part of me anchored to this place... I may revert myself at will."))
+		to_chat(H, span_purple("I mark [target] for reversion. They may revert themselves at will."))
 
 	return TRUE
 
 /datum/action/cooldown/spell/vizier/reversion_trigger
 	button_icon = 'icons/mob/actions/classuniquespells/vizier.dmi'
 	name = "Revert"
-	desc = "Activate to snap back to your marked position and restore your state."
+	desc = "Activate to snap back to my marked position and restore my state."
 	button_icon_state = "reversion"
 	sound = 'sound/magic/timereverse.ogg'
 	spell_color = GLOW_COLOR_ARCANE
@@ -136,6 +147,8 @@
 
 	spell_requirements = SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
+	/// The Vizier's optional pull action, granted only when the target is a fellowship ally.
+	var/datum/action/cooldown/spell/vizier/reversion_pull/linked_pull
 	/// Snapshot data - set by the Reversion caster spell before granting.
 	var/turf/origin
 	var/brute = 0
@@ -165,12 +178,17 @@
 	if(origin)
 		ground_marker = new(origin)
 
+// The marked target activating their own Revert spell.
 /datum/action/cooldown/spell/vizier/reversion_trigger/cast(atom/cast_on)
 	. = ..()
-	var/mob/living/carbon/target = owner
-	if(!istype(target))
-		return FALSE
+	return perform_revert(owner)
 
+/datum/action/cooldown/spell/vizier/reversion_trigger/proc/perform_revert(mob/living/reverter)
+	var/mob/living/carbon/target = owner
+	if(!istype(target) || QDELETED(target))
+		return FALSE
+	if(!istype(reverter) || QDELETED(reverter))
+		return FALSE
 	if(reverting)
 		return FALSE
 	reverting = TRUE
@@ -180,21 +198,24 @@
 		expiry_timer = null
 
 
-	target.balloon_alert(target, "reverting...")
+	reverter.balloon_alert(reverter, "reverting...")
 	target.visible_message(span_purple("[target]'s body begins to flicker, slipping out of the present moment..."))
-	var/datum/progressbar/progbar = new(target, 2 SECONDS, target)
+	var/datum/progressbar/progbar = new(reverter, 2 SECONDS, reverter)
 	var/endtime = world.time + 2 SECONDS
 	var/starttime = world.time
 	while(world.time < endtime)
 		stoplag(1)
-		if(QDELETED(src) || QDELETED(target))
+		if(QDELETED(src) || QDELETED(target) || QDELETED(reverter))
 			break
 		progbar.update(world.time - starttime)
 	qdel(progbar)
 
 
-	if(QDELETED(src) || QDELETED(target) || target != owner)
-		reverting = FALSE
+	if(QDELETED(src))
+		return FALSE
+
+	if(QDELETED(target) || QDELETED(reverter) || owner != target)
+		cleanup()
 		return FALSE
 
 	var/turf/departure = get_turf(target)
@@ -231,6 +252,8 @@
 	// Announce the arrival at the return point
 	playsound(target.loc, 'sound/magic/timereverse.ogg', 100, FALSE)
 	target.balloon_alert_to_viewers("snaps into place!", "I snap back!")
+	if(reverter != target)
+		to_chat(reverter, span_purple("I pull [target] back to their mark."))
 
 	// Remove the status effect and clean up
 	target.remove_status_effect(/datum/status_effect/buff/reversion)
@@ -242,16 +265,17 @@
 	// A revert is already committed and channeling - let it finish, don't tear down under it.
 	if(reverting)
 		return
-	if(!owner)
-		qdel(src)
-		return
-	to_chat(owner, span_purple("The reversion mark fades."))
-	var/mob/living/L = owner
-	L.remove_status_effect(/datum/status_effect/buff/reversion)
+	var/mob/living/carbon/target = owner
+	if(istype(target))
+		target.remove_status_effect(/datum/status_effect/buff/reversion)
+		to_chat(target, span_purple("The reversion mark fades."))
 	cleanup()
 
-/// Remove this spell from the target and delete it.
+/// Remove this spell (and the Vizier's pull, if any) and delete it.
 /datum/action/cooldown/spell/vizier/reversion_trigger/proc/cleanup()
+	if(linked_pull)
+		linked_pull.linked_trigger = null
+		QDEL_NULL(linked_pull)
 	if(expiry_timer)
 		deltimer(expiry_timer)
 		expiry_timer = null
@@ -261,12 +285,77 @@
 	qdel(src)
 
 /datum/action/cooldown/spell/vizier/reversion_trigger/Destroy()
+	if(linked_pull)
+		linked_pull.linked_trigger = null
+		QDEL_NULL(linked_pull)
 	if(expiry_timer)
 		deltimer(expiry_timer)
 		expiry_timer = null
 	QDEL_NULL(ground_marker)
 	snapshot_wounds = null
 	origin = null
+	return ..()
+
+/datum/action/cooldown/spell/vizier/reversion_pull
+	button_icon = 'icons/mob/actions/classuniquespells/vizier.dmi'
+	name = "Pull Reversion"
+	desc = "Pull the fellow I have marked back to their marked position and state, without asking. Works only while we share a fellowship."
+	button_icon_state = "reversion"
+	sound = 'sound/magic/timereverse.ogg'
+	spell_color = GLOW_COLOR_ARCANE
+	glow_intensity = GLOW_INTENSITY_LOW
+
+	click_to_activate = FALSE
+
+	primary_resource_type = SPELL_COST_NONE
+	primary_resource_cost = 0
+
+	invocations = null
+	invocation_type = INVOCATION_NONE
+
+	charge_required = TRUE
+	charge_time = 0
+	hold_drain = 0
+	charge_slowdown = CHARGING_SLOWDOWN_SMALL
+	charge_sound = 'sound/magic/charging.ogg'
+	cooldown_time = 0
+
+	associated_skill = null
+	associated_stat = null
+	spell_tier = 0
+	spell_impact_intensity = SPELL_IMPACT_NONE
+
+	spell_requirements = SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
+
+	var/datum/action/cooldown/spell/vizier/reversion_trigger/linked_trigger
+
+/datum/action/cooldown/spell/vizier/reversion_pull/cast(atom/cast_on)
+	. = ..()
+	if(QDELETED(linked_trigger))
+		if(owner)
+			to_chat(owner, span_warning("The mark I anchored has faded."))
+		qdel(src)
+		return FALSE
+
+	var/mob/living/carbon/caster = owner
+	if(!istype(caster))
+		return FALSE
+
+	var/mob/living/carbon/target = linked_trigger.owner
+	if(!istype(target) || QDELETED(target))
+		to_chat(caster, span_warning("There is nothing left to pull back."))
+		return FALSE
+
+	if(!shares_fellowship(caster, target))
+		to_chat(caster, span_warning("[target] no longer shares my fellowship - I cannot pull them back."))
+		return FALSE
+
+	return linked_trigger.perform_revert(caster)
+
+/datum/action/cooldown/spell/vizier/reversion_pull/Destroy()
+	if(linked_trigger && !QDELETED(linked_trigger) && linked_trigger.linked_pull == src)
+		linked_trigger.linked_pull = null
+	linked_trigger = null
 	return ..()
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
## About The Pull Request
- Reversion on Vizier now grants a **Pull Reversion** spell **if** the target is in the same fellowship, allowing you to trigger the spell on them without them explicitly doing so, presuming they are a friend so that would be used in good faith
- Also removed Stygian from poke spells selection because the new Stygian is a nerfed version designed to work with Ferra in a package and not on its own anymore

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1605" height="771" alt="dreamseeker_v9ciMwIUru" src="https://github.com/user-attachments/assets/eb7b0f22-9e34-412b-b5f2-225bfe86f5a6" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yeah it is good stuffs

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Reversion on Vizier now grants a **Pull Reversion** spell **if** the target is in the same fellowship, allowing you to trigger the spell on them without them explicitly doing so, presuming they are a friend so that would be used in good faith
add: Also removed Stygian from poke spells selection because the new Stygian is a nerfed version designed to work with Ferra in a package and not on its own anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
