### PR TITLE
Fixes Unintended Arcana Grinding

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_aegis.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_aegis.dm
@@ -12,7 +12,6 @@
 	unenchantable = TRUE
 	sellprice = 0
 	static_price = TRUE
-	anvilrepair = /datum/skill/magic/arcane
 	parrysound = list('sound/combat/parry/shield/magicshield (1).ogg', 'sound/combat/parry/shield/magicshield (2).ogg', 'sound/combat/parry/shield/magicshield (3).ogg')
 	associated_skill = /datum/skill/combat/shields
 


### PR DESCRIPTION
## About The Pull Request

As mentioned in #7987, damaging and then repairing your summoned tome-aegis would allow you to grind your Arcana skill up to whatever limit you were allowed to.

By removing the anvilrepair value from the arcyne_aegis base, you will only get the normal athletics XP from doing this.

## Testing Evidence

Tested locally

## Why It's Good For The Game

This is probably unintended behaviour

## Changelog
:cl:
Removed anvilrepair specification from arcyne_aegis, removing Arcana skillgain from reparing it.
/:cl: