### PR TITLE
Adds racial language to race desc + Humen race desc fix

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -333,11 +333,13 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	ResetJobs()
 	if(user)
 		if(pref_species.desc)
+			var/langs = length(pref_species.languages)
+			var/bonus_languages = langs > 1 ? span_info("Racial Language[langs > 2 ? "s" : ""]: [pref_species.get_string_languages()]<br>") : null
 			var/bonus_stats = span_racialstatinfo(pref_species.get_string_bonus_stats())
 			var/traits_list = pref_species.get_string_bonus_traits()
 			var/bonus_traits = traits_list && length(traits_list) ? "<br>" + span_smallracialstatinfo(traits_list) : null
 			var/mechanics = pref_species.mechanics_explanations ? span_info(pref_species.get_string_mechanics_explanations()) : null
-			var/description2print  = fieldset_block(span_big("<b>[span_bignotice(pref_species.desc_title)]</b>"), "[pref_species.desc]<br><hr>[bonus_stats][bonus_traits][mechanics]", "speciesdesc_block")
+			var/description2print  = fieldset_block(span_big("<b>[span_bignotice(pref_species.desc_title)]</b>"), "[pref_species.desc]<br><hr>[bonus_languages][bonus_stats][bonus_traits][mechanics]", "speciesdesc_block")
 			to_chat(user, description2print)
 		to_chat(user, span_red("Classes reset."))
 	random_character(gender, FALSE, FALSE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -334,12 +334,12 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	if(user)
 		if(pref_species.desc)
 			var/langs = length(pref_species.languages)
-			var/bonus_languages = langs > 1 ? span_info("Racial Language[langs > 2 ? "s" : ""]: [pref_species.get_string_languages()]<br>") : null
+			var/bonus_languages = langs > 1 ? span_info("<br>Racial Language[langs > 2 ? "s" : ""]: [pref_species.get_string_languages()]") : null
 			var/bonus_stats = span_racialstatinfo(pref_species.get_string_bonus_stats())
 			var/traits_list = pref_species.get_string_bonus_traits()
 			var/bonus_traits = traits_list && length(traits_list) ? "<br>" + span_smallracialstatinfo(traits_list) : null
 			var/mechanics = pref_species.mechanics_explanations ? span_info(pref_species.get_string_mechanics_explanations()) : null
-			var/description2print  = fieldset_block(span_big("<b>[span_bignotice(pref_species.desc_title)]</b>"), "[pref_species.desc]<br><hr>[bonus_languages][bonus_stats][bonus_traits][mechanics]", "speciesdesc_block")
+			var/description2print  = fieldset_block(span_big("<b>[span_bignotice(pref_species.desc_title)]</b>"), "[pref_species.desc]<br><hr>[bonus_stats][bonus_languages][bonus_traits][mechanics]", "speciesdesc_block")
 			to_chat(user, description2print)
 		to_chat(user, span_red("Classes reset."))
 	random_character(gender, FALSE, FALSE)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2522,3 +2522,24 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return jointext(bonuses, " | ")
 	else
 		return null
+
+/datum/species/proc/get_string_languages()
+	var/list/ret_languages = list()
+	for (var/language_type in languages)
+		var/datum/language/lang = GLOB.language_datum_instances[language_type]
+		if(!lang)
+			continue
+		var/lang_name = initial(lang.name)
+		// Everyone knows Imperial, therefore it's redundant to list. So we'll skip over it
+		if(lang_name == "Imperial")
+			continue
+		var/lang_desc = initial(lang.desc)
+		// If it has a description, give it a tooltip and underline to indicate said tooltip being there
+		if(length(lang_desc))
+			ret_languages.Add(SPAN_TOOLTIP(lang_desc, "\[<u>[lang_name]</u>\]"))
+		else
+			ret_languages.Add("\[[lang_name]\]")
+	if(length(ret_languages))
+		return jointext(ret_languages, " | ")
+	else
+		return null

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -8,8 +8,8 @@
 	origin_default = /datum/virtue/origin/grenzelhoft
 	origin = "Grenzelhoft"
 	sub_name = "Northern Humen"
-	desc = "<b>Humen</b><br>\
-	Humens (or \"Humans\") are the eldest of the Weeping God's creations. Noted for their \
+	desc_title = "Humen"
+	desc = "Humens (or \"Humans\") are the eldest of the Weeping God's creations. Noted for their \
 	tenacity and overwhelming population, humens are the most commonly seen race across the lands, \
 	at a rate of about ten to one in regions such as Grenzelhoft. However, to the west \
 	the opposite is true. Humens come from a vast swathe of cultures and ethnicities, most of which \


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Race descriptions now automatically list any bonus languages that a race grants.
Also adds proper racial description titles to Humens, who I missed when making my race description PR. Oops!

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="612" height="473" alt="dreamseeker_2026-07-05_22-13-13" src="https://github.com/user-attachments/assets/e3046900-1ffa-421a-aa24-9ae1efb73079" />



## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
Same as my racial description PR: It's good to actually tell players in advance what things a race comes with so they can make better, more informed decisions during character creation.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:Ryumi
qol: Race descriptions now include any bonus languages that a race grants.
fix: Fixed Humen race descriptions not displaying quite the same as other races.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
