### PR TITLE
[TM] gamemode adjustments

### DIFF
--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -97,6 +97,7 @@
 	min_round_time = 45 MINUTES
 	is_raid = TRUE
 	spawn_landmark = "Bandit"
+	can_roll = FALSE
 	required_roles = list(
 		/datum/migrant_role/bandit = 1,
 	)

--- a/code/datums/storytellers/presets.dm
+++ b/code/datums/storytellers/presets.dm
@@ -1,13 +1,14 @@
 /// Code-defined gamemode presets. These replace the old storyteller gods. Players vote between them (grouped
 /// into three pools - see GAMEMODE_POOL_* in __DEFINES/storytellers.dm) or admins fine-tune the roundstart
-/// antag config directly.
+/// antag config directly. A preset's vote pool is set by preset_pool, independent of its type hierarchy.
 
 /datum/storyteller/gamemode
 	always_votable = TRUE
 	hag_slots = 1
 
 // ----------------------------------------------------------------------------------------------------------
-// Extended - no hard antags, no soft antags; only a lone Hag may appear
+// PSYDON pool - lowest intensity. No hard antags. Extended opens nothing; Low Intensity opens a few wretches.
+// (Low Intensity is defined further down as no_antag/small_wretch but votes in this pool via preset_pool.)
 // ----------------------------------------------------------------------------------------------------------
 /datum/storyteller/gamemode/extended
 	name = "Extended"
@@ -83,12 +84,12 @@
 	)
 
 // ----------------------------------------------------------------------------------------------------------
-// Atleast one main antag will be selected
+// ASCENDANT pool - guaranteed roundstart hard antag. At least one main antag will be selected.
 // ----------------------------------------------------------------------------------------------------------
 /datum/storyteller/gamemode/guaranteed_antag
 	name = "High Intensity"
 	vote_desc = "Guaranteed hard antagonist. Some soft antagonists remain."
-	desc = "Guaranteed roundstart hard antag. Wretches up to 9. Gnolls max 2. Hag present. Dreamwalker may roll."
+	desc = "Guaranteed roundstart hard antag. Wretches up to 8. Gnolls max 2. Hag present. Dreamwalker may roll."
 	welcome_text = "A cold dread settles over the town.."
 	color_theme = "#a43c3c"
 	preset_pool = GAMEMODE_POOL_GUARANTEED
@@ -102,9 +103,9 @@
 	wretch_slot_cap = 9
 
 /datum/storyteller/gamemode/guaranteed_antag/low_wretch
-	name = "Medium Intensity"
+	name = "Tempered Intensity"
 	vote_desc = "Guaranteed hard antagonist of a random variety. A few soft antagonists too."
-	desc = "Guaranteed roundstart hard antag with more aggressive pop scaling. Wretches up to 4. Gnoll max 1. Hag present."
+	desc = "Guaranteed roundstart hard antag with more aggressive pop scaling. Wretches up to 4. Gnoll max 1. Hag present. No dreamwalker."
 	color_theme = "#7a1f1f"
 	hard_mult = 2
 	block_soft = FALSE
@@ -113,10 +114,10 @@
 	wretch_slot_cap = 4
 
 // ----------------------------------------------------------------------------------------------------------
-// Just wretches/gnolls/hags, etc
+// TEN pool - no hard antags, soft antags only. Standard is the lighter option, Medium the default fallback.
 // ----------------------------------------------------------------------------------------------------------
-/datum/storyteller/gamemode/no_antag	// DEFAULT
-	name = "Standard Intensity"
+/datum/storyteller/gamemode/no_antag	// DEFAULT (inconclusive-vote fallback)
+	name = "Medium Intensity"
 	vote_desc = "No hard antagonists. Soft antagonists scale reasonably."
 	desc = "No hard antags. Wretches scale normally (5 -> 12). Gnolls max 3. Hag present. Dreamwalker may roll."
 	welcome_text = "The warmth of daelight rouses you from your slumber.."
@@ -130,14 +131,25 @@
 	roundstart_prob = 50
 	guarantees_roundstart_roleset = FALSE
 
+/datum/storyteller/gamemode/no_antag/standard
+	name = "Standard Intensity"
+	vote_desc = "No hard antagonists. A moderate spread of soft antagonists."
+	desc = "No hard antags. Wretches up to 6. Gnolls max 2. Hag present. No dreamwalker."
+	color_theme = "#37b3a6"
+	allow_dreamwalker = FALSE
+	preferred_gnoll_mode = GNOLL_SCALING_FLAT	// max 2
+	wretch_slot_cap = 6
+
+// Low Intensity - votes in the PSYDON pool (see preset_pool) despite being a no_antag subtype.
 /datum/storyteller/gamemode/no_antag/small_wretch
 	name = "Low Intensity"
-	vote_desc = "No hard antagonists. Fewer soft antagonists are present.."
-	desc = "No hard antags. Wretches fixed at 5. Gnoll max 1. Hag present. No dreamwalker."
+	vote_desc = "No hard antagonists. Only a handful of soft antagonists are present.."
+	desc = "No hard antags. Wretches fixed at 4. No gnolls. Hag present. No dreamwalker."
 	color_theme = "#1f6b67"
+	preset_pool = GAMEMODE_POOL_EXTENDED
 	allow_dreamwalker = FALSE
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE	// max 1
-	wretch_slot_cap = 5
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
+	wretch_slot_cap = 4
 	roundstart_prob = 0
 
 	starting_point_multipliers = list(

--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -1,6 +1,6 @@
-// Roundstart scaling (storyteller_scale_slots): scaling=2, min_players=20, default_cap=2.
-// The Guaranteed Antag presets raise the cap so bandits scale with pop - 4 normally, 8 under the
-// aggressive No-Wretch preset (which also doubles the per-population step).
+// Roundstart bandit slots are a flat per-gamemode cap - NO population scaling. High Intensity opens 6 slots,
+// Tempered Intensity opens 4. The full cap is opened at roundstart even if not every seat fills (see
+// get_antag_amount / start in events/antagonist/solo/bandits.dm). Bandits still need HARD_ANTAG_MIN_POP to roll.
 /datum/antagonist/bandit
 	name = "Bandit"
 	roundend_category = "bandits"
@@ -18,11 +18,11 @@
 	storyteller_antag_flags = STORYTELLER_ANTAG_VILLAIN | STORYTELLER_ANTAG_ROUNDSTART
 	override_candidatereq = TRUE
 	storyteller_min_players = CHARACTER_INJECTION_MIN_POP
-	storyteller_slot_scaling = 2
+	storyteller_slot_scaling = 1	// unused: bandits use a flat cap, not storyteller_scale_slots
 	storyteller_slot_default_cap = 2
 	storyteller_maxcaps = list(
-		/datum/storyteller/gamemode/guaranteed_antag = 4,
-		/datum/storyteller/gamemode/guaranteed_antag/low_wretch = 6,
+		/datum/storyteller/gamemode/guaranteed_antag = 6,			// High Intensity
+		/datum/storyteller/gamemode/guaranteed_antag/low_wretch = 4,	// Tempered Intensity
 	)
 	var/favor = 150
 	var/totaldonated = 0

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -1,7 +1,7 @@
-/datum/round_event_control/antagonist/migrant_wave/banditsorgnolls
-	name = "Bandits or Gnolls Migration"
-	typepath = /datum/round_event/migrant_wave/banditsorgnolls
-	wave_type = /datum/migrant_wave/bandit
+/datum/round_event_control/antagonist/migrant_wave/only_gnolls
+	name = "Gnoll Migration"
+	typepath = /datum/round_event/migrant_wave/only_gnolls
+	wave_type = /datum/migrant_wave/gnolls
 	max_occurrences = 2
 
 	weight = 18
@@ -14,40 +14,21 @@
 		TAG_VILLIAN,
 	)
 
-/datum/round_event_control/antagonist/migrant_wave/banditsorgnolls/preRunEvent()
+/datum/round_event_control/antagonist/migrant_wave/only_gnolls/preRunEvent()
 	if(is_storyteller_soft_antag_blocked())
 		return EVENT_CANT_RUN
 	return ..()
 
-/datum/round_event/migrant_wave/banditsorgnolls/start()
-	var/gnolls_disabled = (SSgamemode.current_storyteller?.preferred_gnoll_mode == GNOLL_SCALING_NONE)
-	var/evilmode
-	if(gnolls_disabled)
-		evilmode = "bandits"
-	else if(is_storyteller_villain_blocked())
-		evilmode = "gnolls"
-	else
-		evilmode = pick("gnolls", "bandits")
-	if(evilmode == "bandits")
-		var/datum/job/bandit_job = SSjob.GetJob("Bandit")
-		var/bandit_maxcap = max(SSgamemode.story_antag_slot_cap(/datum/antagonist/bandit), bandit_job.total_positions)
-		bandit_job.total_positions = min(bandit_job.total_positions + 4, bandit_maxcap)
-		bandit_job.spawn_positions = min(bandit_job.spawn_positions + 4, bandit_maxcap)
-		if(bandit_job.total_positions < bandit_maxcap)
-			SSmapping.retainer.bandit_goal += 1 * rand(200, 400)
-			SSrole_class_handler.bandits_in_round = TRUE
-			for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
-				if(!player.client)
-					continue
-				to_chat(player, span_danger("Matthios, is this true? Bandits flock to Azuria. four bandit slots have been opened."))
-	if(evilmode == "gnolls")
-		var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
-		var/gnoll_maxcap = max(SSgamemode.story_antag_slot_cap(/datum/antagonist/gnoll), gnoll_job.total_positions)
-		gnoll_job.total_positions = min(gnoll_job.total_positions + 2, gnoll_maxcap)
-		gnoll_job.spawn_positions = min(gnoll_job.spawn_positions + 2, gnoll_maxcap)
-		if(gnoll_job.total_positions < gnoll_maxcap)
-			SSrole_class_handler.assassins_in_round = TRUE
-			for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
-				if(!player.client)
-					continue
-				to_chat(player, span_danger("Graggar demands blood, gnolls flock to Azuria."))
+/datum/round_event/migrant_wave/only_gnolls/start()
+	if(SSgamemode.current_storyteller?.preferred_gnoll_mode == GNOLL_SCALING_NONE)
+		return
+	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
+	var/gnoll_maxcap = max(SSgamemode.story_antag_slot_cap(/datum/antagonist/gnoll), gnoll_job.total_positions)
+	gnoll_job.total_positions = min(gnoll_job.total_positions + 2, gnoll_maxcap)
+	gnoll_job.spawn_positions = min(gnoll_job.spawn_positions + 2, gnoll_maxcap)
+	if(gnoll_job.total_positions < gnoll_maxcap)
+		SSrole_class_handler.assassins_in_round = TRUE
+		for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
+			if(!player.client)
+				continue
+			to_chat(player, span_danger("Graggar demands blood, gnolls flock to Azuria."))

--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -17,7 +17,7 @@
 
 	earliest_start = 0 SECONDS
 
-	weight = 18
+	weight = 10
 
 	typepath = /datum/round_event/antagonist/solo/bandits
 	antag_datum = /datum/antagonist/bandit
@@ -30,10 +30,18 @@
 		return EVENT_CANT_RUN
 	return ..()
 
+/datum/round_event_control/antagonist/solo/bandits/get_antag_amount()
+	var/admin_slot = SSgamemode.get_admin_slot(antag_datum, storyteller_slot_key)
+	if(!isnull(admin_slot))
+		return max(0, admin_slot)
+	return SSgamemode.story_antag_slot_cap(antag_datum, roundstart = roundstart)
+
 /datum/round_event/antagonist/solo/bandits/start()
 	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
-	bandit_job.total_positions = length(setup_minds)
-	bandit_job.spawn_positions = length(setup_minds)
+	var/datum/round_event_control/antagonist/solo/cast_control = control
+	var/max_slots = max(length(setup_minds), cast_control.get_antag_amount())
+	bandit_job.total_positions = max_slots
+	bandit_job.spawn_positions = max_slots
 	SSmapping.retainer.bandit_goal = rand(200,400) + (length(setup_minds) * rand(200,400))
 	for(var/datum/mind/antag_mind as anything in setup_minds)
 		var/mob/living/carbon/human/H = antag_mind.current

--- a/code/modules/events/antagonist/solo/lich.dm
+++ b/code/modules/events/antagonist/solo/lich.dm
@@ -16,7 +16,7 @@
 	base_antags = 1
 	maximum_antags = 1
 
-	weight = 2	//i hate you
+	weight = 11	//i hate you
 	max_occurrences = 1 // mashallah
 
 	earliest_start = 0 SECONDS

--- a/code/modules/events/antagonist/solo/masquerade.dm
+++ b/code/modules/events/antagonist/solo/masquerade.dm
@@ -13,7 +13,7 @@
 	storyteller_rumour_name = "a vampire masquerade"
 	storyteller_slot_key = "Masquerade"
 
-	weight = 12
+	weight = 8
 
 	denominator = 80
 

--- a/code/modules/events/antagonist/solo/vampires.dm
+++ b/code/modules/events/antagonist/solo/vampires.dm
@@ -12,7 +12,7 @@
 	storyteller_pill_label = "Vampire Lord"
 	storyteller_rumour_name = "lycker lords"
 
-	weight = 4
+	weight = 9
 	max_occurrences = 1
 
 	denominator = 80


### PR DESCRIPTION
## About The Pull Request

1. Low Intensity was moved to Psydon pool. 4 wretch max, 0 gnolls or dw or something
2. Medium in Ten now gives 12 wretches, 3 gnolls, with dw
3. Standard in Ten now gives 6 wretches, 2 gnolls, no dw
4. High intensity was unchanged
5. Tempered added to Ascendant, 5 wretches, 1 gnoll, no dw

BANDIT CHANGES
1. Bandits have a slightly higher chance to roll now, right under lich and above VL/Masq/WW
2. Bandits on Tempered will be 4 slots max. On High will be 6 slots. They won't scale to pop so anything above 40 roundstart pop will guarantee bandit slots to 4/6.
3. Disabled bandit migrations

## Testing Evidence

ingame testing

## Why It's Good For The Game

who nose

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: rebalanced gamemodes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
