### PR TITLE
forgot this - depreblesses silver knuckles

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -1098,7 +1098,6 @@
 /obj/item/rogueweapon/knuckledusters/get_mechanics_examine(mob/user)
 	. = ..()
 	. += span_notice("Knuckledusters, similar to Katars, can still parry oncoming blows. Note that their fragility makes this a bit more of a daunting process, however, for unskilled swingers.")
-	//. += span_notice("Activate - while held in your current hand - to turn these into knuckles, which can be worn as gloves to greatly improve your unarmed damage and parrying chances.")
 
 /obj/item/rogueweapon/knuckledusters/silver
 	name = "silver knuckledusters"

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -1111,7 +1111,7 @@
 /obj/item/rogueweapon/knuckledusters/silver/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
-		pre_blessed = BLESSING_TENNITE,\
+		pre_blessed = BLESSING_NONE,\
 		silver_type = SILVER_TENNITE,\
 		added_force = 0,\
 		added_blade_int = 0,\
@@ -1143,7 +1143,7 @@
 /obj/item/rogueweapon/knuckledusters/psy/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
-		pre_blessed = BLESSING_PSYDONIAN,\
+		pre_blessed = BLESSING_NONE,\
 		silver_type = SILVER_PSYDONIAN,\
 		added_force = 0,\
 		added_blade_int = 0,\


### PR DESCRIPTION
## About The Pull Request

yea

## Testing Evidence

yea

## Why It's Good For The Game

* Forgot to do this, after the retooling of silver. Good to cut down on the amount of preblessed weaponry that isn't inherent to a specific class.

## Changelog

:cl:
balance: Silver and Psydonic Knuckledusters no longer spawn with blessings.
/:cl: