### PR TITLE
Revert "Mouth Knife Buff" (#4334)

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -463,7 +463,7 @@
 			else
 				. = INFINITY
 			return
-
+		
 	. = ..()
 	if(glasses)
 		. += glasses.tint
@@ -1096,11 +1096,6 @@
 	var/obj/item/organ/testicles/testicles = getorganslot(ORGAN_SLOT_TESTICLES)
 	return testicles.virility
 
-/mob/living/carbon/human/update_mobility()
-	. = ..()
-	if(!(mobility_flags & MOBILITY_CANSTAND) && mouth?.spitoutmouth)
-		visible_message(span_warning("[src] spits out [mouth]."))
-		dropItemToGround(mouth, silent = FALSE)
 
 /mob/living/carbon/human/Topic(href, href_list)
 	..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -110,6 +110,9 @@
 				//End bloody footprints
 				S.step_action()
 		if(mouth)
+			if(mouth.spitoutmouth && prob(5))
+				visible_message(span_warning("[src] spits out [mouth]."))
+				dropItemToGround(mouth, silent = FALSE)
 			if(src.mind?.has_antag_datum(/datum/antagonist/zombie) && (!src.handcuffed) && prob(50))
 				visible_message(span_warning("[src] spits out [mouth]."))
 				dropItemToGround(mouth, silent = FALSE)


### PR DESCRIPTION
## About The Pull Request
This reverts commit 0ed696a53355fd3c53b72dcf422a4bf0f35d22ae // pr #4334

i'll be honest, this is down to personal preference. i have never actually seen this used & am willing to poke around if people _really_ want to hold daggers in their mouths for some reason. (again, i have never actually seen this done.)

tl;dr: you spit stuff out again on move instead of on laying down. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- compiles, tested and it seems to work.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- as i said i've never seen anyone actually use the dagger-in-mouth
- i do see people smoking zigs every other round & i think itd be better if you didnt have to manually *spit or grab it when you were done chuffing one
- again i am willing to compromise or close this if its unpopular 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:THE GRAND DUKE OF AZURE PEAK
code: you again spit out objects on move instead of on lay-down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
