### PR TITLE
[hotfix] donor kits can no longer be used to make conjured weapons permanent

### DIFF
--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -34,6 +34,10 @@
 		to_chat(user, span_warning("[src] doesn't know how to morph [I]."))
 		return TRUE
 
+	if(I.GetComponent(/datum/component/conjured_item))
+		to_chat(user, span_warning("[src] cannot morph conjured items."))
+		return TRUE
+
 	if(I.loc == user)
 		// pulls from hands/slots/inventory cleanly
 		user.temporarilyRemoveItemFromInventory(I, TRUE)


### PR DESCRIPTION
## About The Pull Request
morphing elixirs could be used on conjured weapons, deleting the conjured item component and giving you a free steel weapon/etc. that's bad. don't do that.

## Testing Evidence
before:
<img width="510" height="362" alt="image" src="https://github.com/user-attachments/assets/e8d95aea-2286-4477-a731-aa1ce5953095" />
<img width="843" height="184" alt="image" src="https://github.com/user-attachments/assets/e1c20fab-3aa7-4d52-9364-ad76fbb570c3" />

after:
<img width="541" height="102" alt="image" src="https://github.com/user-attachments/assets/292d410e-9ebd-47b1-8391-8025af4a6d2b" />


## Why It's Good For The Game
free permanent steel weapons is probably not great

## Changelog
:cl:
fix: Fixed an exploit where conjured weapons/tools could be maid permanent by applying a donor kit
/:cl: