### PR TITLE
Partally Reverts Transfix 1 min cooldown -> 20 seconds + a few other changes

### DIFF
--- a/code/modules/vampire_neu/spells/transfix_neu.dm
+++ b/code/modules/vampire_neu/spells/transfix_neu.dm
@@ -99,11 +99,6 @@
 			to_chat(user, span_userdanger("[target] is far too tense for that!"))
 			break
 
-	for(var/mob/living/carbon/human/target as anything in targets)
-		if(!target in get_hearers_in_view(6, usr))
-			to_chat(user, span_userdanger("[target] is too far away!"))
-			break
-
 		var/willpower = round(target.STAINT / int_divisor, 1)
 		var/willroll = roll(willpower, will_dice)
 

--- a/code/modules/vampire_neu/spells/transfix_neu.dm
+++ b/code/modules/vampire_neu/spells/transfix_neu.dm
@@ -5,10 +5,25 @@
 
 	associated_skill = /datum/skill/magic/blood
 
-	range = 7
+	range = 6
 	chargetime = 0
 	releasedrain = 100
-	recharge_time = 1 MINUTES
+	recharge_time = 20 SECONDS //Do not increase this, allow me to explain:
+
+/* Transfix currently, how it works:
+- You cast the spell, it gives you a list of everyone nearby
+- You transfix someone, after typing sufficent characters (10+ letters)
+- If they/you have cmode on, you full stop cannot use it. Yes, you have to play along with this to start with.
+- They can just walk away, seriously, this is a thing and why I want this short again.
+- Surprisingly, yes. Drowsiness wears off over time so we need to account for that.
+- It builds in stacks, lickers and thinbloods have it as a 3-4 tap move if RNG is nice to you. So-> 60 (1 minute) -> 80 (1 minute, 20 seconds)
+
+- Vampires, are all inherently antagonistic and need a non-frag way to take people out and drink them/turn them potentally.
+- Currently people deathgasp through all Z levels which can be heard afar, this probably isn't intended but yes.
+
+- If you rework transfix to something else entirely or our combat system de-neuters grabs to the point of absolutely useless, then feel free to. Don't touch it for now.
+- Even wretchpires need to being able to take people out before others show up, that's why it's short.
+*/
 
 	/// Ignore crosses and give a different message
 	var/powerful = FALSE
@@ -28,6 +43,19 @@
 			continue
 		if(target.mind.has_antag_datum(/datum/antagonist/vampire))
 			continue
+		if(target.mind.has_antag_datum(/datum/antagonist/zombie))
+			continue
+		if(target.mind.has_antag_datum(/datum/antagonist/skeleton))
+			continue
+		if(target.mind.has_antag_datum(/datum/antagonist/werewolf))
+			continue
+		if(target.mind.has_antag_datum(/datum/antagonist/lich))
+			continue
+		//Full-antagonists only and supernatural ones only too.
+		//Yes, Gnolls aren't immune. They can just use cmode, but this gives hunted vampires a card to play to maybe get (1/2 free escapes)
+
+		//Again, do not give it to virtues. Not blackblooded, not rotcured. Period. This is your quiet take-a-person-down unsuspectingly ability. If you want protection get a silver cross.
+		//Do not give people inherent and unexplainable protection, period. Not even constructs/reverents, it doesn't need to make sense or realistic here. Its a mechanical nessessity.
 		selection += target
 
 	if(!selection.len)
@@ -71,6 +99,11 @@
 			to_chat(user, span_userdanger("[target] is far too tense for that!"))
 			break
 
+	for(var/mob/living/carbon/human/target as anything in targets)
+		if(!target in get_hearers_in_view(6, usr))
+			to_chat(user, span_userdanger("[target] is too far away!"))
+			break
+
 		var/willpower = round(target.STAINT / int_divisor, 1)
 		var/willroll = roll(willpower, will_dice)
 
@@ -94,18 +127,13 @@
 					to_chat(user, "The mind of [target] gives way slightly.")
 					target.Slowdown(20)
 				if(51 to 90)
-					to_chat(target, "Your eyelids force themselves shut as you feel intense lethargy.")
+					to_chat(target, "Your eyelids weigh heavy as you feel intense lethargy.")
 					to_chat(user, "[target] will not be able to resist much more.")
-					target.eyesclosed = TRUE
-					target.become_blind("eyelids")
-					if(target.hud_used)
-						for(var/atom/movable/screen/eye_intent/eyet in target.hud_used.static_inventory)
-							eyet.update_icon(target)
-					target.Slowdown(50)
+					target.Slowdown(30)
 				if(91 to INFINITY)
-					to_chat(target, span_userdanger("You can't take it anymore. Your legs give out as you fall into the dreamworld."))
+					to_chat(target, span_userdanger("You can't take it anymore. Your legs give out as you collapse into a long slumber."))
 					to_chat(user, "[target] is mine now.")
-					target.eyesclosed = TRUE
+					target.eyesclosed = TRUE //You're pretty much FUCKED at this point, we make it obvious
 					target.become_blind("eyelids")
 					if(target.hud_used)
 						for(var/atom/movable/screen/eye_intent/eyet in target.hud_used.static_inventory)


### PR DESCRIPTION
## About The Pull Request

Transfix currently has a solid Cmode check that prevents it physically working on you, as-is.

There's several issues w/ 1 minute cooldown per step of transfix (*yes seriously, its that long*)


Regular vampires have to use it about 4-5 times to knock someone out, which means 4-5 minutes (*sometimes upwards of 7 which is nearly a quarter of a day*) of trying to knock people out. The whole shtick w/transfix is that you can knock people out and drag them off unaware somewhere quiet alone to kidnap.

20 seconds should make it -> 1 minute -> 1 minute 20 seconds, at best for lesser vampires. So its still not a free win. Not forceclosing your eyes should make it a lot less of a PITA to deal with for newer players until you're unconcious.

---

True undead (this only applies to actual antagonists, so wretches can't grief them, I.E skeletons/lich/etc) are immune  to being on your transfix list. This also includes zombies too because they're sort of mindless to begin with.

Werewolves are included as well because their time in wereform is limited. Gnolls/Virtues/Rituos users are purposefully left out, because transfix mechanically still has a use on kidnapping them even if some of them are immune to turning or whatever else.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Used it in localhost worked.

Turned self deadite, wasn't pickable.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Vampires shouldn't have to bank on you not instantly pressing succumb to take captives (even if its just to roleplay or swipe items for access). We shouldn't make an ability that's already nerfed beyond abusability (all slot silver crosses work + cmode check) to being completely beyond useless to the point you'd be better off just fragging everyone and hoping someone doesn't instantly succumb/a mob of 30 people for 1 guy.

Vampires are a stealth antagonist and this remains one of the few covert ways to take people down they still have to play along with, especally if you're inside of the keep. You basically ***need to use transfix to take people out.***

People currently just walk off mid-transfixing because there's no way you're going to keep a stranger on the road in a 4+ minute conversation when they're just doing adventurer stuff on autopilot.

---

Being able to transfix blatently mindless corpses/ancient liches is silly. Skeletons I may revert to being transfixable again, they're excluded for now since necro/lich/siege skeletons are covered. They can already examine to know you're another deadite and will probably leave you alone anyway.

Werewolves are too mechanically on-the-clock to balance with transfix, so they're just immune to even being listed.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: transfix 1 minute -> 20 seconds cooldown.
balance: transfix no longer works on full-supernatural antagonists (true deadites).
balance: transfix also doesn't affect werewolves (because they're on the clock and you sort of shouldn't be knocking them out)
balance: transfix only force-closes your eyes when it actually knocks you out, to make it less annoying to deal with.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
