### PR TITLE
fix timer corruption

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -17,7 +17,22 @@
 #define MC_AVG_FAST_UP_SLOW_DOWN(average, current) (average > current ? MC_AVERAGE_SLOW(average, current) : MC_AVERAGE_FAST(average, current))
 #define MC_AVG_SLOW_UP_FAST_DOWN(average, current) (average < current ? MC_AVERAGE_SLOW(average, current) : MC_AVERAGE_FAST(average, current))
 
-#define NEW_SS_GLOBAL(varname) if(varname != src){if(istype(varname)){Recover();qdel(varname);}varname = src;}
+/// TRUE only while the Master controller is intentionally creating replacement subsystems.
+/// Anything else constructing a subsystem while its global is live is rogue - most notably BYOND
+/// savefile deserialization: old character saves that captured a /datum/timedevent also captured its
+/// timer_subsystem reference (and, via queue_next/queue_prev, potentially every queued subsystem),
+/// and reading them back constructs shadow subsystems whose New() would otherwise qdel the real,
+/// live subsystem and install the stale shadow as the global.
+GLOBAL_REAL_VAR(subsystem_takeover_allowed)
+
+#define NEW_SS_GLOBAL(varname) if(varname != src){\
+	if(istype(varname) && !subsystem_takeover_allowed){\
+		stack_trace("Rogue [type] instance created while the global is live (savefile deserialization?); refusing to replace [#varname]");\
+	} else {\
+		if(istype(varname)){Recover();qdel(varname);}\
+		varname = src;\
+	}\
+}
 
 #define START_PROCESSING(Processor, Datum) if (!(Datum.datum_flags & Processor.processing_flag)) {Datum.datum_flags |= Processor.processing_flag;Processor.processing += Datum}
 #define STOP_PROCESSING(Processor, Datum) Datum.datum_flags &= ~Processor.processing_flag;Processor.processing -= Datum

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -99,8 +99,10 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		else
 			var/list/subsytem_types = subtypesof(/datum/controller/subsystem)
 			sortTim(subsytem_types, GLOBAL_PROC_REF(cmp_subsystem_init))
+			subsystem_takeover_allowed = TRUE
 			for(var/I in subsytem_types)
 				_subsystems += new I
+			subsystem_takeover_allowed = FALSE
 		Master = src
 
 	if(!GLOB)
@@ -282,7 +284,9 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 	if (istype(Master.subsystems))
 		if(FireHim)
+			subsystem_takeover_allowed = TRUE
 			Master.subsystems += new BadBoy.type	//NEW_SS_GLOBAL will remove the old one
+			subsystem_takeover_allowed = FALSE
 		subsystems = Master.subsystems
 		current_runlevel = Master.current_runlevel
 		StartProcessing(10)
@@ -302,7 +306,9 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		world.TgsInitializationComplete()
 
 	if(init_sss)
+		subsystem_takeover_allowed = TRUE
 		init_subtypes(/datum/controller/subsystem, subsystems)
+		subsystem_takeover_allowed = FALSE
 #ifdef TESTING
 	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
 #endif

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -36,8 +36,10 @@
 	var/queued_time = 0		//time we entered the queue, (for timing and priority reasons)
 	var/queued_priority 	//we keep a running total to make the math easier, if priority changes mid-fire that would break our running total, so we store it here
 	//linked list stuff for the queue
-	var/datum/controller/subsystem/queue_next
-	var/datum/controller/subsystem/queue_prev
+	//tmp: if a subsystem datum ever gets serialized (e.g. dragged into a savefile through a stray
+	//reference), these must not pull every other queued subsystem into the file with it
+	var/tmp/datum/controller/subsystem/queue_next
+	var/tmp/datum/controller/subsystem/queue_prev
 
 	var/runlevels = RUNLEVELS_DEFAULT	//points of the game at which the SS can fire
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -108,6 +108,11 @@ SUBSYSTEM_DEF(timer)
 	if (next_clienttime_timer_index)
 		clienttime_timers.Cut(1, next_clienttime_timer_index+1)
 		next_clienttime_timer_index = 0
+	// Strip out any null entries a hard-deleted timer may have left behind. BYOND nulls (rather than
+	// removes) list references to a del'd datum, and a single null in this queue makes every
+	// BINARY_INSERT in bucketJoin() runtime with "Cannot read null.timeToRun".
+	if (length(clienttime_timers))
+		listclearnulls(clienttime_timers)
 	for (next_clienttime_timer_index in 1 to length(clienttime_timers))
 		if (MC_TICK_CHECK)
 			next_clienttime_timer_index--
@@ -152,6 +157,11 @@ SUBSYSTEM_DEF(timer)
 		bucket_list = src.bucket_list
 		resumed = FALSE
 
+	// Strip out any null entries a hard-deleted timer may have left behind in the long-run queue.
+	// A null that lands in the far-future tail is never reached by the front-processing loop below,
+	// so it persists indefinitely and makes every BINARY_INSERT into second_queue (bucketJoin) runtime.
+	if (length(second_queue))
+		listclearnulls(second_queue)
 
 	// Iterate through each bucket starting from the practical offset
 	while (practical_offset <= BUCKET_LEN && head_offset + ((practical_offset - 1) * world.tick_lag) <= world.time)
@@ -329,6 +339,9 @@ SUBSYSTEM_DEF(timer)
 	// Cut the timers that are tracked by the buckets from the secondary queue
 	if (i)
 		alltimers.Cut(1, i + 1)
+	// Drop any null entries (from hard-deleted timers) so the rebuilt queue stays clean
+	if (length(alltimers))
+		listclearnulls(alltimers)
 	second_queue = alltimers
 	bucket_count = new_bucket_count
 
@@ -358,11 +371,14 @@ SUBSYSTEM_DEF(timer)
  * See the documentation for the timer subsystem for an explanation of the buckets referenced
  * below in next and prev
  */
+// Object-reference vars below are /tmp so a timedevent can never drag its callback target, its
+// bucket neighbours, or the entire timer subsystem into a savefile if a datum holding a timer
+// reference is ever serialized (this happened with virtues in character saves and poisoned them)
 /datum/timedevent
 	/// ID used for timers when the TIMER_STOPPABLE flag is present
 	var/id
 	/// The callback to invoke after the timer completes
-	var/datum/callback/callBack
+	var/tmp/datum/callback/callBack
 	/// The time at which the callback should be invoked at
 	var/timeToRun
 	/// The length of the timer
@@ -377,13 +393,13 @@ SUBSYSTEM_DEF(timer)
 	var/spent = 0
 	/// Holds info about this timer, stored from the moment it was created
 	/// Used to create a visible "name" whenever the timer is stringified
-	var/list/timer_info
+	var/tmp/list/timer_info
 	/// Next timed event in the bucket
-	var/datum/timedevent/next
+	var/tmp/datum/timedevent/next
 	/// Previous timed event in the bucket
-	var/datum/timedevent/prev
+	var/tmp/datum/timedevent/prev
 	/// The timer subsystem this event is associated with
-	var/datum/controller/subsystem/timer/timer_subsystem
+	var/tmp/datum/controller/subsystem/timer/timer_subsystem
 	/// Boolean indicating if timer joined into bucket
 	var/bucket_joined = FALSE
 	/// Initial bucket position
@@ -392,6 +408,12 @@ SUBSYSTEM_DEF(timer)
 /datum/timedevent/New(datum/callback/callBack, wait, flags, datum/controller/subsystem/timer/timer_subsystem, hash, source)
 	var/static/nextid = 1
 	id = TIMER_ID_NULL
+	// A timedevent with no callback is never valid (_addtimer asserts a callback before constructing).
+	// This only happens when BYOND reconstructs a stray timer while deserializing a savefile - New()
+	// is called with all-null args. Bail before touching the (null) timer_subsystem so we don't runtime;
+	// the orphaned datum is never registered anywhere and is simply discarded by the loader.
+	if(!istype(callBack))
+		return
 	src.callBack = callBack
 	src.wait = wait
 	src.flags = flags
@@ -416,7 +438,14 @@ SUBSYSTEM_DEF(timer)
 		timer_subsystem.timer_id_dict[id] = src
 
 	if ((timeToRun < world.time || timeToRun < timer_subsystem.head_offset) && !(flags & TIMER_CLIENT_TIME))
-		CRASH("Invalid timer state: Timer created that would require a backtrack to run (addtimer would never let this happen): [SStimer.get_timer_debug_string(src)]")
+		// This should be impossible: head_offset is only ever set to world.time or lower and advanced
+		// strictly behind it, so it cannot outrun a freshly computed timeToRun. When it does, the
+		// subsystem's clock has drifted (corruption/overload). Historically this CRASHed AND leaked the
+		// half-built timer (registered in timer_id_dict but never bucket-joined, so it never fired or
+		// cleaned up). Instead, log it and force a bucket rebuild so head_offset re-syncs to world.time;
+		// the timer still joins below and reset_buckets() re-places it correctly on the next fire.
+		stack_trace("Timer created in the past (head_offset [timer_subsystem.head_offset] > timeToRun [timeToRun] @ world.time [world.time]); forcing bucket reset: [SStimer.get_timer_debug_string(src)]")
+		timer_subsystem.bucket_resolution = null
 
 	if (callBack.object != GLOBAL_PROC && !QDESTROYING(callBack.object))
 		LAZYADD(callBack.object._active_timers, src)
@@ -425,6 +454,10 @@ SUBSYSTEM_DEF(timer)
 
 /datum/timedevent/Destroy()
 	..()
+	// Never-initialized orphan (savefile reconstruction; see New) - nothing was ever registered,
+	// so there is nothing to unhook and touching the null timer_subsystem would runtime
+	if (!timer_subsystem)
+		return QDEL_HINT_IWILLGC
 	if (flags & TIMER_UNIQUE && hash)
 		timer_subsystem.hashes -= hash
 

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -50,7 +50,9 @@
 	*/
 	var/list/cooldowns
 	var/abstract_type = /datum
-	var/list/_active_timers
+	/// tmp: live timers must never serialize into savefiles - a saved timedevent poisons the save
+	/// with refs to its callback target and the timer subsystem itself
+	var/tmp/list/_active_timers
 
 #ifdef TESTING
 	var/running_find_references

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -7,7 +7,7 @@
 //	where you would want the updater procs below to run
 
 //	This also works with decimals.
-#define SAVEFILE_VERSION_MAX	35
+#define SAVEFILE_VERSION_MAX	36
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -51,6 +51,13 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 31) // RAISE THIS TO SAVEFILE_VERSION_MAX (and make sure to add +1 to the version) EVERY TIME YOU ADD SERVER-CHANGING KEYBINDS LIKE CHANGING HOW SAY WORKS!!
 		force_reset_keybindings_direct(TRUE)
 		addtimer(CALLBACK(src, PROC_REF(force_reset_keybindings)), 30)
+	if(current_version < 36)
+		// Scrub legacy whole-datum virtue saves from every character slot. Old saves captured live
+		// virtues whose _active_timers dragged /datum/timedevent (and through it the entire timer
+		// subsystem) into the file; reading those keys is only safe while the NEW_SS_GLOBAL takeover
+		// guard is compiled in. Rewriting them in the snapshot format here makes the file permanently
+		// safe, even for future builds without the guard (i.e. this fix can be reverted safely).
+		_scrub_all_slot_virtues(S)
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
 	if(current_version < 19)
@@ -447,123 +454,93 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		//statpack = new statpack
 
 /datum/preferences/proc/_load_virtue(S)
-	var/virtue_type
-	var/virtuetwo_type
+	var/virtue_saved
+	var/virtuetwo_saved
 	var/origin_type
-	S["virtue"] >> virtue_type
-	S["virtuetwo"] >> virtuetwo_type
+	var/list/virtue_choices
+	var/list/virtuetwo_choices
+	S["virtue"] >> virtue_saved
+	S["virtuetwo"] >> virtuetwo_saved
 	S["virtue_origin"] >> origin_type
-	var/error_check = FALSE
-	var/error_found = FALSE
-	if (istype(virtue_type, /datum/virtue))
-		virtue = virtue_type
-		error_check = TRUE
-	else if(ispath(virtue_type, /datum/virtue))
-		virtue = new virtue_type
-	else
-		virtue = new /datum/virtue/none
+	S["virtue_choices"] >> virtue_choices
+	S["virtuetwo_choices"] >> virtuetwo_choices
 
-	if(error_check)
-		//Future-proofing sanity checks in case virtues get adjusted later. We do a full reset if we find any discrepancies.
-		var/datum/virtue/sane_virtue = new virtue.type
-		if(virtue.name != sane_virtue.name)	//We should keep the names & descs updated across saves, too
-			virtue.name = sane_virtue.name
-
-		if(virtue.desc != sane_virtue.desc)	//Not errors warranting a full reset, in theory, anyway.
-			virtue.desc = sane_virtue.desc
-
-		if(length(virtue.picked_choices) > sane_virtue.max_choices)
-			error_found = TRUE
-		
-		if(sane_virtue.max_choices != virtue.max_choices)
-			error_found = TRUE
-		
-		if(length(virtue.extra_choices) != length(sane_virtue.extra_choices))
-			error_found = TRUE
-		
-		if(!error_found)
-			for(var/choice in virtue.extra_choices)
-				if(!(choice in sane_virtue.extra_choices))
-					error_found = TRUE
-					break
-
-			var/total_ours = 0
-			var/total_sane = 0
-
-			for(var/cost in virtue.choice_costs)
-				total_ours += cost
-			for(var/cost in sane_virtue.choice_costs)
-				total_sane += cost
-
-			if(total_ours != total_sane)
-				error_found = TRUE
-
-		if(error_found)
-			qdel(virtue)
-			virtue = sane_virtue
-		else
-			qdel(sane_virtue)
-			virtue.on_load()
-
-	error_check = FALSE
-	if(istype(virtuetwo_type, /datum/virtue))
-		virtuetwo = virtuetwo_type
-		error_check = TRUE
-	else if(ispath(virtuetwo_type, /datum/virtue))
-		virtuetwo = new virtuetwo_type
-	else
-		virtuetwo = new /datum/virtue/none
-
-
-	if(error_check)
-		//Future-proofing sanity checks in case virtues get adjusted later. We do a full reset if we find any discrepancies.
-		var/datum/virtue/sane_virtuetwo = new virtuetwo.type
-		error_found = FALSE
-
-		if(virtuetwo.name != sane_virtuetwo.name)	//We should keep the names & descs updated across saves, too
-			virtue.name = sane_virtuetwo.name
-
-		if(virtuetwo.desc != sane_virtuetwo.desc)	//Not errors warranting a full reset, in theory, anyway.
-			virtuetwo.desc = sane_virtuetwo.desc
-
-
-		if(length(virtuetwo.picked_choices) > sane_virtuetwo.max_choices)
-			error_found = TRUE
-		
-		if(sane_virtuetwo.max_choices != virtuetwo.max_choices)
-			error_found = TRUE
-		
-		if(length(virtuetwo.extra_choices) != length(sane_virtuetwo.extra_choices))
-			error_found = TRUE
-		
-		if(!error_found)
-			for(var/choice in virtuetwo.extra_choices)
-				if(!(choice in sane_virtuetwo.extra_choices))
-					error_found = TRUE
-					break
-
-			var/total_ours = 0
-			var/total_sane = 0
-
-			for(var/cost in virtuetwo.choice_costs)
-				total_ours += cost
-			for(var/cost in sane_virtuetwo.choice_costs)
-				total_sane += cost
-				
-			if(total_ours != total_sane)
-				error_found = TRUE
-
-		if(error_found)
-			virtuetwo = sane_virtuetwo
-			qdel(virtue)
-		else
-			qdel(sane_virtuetwo)
-			virtuetwo.on_load()
+	virtue = _saveload_virtues(virtue_saved, virtue_choices)
+	virtuetwo = _saveload_virtues(virtuetwo_saved, virtuetwo_choices)
 
 	if(origin_type)
 		virtue_origin = new origin_type
 	else
 		virtue_origin = new /datum/virtue/none
+
+//virtue rebuilding because it cannot be trusted to handle timers oml
+/datum/preferences/proc/_saveload_virtues(saved, list/saved_choices)
+	var/virtue_path
+	if(ispath(saved, /datum/virtue))
+		virtue_path = saved
+	else if(istype(saved, /datum/virtue))
+		var/datum/virtue/legacy = saved
+		virtue_path = legacy.type
+		if(!islist(saved_choices))
+			saved_choices = legacy.picked_choices
+	if(!virtue_path)
+		return new /datum/virtue/none
+
+	var/datum/virtue/resolved = new virtue_path
+	if(islist(saved_choices) && length(saved_choices))
+		var/list/valid_choices = list()
+		for(var/choice in saved_choices)
+			if(length(valid_choices) >= resolved.max_choices)
+				break
+			if((choice in resolved.extra_choices) && !(choice in valid_choices))
+				valid_choices += choice
+		resolved.picked_choices = valid_choices
+	resolved.on_load()
+	return resolved
+
+/**
+ * One-time migration (savefile version 36): rewrites the virtue keys of every character slot in
+ * the clean snapshot format, purging any legacy whole-datum saves whose embedded timers poisoned
+ * the file with references to the timer subsystem. Idempotent; re-running on an already-clean
+ * slot just rewrites an equivalent snapshot. S is expected (and restored) at cd "/".
+ */
+/datum/preferences/proc/_scrub_all_slot_virtues(savefile/S)
+	var/old_cd = S.cd
+	var/static/list/virtue_keys = list("virtue" = "virtue_choices", "virtuetwo" = "virtuetwo_choices")
+	for(var/entry in S.dir)
+		if(copytext(entry, 1, 10) != "character")
+			continue
+		S.cd = "/[entry]"
+		for(var/key in virtue_keys)
+			if(!(key in S.dir))
+				continue
+			var/saved
+			var/list/saved_choices
+			S[key] >> saved
+			S[virtue_keys[key]] >> saved_choices
+			var/datum/virtue/resolved = _saveload_virtues(saved, saved_choices)
+			var/datum/virtue/snapshot = _virtue_save_snapshot(resolved)
+			WRITE_FILE(S[key], snapshot)
+			WRITE_FILE(S[virtue_keys[key]], resolved.picked_choices)
+			if(istype(saved, /datum/virtue))
+				var/datum/virtue/legacy = saved
+				legacy._active_timers = null	// reconstructed orphans were never registered; do not qdel them
+				qdel(legacy)
+			qdel(snapshot)
+			qdel(resolved)
+	S.cd = old_cd
+
+/**
+ * Builds a throwaway, never-applied clone of `source` carrying only the data that is safe to
+ * persist (its type and picked_choices). Serialized into S["virtue"] so a rollback to the old
+ * whole-datum loader can still recover the virtue, without ever writing a live virtue whose
+ * _active_timers hold /datum/timedevent objects. Caller is responsible for qdel-ing the result.
+ */
+/datum/preferences/proc/_virtue_save_snapshot(datum/virtue/source)
+	var/datum/virtue/snapshot = new source.type
+	snapshot.picked_choices = source.picked_choices?.Copy()
+	snapshot._active_timers = null	// a fresh clone has none; nulled anyway so timers never serialize
+	return snapshot
 
 /datum/preferences/proc/_load_gear_list(savefile/S)
 	S["gear_list"] >> gear_list
@@ -1015,8 +992,21 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["titles_pref"] , titles_pref)
 	WRITE_FILE(S["clothes_pref"] , clothes_pref)
 	WRITE_FILE(S["statpack"] , statpack.type)
-	WRITE_FILE(S["virtue"] , virtue)
-	WRITE_FILE(S["virtuetwo"], virtuetwo)
+	// Persist the picked sub-options explicitly for the current loader.
+	WRITE_FILE(S["virtue_choices"] , virtue.picked_choices)
+	WRITE_FILE(S["virtuetwo_choices"], virtuetwo.picked_choices)
+	// Store the virtue as a fresh, never-applied clone rather than a bare type path, so a rollback
+	// to the old whole-datum loader still recovers the type AND picked_choices (a bare path makes
+	// the old loader build an empty virtue and silently drop sub-choices). The clone is safe to
+	// serialize because virtue timers/components only attach during apply_to_human (e.g. the
+	// linguist addtimer in utility.dm), never in New(); _virtue_save_snapshot also nulls
+	// _active_timers as belt-and-suspenders so no /datum/timedevent can ever reach the savefile.
+	var/datum/virtue/virtue_snapshot = _virtue_save_snapshot(virtue)
+	WRITE_FILE(S["virtue"] , virtue_snapshot)
+	qdel(virtue_snapshot)
+	var/datum/virtue/virtuetwo_snapshot = _virtue_save_snapshot(virtuetwo)
+	WRITE_FILE(S["virtuetwo"], virtuetwo_snapshot)
+	qdel(virtuetwo_snapshot)
 	WRITE_FILE(S["virtue_origin"], virtue_origin.type)
 	WRITE_FILE(S["race_bonus"], race_bonus)
 	WRITE_FILE(S["combat_music"], combat_music.type)


### PR DESCRIPTION
## About The Pull Request

 did i use AI for this? yes i had help in doing the RCA and getting the actual code out quickly

## Testing Evidence

allah watched me do it

## Why It's Good For The Game

seems like timers are being corrupted by getting flooded by null datums thanks to savefile corruptions (DATUM SAVING AHHHHHHHHHHHHHHHH) which cascaded into entries being deserialised.


<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
map: added/modified/removed map content
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
