### PR TITLE
corrects errant icon_state for griddlewiener

### DIFF
--- a/modular/Neu_Food/code/cooked/cooked_deep_fried.dm
+++ b/modular/Neu_Food/code/cooked/cooked_deep_fried.dm
@@ -59,7 +59,7 @@
 	name = "griddlewiener"
 	desc = "A deep-fried sausage, tucked into a griddle blanket, beloved by all, especially during the Harvest Festival."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_deep_fried.dmi'
-	icon_state = "griddlewiener"
+	icon_state = "griddleweiner"
 	faretype = FARE_LAVISH
 	foodtype = MEAT | GRAIN
 	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_TWO_MEALS)


### PR DESCRIPTION
## About The Pull Request
- title
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- compiles
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:THE GRAND DUKE OF AZURE PEAK
fix: griddlewiener should show up now. or is it griddleweiner. griddlewieiner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
