### PR TITLE
cleans up ghosts

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -140,6 +140,12 @@ GLOBAL_LIST_INIT(our_forest_sex, typecacheof(list(
 //Misc mobs
 #define isobserver(A) (istype(A, /mob/dead/observer))
 
+#define isplayerghost(A) (isobserver(A) && !isscryeye(A) && !isadminghost(A))
+
+#define isscryeye(A) (istype(A, /mob/dead/observer/eye))
+
+#define isadminghost(A) (istype(A, /mob/dead/observer/admin))
+
 #define isdead(A) (istype(A, /mob/dead))
 
 #define isnewplayer(A) (istype(A, /mob/dead/new_player))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -391,6 +391,8 @@
 	var/list/candidates = list()
 
 	for(var/mob/dead/observer/G in GLOB.player_list)
+		if(isscryeye(G))
+			continue
 		candidates += G
 
 	for(var/mob/living/carbon/spirit/bigchungus in GLOB.player_list)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -644,7 +644,7 @@ GLOBAL_LIST_EMPTY(species_list)
 	if(check_rights(R_WATCH, FALSE))
 		observer = new /mob/dead/observer/admin(src)
 	else
-		observer = new /mob/dead/observer/rogue/nodraw(src)
+		observer = new /mob/dead/observer/nodraw(src)
 	if(!existing)
 		lobbyer.spawning = TRUE
 

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -35,7 +35,7 @@
 		G.follow()
 	else
 		if(G.client)
-			if(istype(G, /mob/dead/observer/rogue/arcaneeye))
+			if(isscryeye(G) || G.trapped)
 				return
 			if(alert("Travel with the boatman?", "", "Yes", "No") == "Yes")
 				G.returntolobby(0)

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -1,29 +1,20 @@
 /mob/dead/observer/DblClickOn(atom/A, params)
+	return
+
+/mob/dead/observer/admin/DblClickOn(atom/A, params)
 	if(check_click_intercept(params, A))
 		return
 
 	if(can_reenter_corpse && mind && mind.current)
-		if(A == mind.current || (mind.current in A)) // double click your corpse or whatever holds it
-			reenter_corpse()						// (cloning scanner, body bag, closet, mech, etc)
-			return									// seems legit.
+		if(A == mind.current || (mind.current in A))
+			reenter_corpse()
+			return
 
-	// Things you might plausibly want to follow
 	if(ismovableatom(A))
 		ManualFollow(A)
 
-	// Otherwise jump
 	else if(A.loc)
 		forceMove(get_turf(A))
-
-/mob/dead/observer/profane/DblClickOn(atom/A, params) // Souls trapped by the dagger should not be jumping around.
-	return
-
-/mob/dead/observer/rogue/DblClickOn(atom/A, params)
-	var/mob/target
-	if(ismob(A))
-		target = A
-	if(target && (target.client.prefs.ghost_toggles & TOGGLE_ANTIGHOST))
-		return
 
 /mob/dead/observer/ClickOn(atom/A, params)
 	if(check_click_intercept(params,A))

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -92,7 +92,7 @@
 	//we stack the orbits up client side, so we can assign this back to normal server side without it breaking the orbit
 	orbiter.transform = initial_transform
 	orbiter.forceMove(get_turf(parent))
-	if(!istype(orbiter, /mob/dead/observer/screye))
+	if(!isscryeye(orbiter))
 		to_chat(orbiter, span_notice("Now orbiting [parent]."))
 
 /datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)

--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -1376,7 +1376,7 @@ Inquisitorial armory down here
 		lookat = whofedme
 	playsound(src, 'sound/items/blackmirror_use.ogg', 100, FALSE)
 	ADD_TRAIT(user, TRAIT_NOSSDINDICATOR, "blackmirror")
-	var/mob/dead/observer/screye/blackmirror/S = user.scry_ghost()
+	var/mob/dead/observer/eye/screye/blackmirror/S = user.scry_ghost()
 	if(!S)
 		return
 	S.ManualFollow(lookat)
@@ -1527,7 +1527,7 @@ Inquisitorial armory down here
 		lookat = source.whofedme
 	playsound(L, 'sound/items/blackmirror_use.ogg', 100, FALSE)
 	ADD_TRAIT(L, TRAIT_NOSSDINDICATOR, "blackmirror")
-	var/mob/dead/observer/screye/blackmirror/S = L.scry_ghost()
+	var/mob/dead/observer/eye/screye/blackmirror/S = L.scry_ghost()
 	if(!S)
 		return
 	S.ManualFollow(lookat)

--- a/code/game/objects/items/rogueitems/magic.dm
+++ b/code/game/objects/items/rogueitems/magic.dm
@@ -196,7 +196,7 @@
 		return
 	message_admins("SCRYING: [user.real_name] ([user.ckey]) has used the scrying orb to leer at [target.real_name] ([target.ckey])")
 	log_game("SCRYING: [user.real_name] ([user.ckey]) has used the scrying orb to leer at [target.real_name] ([target.ckey])")
-	var/mob/dead/observer/screye/S = user.scry_ghost()
+	var/mob/dead/observer/eye/screye/S = user.scry_ghost()
 	if(!S)
 		return
 	S.ManualFollow(target)

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -1300,16 +1300,16 @@
 				user.adjust_triumphs(1)
 				init_profane_soul(target, user) //If they are still in their body, send them to the dagger!
 
-/obj/item/rogueweapon/huntingknife/idagger/steel/profane/proc/init_profane_soul(mob/living/carbon/human/target, mob/user)
+/obj/item/rogueweapon/huntingknife/idagger/steel/profane/proc/init_profane_soul(mob/living/carbon/human/target, mob/user, mob/soul)
 	record_featured_stat(FEATURED_STATS_CRIMINALS, user)
 	record_round_statistic(STATS_ASSASSINATIONS)
 	var/mob/dead/observer/profane/S = new /mob/dead/observer/profane(src)
-	S.AddComponent(/datum/component/profaned, src)
+	S.forceMove(src)
 	S.name = "soul of [target.real_name]"
 	S.real_name = "soul of [target.real_name]"
 	S.deadchat_name = target.real_name
-	S.ManualFollow(src)
-	S.key = target.key
+	var/mob/keysource = soul || target
+	S.key = keysource.key
 	S.language_holder = target.language_holder.copy(S)
 	target.visible_message("<span class='danger'>[target]'s soul is pulled from their body and sucked into the profane dagger!</span>", "<span class='danger'>My soul is trapped within the profane dagger. Damnation!</span>")
 	playsound(src, 'sound/magic/soulsteal.ogg', 100, extrarange = 5)
@@ -1327,32 +1327,21 @@
 	if(!chosen_ghost || !chosen_ghost.client) // If there is no valid ghost or if that ghost has no active player
 		return FALSE
 	user.adjust_triumphs(1)
-	init_profane_soul(target, user) // If we got the soul, store them in the dagger.
-	qdel(target) // Get rid of that ghost!
+	init_profane_soul(target, user, chosen_ghost)
+	qdel(chosen_ghost)
 	return TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/profane/proc/release_profane_souls(mob/user) // For ways to release the souls trapped within a profane dagger, such as a Necrite burial rite. Returns the number of freed souls.
 	var/freed_souls = 0
 	for(var/mob/dead/observer/profane/A in src) // for every trapped soul in the dagger, whether they have left the game or not
 		to_chat(A, "<b>I have been freed from my vile prison, I await Necra's cold grasp. Salvation!</b>")
+		A.trapped = FALSE
 		A.returntolobby() //Send the trapped soul back to the lobby
 		user.visible_message("<span class='warning'>The [A.name] flows out from the profane dagger, finally free of its grasp.</span>")
 		freed_souls += 1
 	user.visible_message("<span class='warning'>The profane dagger shatters into putrid smoke!</span>")
 	qdel(src) // Delete the dagger. Forevermore.
 	return freed_souls
-
-/datum/component/profaned
-	var/atom/movable/container
-
-/datum/component/profaned/Initialize(atom/movable/container)
-	if(!istype(parent, /mob/dead/observer/profane))
-		return COMPONENT_INCOMPATIBLE
-	var/mob/dead/observer/profane/S = parent
-
-	src.container = container
-
-	S.forceMove(container)
 
 // Standard of the keep.
 // Big ol' flag that they keep to give bonuses, used by the manorguard standard bearer.

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -316,6 +316,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/mob/dead/observer/G_found
 	for(var/mob/dead/observer/G in GLOB.player_list)
+		if(isscryeye(G))
+			continue
 		if(G.ckey == input)
 			G_found = G
 			break

--- a/code/modules/antagonists/roguetown/villain/minor_antags/assassin.dm
+++ b/code/modules/antagonists/roguetown/villain/minor_antags/assassin.dm
@@ -57,7 +57,7 @@
 
 /datum/antagonist/assassin/roundend_report()
 	var/traitorwin = FALSE
-	for(var/obj/item/I in owner.current) // Check to see if the Assassin has their profane dagger on them, and then check the souls contained therein.
+	for(var/obj/item/I in owner.current.GetAllContents()) // Check to see if the Assassin has their profane dagger on them, and then check the souls contained therein.
 		if(istype(I, /obj/item/rogueweapon/huntingknife/idagger/steel/profane))
 			for(var/mob/dead/observer/profane/A in I) // Each trapped soul is announced to the server
 				if(A)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
@@ -69,7 +69,7 @@
 	if(target.stat != DEAD && target.stat != UNCONSCIOUS)
 		to_chat(target, span_warning("I feel as though the ground is watching me."))
 	ADD_TRAIT(user, TRAIT_NOSSDINDICATOR, "hagmirror")
-	var/mob/dead/observer/screye/blackmirror/S = H.scry_ghost()
+	var/mob/dead/observer/eye/screye/blackmirror/S = H.scry_ghost()
 	if(!S)
 		return
 	S.ManualFollow(target)
@@ -133,7 +133,7 @@
 	if(target.stat != DEAD && target.stat != UNCONSCIOUS)
 		to_chat(target, span_warning("I feel as though the ground is watching me."))
 	ADD_TRAIT(user, TRAIT_NOSSDINDICATOR, "hagmirror")
-	var/mob/dead/observer/screye/blackmirror/S = user.scry_ghost()
+	var/mob/dead/observer/eye/screye/blackmirror/S = user.scry_ghost()
 	if(!S)
 		return
 	S.ManualFollow(target)

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -3,21 +3,15 @@
 	if(client)
 		client.update_ooc_verb_visibility()
 
-	if(client && client.prefs)
-		ghost_accs = client.prefs.ghost_accs
-		ghost_others = client.prefs.ghost_others
-	var/preferred_form = null
-
 	if(IsAdminGhost(src))
 		has_unlimited_silicon_privilege = 1
 
 	if(client.prefs.unlock_content)
-		preferred_form = client.prefs.ghost_form
 		ghost_orbit = client.prefs.ghost_orbit
 
 	var/turf/T = get_turf(src)
 	if (isturf(T))
 		update_z(T.z)
 
-	update_icon(preferred_form)
+	update_icon()
 	updateghostimages()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -12,16 +12,16 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 	layer = GHOST_LAYER
 	stat = DEAD
 	density = FALSE
-	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS
+	sight = 0
 	see_invisible = SEE_INVISIBLE_OBSERVER
-	see_in_dark = 100
+	see_in_dark = 10
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	invisibility = INVISIBILITY_OBSERVER
 	hud_type = /datum/hud/ghost
 	movement_type = GROUND | FLYING
-	var/draw_icon = FALSE
+	var/draw_icon = TRUE
+	var/trapped = FALSE
 	var/can_reenter_corpse
-	var/datum/hud/living/carbon/hud = null // hud
 	var/bootime = 0
 	var/next_gmove = 0
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
@@ -33,30 +33,11 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 	var/image/ghostimage_simple = null //this mob with the simple white ghost sprite
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
 	var/mob/observetarget = null	//The target mob that the ghost is observing. Used as a reference in logout()
-	var/ghost_hud_enabled = 1 //did this ghost disable the on-screen HUD?
-	var/data_huds_on = 0 //Are data HUDs currently enabled?
-	var/health_scan = FALSE //Are health scans currently enabled?
-	var/gas_scan = FALSE //Are gas scans currently enabled?
-	var/list/datahuds = list() //list of data HUDs shown to ghosts.
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
-
-	//These variables store hair data if the ghost originates from a species with head and/or facial hair.
-	var/hairstyle
-	var/hair_color
-	var/mutable_appearance/hair_overlay
-	var/facial_hairstyle
-	var/facial_hair_color
-	var/mutable_appearance/facial_hair_overlay
-	var/ears
-	var/mutable_appearance/ears_overlay
 
 	var/updatedir = 1						//Do we have to update our dir as the ghost moves around?
 	var/lastsetting = null	//Stores the last setting that ghost_others was set to, for a little more efficiency when we update ghost images. Null means no update is necessary
 
-	//We store copies of the ghost display preferences locally so they can be referred to even if no client is connected.
-	//If there's a bug with changing your ghost settings, it's probably related to this.
-	var/ghost_accs = GHOST_ACCS_DEFAULT_OPTION
-	var/ghost_others = GHOST_OTHERS_DEFAULT_OPTION
 	// Used for displaying in ghost chat, without changing the actual name
 	// of the mob
 	var/deadchat_name
@@ -64,33 +45,58 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 	var/ghostize_time = 0
 	move_resist = INFINITY
 
-/mob/dead/observer/rogue
-//	see_invisible = SEE_INVISIBLE_LIVING
-	sight = 0
-	see_in_dark = 10
-	var/misting = 0
-	draw_icon = TRUE
-
 /mob/dead/observer/admin
 	hud_type = /datum/hud/adminghost
+	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS
+	see_in_dark = 100
+	draw_icon = FALSE
 
-/mob/dead/observer/rogue/nodraw
+/mob/dead/observer/nodraw
 	draw_icon = FALSE
 	icon = 'icons/roguetown/mob/misc.dmi'
 	icon_state = "hollow"
 	alpha = 150
 
-/mob/dead/observer/screye
-//	see_invisible = SEE_INVISIBLE_LIVING
-	sight = 0
+/mob/dead/observer/profane
+	trapped = TRUE
+
+/mob/dead/observer/profane/setup_ghost_verbs()
+	return
+
+/mob/dead/observer/eye
 	see_in_dark = 0
+	draw_icon = FALSE
 	hud_type = /datum/hud/obs
 
-/mob/dead/observer/screye/blackmirror
+/mob/dead/observer/eye/setup_ghost_verbs()
+	return
+
+/mob/dead/observer/eye/horde_respawn()
+	return
+
+/mob/dead/observer/eye/Move(NewLoc, direct)
+	if(updatedir)
+		setDir(direct)
+	if(NewLoc)
+		var/turf/target_turf = get_turf(NewLoc)
+		if(target_turf)
+			return forceMove(target_turf)
+		return FALSE
+	var/turf/current_turf = get_turf(src)
+	if(!current_turf)
+		return FALSE
+	var/turf/step_turf = get_step(current_turf, direct)
+	if(step_turf)
+		return forceMove(step_turf)
+	return FALSE
+
+/mob/dead/observer/eye/screye
+
+/mob/dead/observer/eye/screye/blackmirror
 	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS
 	see_in_dark = 100
 
-/mob/dead/observer/screye/Move(n, direct)
+/mob/dead/observer/eye/screye/Move(n, direct)
 	return
 
 
@@ -103,12 +109,7 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 		/mob/dead/observer/proc/open_spawners_menu,
 		/mob/dead/observer/proc/tray_view))
 
-	if(!istype(src, /mob/dead/observer/rogue/arcaneeye))
-		if(!istype(src, /mob/dead/observer/screye))
-			if(client)
-				add_verb(client, GLOB.ghost_verbs)
-			client?.init_verbs()
-			to_chat(src, span_danger("Click the <b>SKULL</b> on the left of your HUD to respawn."))
+	setup_ghost_verbs()
 
 	if(icon_state in GLOB.ghost_forms_with_directions_list)
 		ghostimage_default = image(src.icon,src,src.icon_state + "")
@@ -155,15 +156,6 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 
 		if(draw_icon)
 			if(ishuman(body))
-//				var/mob/living/carbon/human/body_human = body
-//				var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
-//				var/od = body_human.dir
-//				for(var/D in GLOB.cardinals)
-//					body_human.dir = D
-//					COMPILE_OVERLAYS(body)
-//					var/icon/partial = getFlatIcon(body, no_anim = TRUE, base_size = TRUE)
-//					out_icon.Insert(partial,dir=D)
-//				body_human.dir = od
 				var/mutable_appearance/MA = new()
 				MA.appearance = body
 				MA.transform = null //so we are standing
@@ -172,15 +164,7 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 				pixel_x = 0
 				pixel_y = 0
 				invisibility = INVISIBILITY_OBSERVER
-//				icon = out_icon
 				alpha = 100
-/*			if(HAIR in body_human.dna.species.species_traits)
-				hairstyle = body_human.hairstyle
-				hair_color = brighten_color(body_human.hair_color)
-			if(FACEHAIR in body_human.dna.species.species_traits)
-				facial_hairstyle = body_human.facial_hairstyle
-				facial_hair_color = brighten_color(body_human.facial_hair_color)
-			*/
 	update_icon()
 
 	if(!T)
@@ -197,7 +181,8 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 		remove_verb(src, /mob/dead/observer/verb/boo)
 		remove_verb(src, /mob/dead/observer/verb/possess)
 
-	GLOB.dead_mob_list += src
+	if(!isscryeye(src))
+		GLOB.dead_mob_list += src
 
 	for(var/v in GLOB.active_alternate_appearances)
 		if(!v)
@@ -208,18 +193,16 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 	. = ..()
 
 	grant_all_languages()
-//	show_data_huds()
-//	data_huds_on = 1
 
 /mob/dead/observer/Login()
 	. = ..()
-	if(!(istype(src, /mob/dead/observer/rogue/arcaneeye)))
-		if(istype(src, /mob/dead/observer/screye))
-			return
-		if(client)
-			add_verb(client, GLOB.ghost_verbs)
-		client?.init_verbs()
-		to_chat(src, span_danger("Click the <b>SKULL</b> on the left of your HUD to respawn."))
+	setup_ghost_verbs()
+
+/mob/dead/observer/proc/setup_ghost_verbs()
+	if(client)
+		add_verb(client, GLOB.ghost_verbs)
+	client?.init_verbs()
+	to_chat(src, span_danger("Click the <b>SKULL</b> on the left of your HUD to respawn."))
 
 /mob/dead/observer/narsie_act()
 	var/old_color = color
@@ -244,145 +227,45 @@ GLOBAL_VAR_CONST(observer_move_delay_multiplier, 0.5)
 /mob/dead/CanPass(atom/movable/mover, turf/target)
 	return 1
 
-/mob/dead/observer/rogue/CanPass(atom/movable/mover, turf/target)
-	if(!isinhell)
-		if(istype(mover, /mob/dead/observer/rogue))
-			return 0
-		if(istype(mover, /mob/dead/observer/rogue/arcaneeye))
-			return 1
+/mob/dead/observer/CanPass(atom/movable/mover, turf/target)
+	if(!isinhell && isplayerghost(src) && isplayerghost(mover))
+		return 0
 	return 1
-
-/*
- * This proc will update the icon of the ghost itself, with hair overlays, as well as the ghost image.
- * Please call update_icon(icon_state) from now on when you want to update the icon_state of the ghost,
- * or you might end up with hair on a sprite that's not supposed to get it.
- * Hair will always update its dir, so if your sprite has no dirs the haircut will go all over the place.
- * |- Ricotez
- */
-/mob/dead/observer/update_icon(new_form)
-	. = ..()
-/*
-	if(client) //We update our preferences in case they changed right before update_icon was called.
-		ghost_accs = client.prefs.ghost_accs
-		ghost_others = client.prefs.ghost_others
-
-	if(hair_overlay)
-		cut_overlay(hair_overlay)
-		hair_overlay = null
-
-	if(facial_hair_overlay)
-		cut_overlay(facial_hair_overlay)
-		facial_hair_overlay = null
-
-	if(ear_overlay)
-		cut_overlay(ear_overlay)
-		ear_overlay = null
-
-	if(new_form)
-		icon_state = new_form
-		if(icon_state in GLOB.ghost_forms_with_directions_list)
-			ghostimage_default.icon_state = new_form + "_nodir" //if this icon has dirs, the default ghostimage must use its nodir version or clients with the preference set to default sprites only will see the dirs
-		else
-			ghostimage_default.icon_state = new_form
-
-	if(ghost_accs >= GHOST_ACCS_DIR && icon_state in GLOB.ghost_forms_with_directions_list) //if this icon has dirs AND the client wants to show them, we make sure we update the dir on movement
-		updatedir = 1
-	else
-		updatedir = 0	//stop updating the dir in case we want to show accessories with dirs on a ghost sprite without dirs
-		setDir(2 		)//reset the dir to its default so the sprites all properly align up
-
-	if(ghost_accs == GHOST_ACCS_FULL && icon_state in GLOB.ghost_forms_with_accessories_list) //check if this form supports accessories and if the client wants to show them
-		var/datum/sprite_accessory/S
-		if(facial_hairstyle)
-			S = GLOB.facial_hairstyles_list[facial_hairstyle]
-			if(S)
-				facial_hair_overlay = mutable_appearance(S.icon, "[S.icon_state]", -HAIR_LAYER)
-				if(facial_hair_color)
-					facial_hair_overlay.color = "#" + facial_hair_color
-				facial_hair_overlay.alpha = 200
-				add_overlay(facial_hair_overlay)
-		if(hairstyle)
-			S = GLOB.hairstyles_list[hairstyle]
-			if(S)
-				hair_overlay = mutable_appearance(S.icon, "[S.icon_state]", -HAIR_LAYER)
-				if(hair_color)
-					hair_overlay.color = "#" + hair_color
-				hair_overlay.alpha = 200
-				add_overlay(hair_overlay)
-		if(ear_style)
-			S = GLOB.ears_list[ear_style]
-			ear_overlay = mutable_appearance(S.icon, layer = -layer)*/
-
-
-/*
- * Increase the brightness of a color by calculating the average distance between the R, G and B values,
- * and maximum brightness, then adding 30% of that average to R, G and B.
- *
- * I'll make this proc global and move it to its own file in a future update. |- Ricotez
- */
-/mob/proc/brighten_color(input_color)
-	var/r_val
-	var/b_val
-	var/g_val
-	var/color_format = length(input_color)
-	if(color_format == 3)
-		r_val = hex2num(copytext(input_color, 1, 2))*16
-		g_val = hex2num(copytext(input_color, 2, 3))*16
-		b_val = hex2num(copytext(input_color, 3, 0))*16
-	else if(color_format == 6)
-		r_val = hex2num(copytext(input_color, 1, 3))
-		g_val = hex2num(copytext(input_color, 3, 5))
-		b_val = hex2num(copytext(input_color, 5, 0))
-	else
-		return 0 //If the color format is not 3 or 6, you're using an unexpected way to represent a color.
-
-	r_val += (255 - r_val) * 0.4
-	if(r_val > 255)
-		r_val = 255
-	g_val += (255 - g_val) * 0.4
-	if(g_val > 255)
-		g_val = 255
-	b_val += (255 - b_val) * 0.4
-	if(b_val > 255)
-		b_val = 255
-
-	return num2hex(r_val, 2) + num2hex(g_val, 2) + num2hex(b_val, 2)
 
 /*
 Transfer_mind is there to check if mob is being deleted/not going to have a body.
 Works together with spawning an observer, noted above.
 */
 
-/mob/proc/ghostize(can_reenter_corpse = 1, force_respawn = FALSE, admin = FALSE, drawskip, ignore_zombie = FALSE)
+/mob/proc/make_observer(ghostpath, reenter = TRUE)
 	if(!key)
 		return
-	stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now
-//	stop_all_loops()
+	stop_sound_channel(CHANNEL_HEARTBEAT)
 	if(client)
 		SSdroning.kill_rain(client)
 		SSdroning.kill_loop(client)
 		SSdroning.kill_droning(client)
-//		var/S = sound('sound/ambience/creepywind.ogg', repeat = 1, wait = 0, volume = client.prefs.musicvol, channel = CHANNEL_MUSIC)
-//		play_priomusic(S)
-	var/mob/dead/observer/ghost	// Transfer safety to observer spawning proc.
+	var/mob/dead/observer/ghost = new ghostpath(src)
+	ghost.ghostize_time = world.time
+	SStgui.on_transfer(src, ghost)
+	ghost.can_reenter_corpse = reenter
+	return ghost
+
+/mob/proc/ghostize(can_reenter_corpse = 1, force_respawn = FALSE, admin = FALSE, drawskip, ignore_zombie = FALSE)
+	var/ghostpath = /mob/dead/observer
 	if(admin)
-		ghost = new /mob/dead/observer/admin(src)
+		ghostpath = /mob/dead/observer/admin
 	else if(drawskip)
-		ghost = new /mob/dead/observer/rogue/nodraw(src)
-	else
-		ghost = new /mob/dead/observer/rogue(src)
+		ghostpath = /mob/dead/observer/nodraw
+	var/mob/dead/observer/ghost = make_observer(ghostpath, can_reenter_corpse)
+	if(!ghost)
+		return
 	if(!admin)
 		ghost.add_client_colour(/datum/client_colour/monochrome)
-	ghost.ghostize_time = world.time
-	SStgui.on_transfer(src, ghost) // Transfer NanoUIs.
-	ghost.can_reenter_corpse = can_reenter_corpse
-	ghost.advjob = src.advjob
-	// Clear any active spell click intercept before the client transfers to the ghost.
-	// Without this, the client keeps signal registrations from the old body's active spell,
-	// causing the ghost to cast the old body's last spell on click.
+	ghost.advjob = advjob
 	if(click_intercept && istype(click_intercept, /datum/action/cooldown))
-		var/datum/action/cooldown/active_ability = click_intercept
-		active_ability.unset_click_ability(src, refund_cooldown = FALSE)
+		var/datum/action/cooldown/ability = click_intercept
+		ability.unset_click_ability(src, refund_cooldown = FALSE)
 	ghost.key = key
 	return ghost
 
@@ -399,20 +282,12 @@ Works together with spawning an observer, noted above.
 				return
 	return ..()
 
-/mob/proc/scry_ghost()
-	if(key)
-		stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now
-//		stop_all_loops()
-		if(client)
-			SSdroning.kill_rain(client)
-			SSdroning.kill_loop(client)
-			SSdroning.kill_droning(client)
-		var/mob/dead/observer/screye/ghost = new(src)	// Transfer safety to observer spawning proc.
-		ghost.ghostize_time = world.time
-		SStgui.on_transfer(src, ghost) // Transfer NanoUIs.
-		ghost.can_reenter_corpse = TRUE
-		ghost.key = key
-		return ghost
+/mob/proc/scry_ghost(eyetype = /mob/dead/observer/eye/screye)
+	var/mob/dead/observer/eye/ghost = make_observer(eyetype)
+	if(!ghost)
+		return
+	ghost.key = key
+	return ghost
 
 /*
 This is the proc mobs get to turn into a ghost. Forked from ghostize due to compatibility issues.
@@ -492,6 +367,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set category = "Preferences.Options"
 	set hidden = 1
 	if (CONFIG_GET(flag/norespawn))
+		return
+	if(trapped)
 		return
 	if ((stat != DEAD || !( SSticker )))
 		to_chat(src, span_boldnotice("I must be dead to use this!"))
@@ -585,6 +462,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!isobserver(usr))
 		to_chat(usr, span_warning("Not when you're not dead!"))
 		return
+	if(trapped || isscryeye(src))
+		return
+	area_tele()
+
+/mob/dead/observer/proc/area_tele()
 	var/list/filtered = list()
 	for(var/V in GLOB.sortedAreas)
 		var/area/A = V
@@ -600,10 +482,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		L+=T
 
 	if(!L || !L.len)
-		to_chat(usr, span_warning("No area available."))
+		to_chat(src, span_warning("No area available."))
 		return
 
-	usr.forceMove(pick(L))
+	forceMove(pick(L))
 
 /mob/dead/observer/verb/follow()
 	set name = "Orbit" // "Haunt"
@@ -625,6 +507,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 // This is the ghost's follow verb with an argument
 /mob/dead/observer/proc/ManualFollow(atom/movable/target)
 	if (!istype(target))
+		return
+	if(trapped)
 		return
 
 	var/icon/I = icon(target.icon,target.icon_state,target.dir)
@@ -665,6 +549,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set desc = ""
 	set hidden = 1
 
+	if(trapped || isscryeye(src))
+		return
 	if(isobserver(usr)) //Make sure they're an observer!
 
 
@@ -758,9 +644,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	update_sight()
 
 /mob/dead/observer/update_sight()
-	if(client)
-		ghost_others = client.prefs.ghost_others //A quick update just in case this setting was changed right before calling the proc
-
 	if (!ghostvision)
 		see_invisible = SEE_INVISIBLE_LIVING
 	else
@@ -778,7 +661,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		O.updateghostimages()
 
 /mob/dead/observer/proc/horde_respawn()
-	if(istype(src, /mob/dead/observer/rogue/arcaneeye))
+	if(trapped)
 		return
 	var/bt = world.time
 	SEND_SOUND(src, sound('sound/misc/notice (2).ogg'))
@@ -883,57 +766,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/mind_initialize()
 	return
 
-/mob/dead/observer/proc/show_data_huds()
-	for(var/hudtype in datahuds)
-		var/datum/atom_hud/H = GLOB.huds[hudtype]
-		H.add_hud_to(src)
-
-/mob/dead/observer/proc/remove_data_huds()
-	for(var/hudtype in datahuds)
-		var/datum/atom_hud/H = GLOB.huds[hudtype]
-		H.remove_hud_from(src)
-
-/mob/dead/observer/verb/toggle_data_huds()
-	set name = "Toggle Sec/Med/Diag HUD"
-	set desc = ""
-	set hidden = 1
-	if(!check_rights(R_WATCH))
-		return
-	if(data_huds_on) //remove old huds
-		remove_data_huds()
-		to_chat(src, span_notice("Data HUDs disabled."))
-		data_huds_on = 0
-	else
-		show_data_huds()
-		to_chat(src, span_notice("Data HUDs enabled."))
-		data_huds_on = 1
-
-/mob/dead/observer/verb/toggle_health_scan()
-	set name = "Toggle Health Scan"
-	set desc = ""
-	set hidden = 1
-	if(!check_rights(R_WATCH))
-		return
-	if(health_scan) //remove old huds
-		to_chat(src, span_notice("Health scan disabled."))
-		health_scan = FALSE
-	else
-		to_chat(src, span_notice("Health scan enabled."))
-		health_scan = TRUE
-
-/mob/dead/observer/verb/toggle_gas_scan()
-	set name = "Toggle Gas Scan"
-	set desc = ""
-	set hidden = 1
-	if(!check_rights(R_WATCH))
-		return
-	if(gas_scan)
-		to_chat(src, span_notice("Gas scan disabled."))
-		gas_scan = FALSE
-	else
-		to_chat(src, span_notice("Gas scan enabled."))
-		gas_scan = TRUE
-
 /mob/dead/observer/verb/restore_ghost_appearance()
 	set name = "Restore Ghost Character"
 	set desc = "Sets your deadchat name and ghost appearance to your \
@@ -955,13 +787,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		client.prefs.real_name = random_unique_name(gender)
 	if(client.prefs.randomise[RANDOM_BODY])
 		client.prefs.random_character(gender)
-
-	if(HAIR in client.prefs.pref_species.species_traits)
-		hairstyle = client.prefs.hairstyle
-		hair_color = brighten_color(client.prefs.hair_color)
-	if(FACEHAIR in client.prefs.pref_species.species_traits)
-		facial_hairstyle = client.prefs.facial_hairstyle
-		facial_hair_color = brighten_color(client.prefs.facial_hair_color)
 
 	update_icon()
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -4,6 +4,9 @@
 		return 1
 
 /mob/dead/observer/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+	return
+
+/mob/dead/observer/admin/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if (!message)
 		return
@@ -25,37 +28,15 @@
 
 	. = say_dead(message)
 
-/mob/dead/observer/rogue/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	return
+/mob/dead/observer/profane/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+	if (!message)
+		return
 
-/mob/dead/observer/rogue/say_dead(message)
-	return
+	if(check_emote(message, forced))
+		return
 
-/mob/dead/observer/screye/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	return
-
-/mob/dead/observer/screye/say_dead(message)
-	return
-
-/*
-/mob/dead/observer/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode, original_message)
-	. = ..()
-	var/atom/movable/to_follow = speaker
-	if(radio_freq)
-		var/atom/movable/virtualspeaker/V = speaker
-
-		if(isAI(V.source))
-			var/mob/living/silicon/ai/S = V.source
-			to_follow = S.eyeobj
-		else
-			to_follow = V.source
-	var/link = FOLLOW_LINK(src, to_follow)
-// Create map text prior to modifying message for goonchat
-	if (client?.prefs.chat_on_map && (client.prefs.see_chat_non_mob || ismob(speaker)))
-		create_chat_message(speaker, message_language, raw_message, spans, message_mode)
-	// Recompose the message, because it's scrambled by default
-	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
-	to_chat(src, "[link] [message]")*/
+	. = say_dead(message)
 
 /mob/dead/observer/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode, original_message)
 	. = ..()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -955,6 +955,8 @@
 	if(ignore_mapload && SSatoms.initialized != INITIALIZATION_INNEW_REGULAR)	//don't notify for objects created during a map load
 		return
 	for(var/mob/dead/observer/O in GLOB.player_list)
+		if(isscryeye(O))
+			continue
 		if(!notify_suiciders && (O in GLOB.suicided_mob_list))
 			continue
 		if (ignore_key && (O.ckey in GLOB.poll_ignore[ignore_key]))

--- a/code/modules/roguetown/roguejobs/mages/leylines.dm
+++ b/code/modules/roguetown/roguejobs/mages/leylines.dm
@@ -117,6 +117,8 @@ GLOBAL_LIST_EMPTY(leyline_activations)
 	var/counts = list(0,0,0,0)
 	var/list/candidates = list()
 	for(var/mob/dead/observer/G in GLOB.player_list)
+		if(isscryeye(G))
+			continue
 		candidates += G
 
 	for(var/mob/living/carbon/spirit/bigchungus in GLOB.player_list)

--- a/code/modules/roguetown/roguemachine/zadcote/zad_voyeur.dm
+++ b/code/modules/roguetown/roguemachine/zadcote/zad_voyeur.dm
@@ -39,14 +39,14 @@
 	broadcaster.visible_message(span_notice("A strange blue glow emits from [source_desc]."))
 	add_filter("zad_voyeur_glow", 2, list("type" = "outline", "size" = 1, "color" = "#4488ff"))
 	set_light(2, 2, 2, l_color = "#1b7bf1")
-	var/mob/dead/observer/screye/zadcote_voyeur/S = spawn_zad_screye(operator)
+	var/mob/dead/observer/eye/screye/zadcote_voyeur/S = operator.scry_ghost(/mob/dead/observer/eye/screye/zadcote_voyeur)
 	if(!S)
 		end_voyeur_visuals()
 		return
 	S.bonded_cage = WEAKREF(src)
-	active_voyeur_screye = WEAKREF(S)
+	voyeur_screye = WEAKREF(S)
 	if(holder)
-		active_voyeur_holder = WEAKREF(holder)
+		voyeur_holder = WEAKREF(holder)
 	S.ManualFollow(target)
 	operator.visible_message(span_danger("[operator] stares into the zadcote, [operator.p_their()] eyes rolling back into [operator.p_their()] head."))
 	to_chat(S, span_notice("You see through the zad's eyes. Click <b>Stop Scrying</b> in the IC tab to return early; otherwise the bond breaks on its own after [ZAD_VOYEUR_DURATION / (1 MINUTES)] minute\s."))
@@ -58,10 +58,10 @@
 	addtimer(CALLBACK(src, PROC_REF(finish_voyeur)), ZAD_VOYEUR_DURATION)
 
 /obj/item/zadcage/proc/finish_voyeur()
-	var/mob/dead/observer/screye/zadcote_voyeur/S = active_voyeur_screye?.resolve()
-	var/mob/holder = active_voyeur_holder?.resolve()
-	active_voyeur_screye = null
-	active_voyeur_holder = null
+	var/mob/dead/observer/eye/screye/zadcote_voyeur/S = voyeur_screye?.resolve()
+	var/mob/holder = voyeur_holder?.resolve()
+	voyeur_screye = null
+	voyeur_holder = null
 	end_voyeur_visuals()
 	if(holder)
 		holder.clear_alert("scryingeye", TRUE)
@@ -73,30 +73,15 @@
 	remove_filter("zad_voyeur_glow")
 	set_light(0)
 
-/proc/spawn_zad_screye(mob/operator)
-	if(!operator || !operator.key)
-		return null
-	if(operator.client)
-		SSdroning.kill_rain(operator.client)
-		SSdroning.kill_loop(operator.client)
-		SSdroning.kill_droning(operator.client)
-	operator.stop_sound_channel(CHANNEL_HEARTBEAT)
-	var/mob/dead/observer/screye/zadcote_voyeur/ghost = new(operator)
-	ghost.ghostize_time = world.time
-	SStgui.on_transfer(operator, ghost)
-	ghost.can_reenter_corpse = TRUE
-	ghost.key = operator.key
-	return ghost
-
-/mob/dead/observer/screye/zadcote_voyeur
+/mob/dead/observer/eye/screye/zadcote_voyeur
 	name = "scrying through a zad"
 	var/datum/weakref/bonded_cage
 
-/mob/dead/observer/screye/zadcote_voyeur/Initialize()
+/mob/dead/observer/eye/screye/zadcote_voyeur/Initialize()
 	. = ..()
-	add_verb(src, /mob/dead/observer/screye/zadcote_voyeur/proc/end_zad_voyeur)
+	add_verb(src, /mob/dead/observer/eye/screye/zadcote_voyeur/proc/end_zad_voyeur)
 
-/mob/dead/observer/screye/zadcote_voyeur/proc/end_zad_voyeur()
+/mob/dead/observer/eye/screye/zadcote_voyeur/proc/end_zad_voyeur()
 	set category = "IC"
 	set name = "Stop Scrying"
 	set desc = "End the zad-scrying and return to your body."

--- a/code/modules/roguetown/roguemachine/zadcote/zadcage.dm
+++ b/code/modules/roguetown/roguemachine/zadcote/zadcage.dm
@@ -12,8 +12,8 @@
 	var/datum/zad_occupancy/current_occupancy
 	var/severed_announced = FALSE
 	var/list/obj/item/held_payload = list()
-	var/datum/weakref/active_voyeur_screye
-	var/datum/weakref/active_voyeur_holder
+	var/datum/weakref/voyeur_screye
+	var/datum/weakref/voyeur_holder
 
 /obj/item/zadcage/update_icon()
 	cut_overlays()
@@ -26,7 +26,7 @@
 
 /obj/item/zadcage/Destroy()
 	STOP_PROCESSING(SSroguemachine, src)
-	if(active_voyeur_screye)
+	if(voyeur_screye)
 		finish_voyeur()
 	var/datum/zadlink/link = resolve_link()
 	if(link)

--- a/code/modules/spells/pantheon/divine/necra.dm
+++ b/code/modules/spells/pantheon/divine/necra.dm
@@ -957,7 +957,7 @@ var/global/mob/_corpse_sort_ref = null
 		)
 
 	// Create scry eye
-	var/mob/dead/observer/screye/S = user.scry_ghost()
+	var/mob/dead/observer/eye/screye/S = user.scry_ghost()
 	if(!S)
 		return FALSE
 

--- a/code/modules/vampire_neu/covens/coven_powers/auspex.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/auspex.dm
@@ -126,4 +126,4 @@
 	. = ..()
 	owner.visible_message("<font color='red'>[owner]'s eyes turn blank, like they are not even here.</font>", "<font color='red'>I begin to channel my consciousness into a psychic projection.</font>")
 	if(do_after(owner, 6 SECONDS, src))
-		owner.scry(can_reenter_corpse = 1, force_respawn = FALSE)
+		owner.scry_ghost(/mob/dead/observer/eye/arcane)

--- a/code/modules/vampire_neu/objects/scrying.dm
+++ b/code/modules/vampire_neu/objects/scrying.dm
@@ -1,4 +1,4 @@
-/obj/structure/vampire/scryingorb // Method of spying on the town
+/obj/structure/vampire/scryingorb
 	name = "Eye of Night"
 	icon_state = "scrying"
 	desc = "An unholy creation of impossible design, floats before you. Upon its surface flashes countless images and shapes beyond your understanding, places that shouldn't exist. Merely being in its vicinity sends a shiver down your spine."
@@ -6,7 +6,7 @@
 	if(user?.mind.has_antag_datum(/datum/antagonist/vampire/lord))
 		user.visible_message("<font color='red'>[user]'s eyes turn dark red, as they channel the [src]</font>", "<font color='red'>I begin to channel my consciousness into a Predator's Eye.</font>")
 		if(do_after(user, 6 SECONDS, src))
-			user.scry(can_reenter_corpse = 1, force_respawn = FALSE)
+			user.scry_ghost(/mob/dead/observer/eye/arcane)
 	else
 		to_chat(user, span_warning("I don't have the power to use this!"))
 
@@ -15,19 +15,12 @@
 	if(user.mind?.has_antag_datum(/datum/antagonist/vampire/lord))
 		. += span_bloody("Your scrying eye; spy upon the mortal or immortal realms alyke, peer through all languages and places. Just be careful whom walks past your eye. Your presence is powerful enough to be noticed even lyke this.")
 
-/mob/dead/observer/rogue/arcaneeye
-	sight = 0
-	see_in_dark = 2
-	invisibility = INVISIBILITY_OBSERVER
-	see_invisible = SEE_INVISIBLE_OBSERVER
-
-	misting = 0
-	var/mob/living/carbon/human/vampirelord = null
+/mob/dead/observer/eye/arcane
 	icon_state = "arcaneeye"
-	draw_icon = FALSE
+	see_in_dark = 2
 	hud_type = /datum/hud/eye
 
-/mob/dead/observer/rogue/arcaneeye/proc/scry_tele()
+/mob/dead/observer/eye/arcane/proc/scry_tele()
 	set category = "RoleUnique.Arcane Eye"
 	set name = "Teleport"
 	set desc= "Teleport to a location"
@@ -36,50 +29,27 @@
 	if(!isobserver(usr))
 		to_chat(usr, span_warning("You're not an Eye!"))
 		return
-	var/list/filtered = list()
-	for(var/V in GLOB.sortedAreas)
-		var/area/A = V
-		if(!A.hidden)
-			filtered += A
-	var/area/thearea  = input("Area to jump to", "BOOYEA") as null|anything in filtered
+	area_tele()
 
-	if(!thearea)
-		return
-
-	var/list/L = list()
-	for(var/turf/T in get_area_turfs(thearea.type))
-		L+=T
-
-	if(!L || !L.len)
-		to_chat(usr, span_warning("No area available."))
-		return
-
-	usr.forceMove(pick(L))
-
-/mob/dead/observer/rogue/arcaneeye/Initialize()
+/mob/dead/observer/eye/arcane/Initialize()
 	. = ..()
-	set_invisibility(GLOB.observer_default_invisibility)
 	add_verb(src, list(
-		/mob/dead/observer/rogue/arcaneeye/proc/scry_tele,
-		/mob/dead/observer/rogue/arcaneeye/proc/cancel_scry,
-		/mob/dead/observer/rogue/arcaneeye/proc/eye_down,
-		/mob/dead/observer/rogue/arcaneeye/proc/eye_up,
-		/mob/dead/observer/rogue/arcaneeye/proc/vampire_telepathy))
+		/mob/dead/observer/eye/arcane/proc/scry_tele,
+		/mob/dead/observer/eye/arcane/proc/cancel_scry,
+		/mob/dead/observer/eye/arcane/proc/eye_down,
+		/mob/dead/observer/eye/arcane/proc/eye_up,
+		/mob/dead/observer/eye/arcane/proc/vampire_telepathy))
 	name = "Arcane Eye"
-	grant_all_languages()
 
-/mob/dead/observer/rogue/arcaneeye/proc/cancel_scry()
+/mob/dead/observer/eye/arcane/proc/cancel_scry()
 	set category = "RoleUnique.Arcane Eye"
 	set name = "Cancel Eye"
 	set desc= "Return to Body"
 
-	if(vampirelord)
-		vampirelord.ckey = ckey
+	if(reenter_corpse())
 		qdel(src)
-	else
-		to_chat(src, "My body has been destroyed! I'm trapped!")
 
-/mob/dead/observer/rogue/arcaneeye/Crossed(mob/living/L)
+/mob/dead/observer/eye/arcane/Crossed(mob/living/L)
 	if(istype(L, /mob/living/carbon/human))
 		var/mob/living/carbon/human/V = L
 		var/holyskill = V.get_skill_level(/datum/skill/magic/holy)
@@ -94,7 +64,7 @@
 			to_chat(V, "<font color='red'>You feel like someone is watching you, or something.</font>")
 			return
 
-/mob/dead/observer/rogue/arcaneeye/proc/vampire_telepathy()
+/mob/dead/observer/eye/arcane/proc/vampire_telepathy()
 	set name = "Telepathy"
 	set category = "RoleUnique.Arcane Eye"
 
@@ -105,45 +75,20 @@
 		to_chat(V, span_boldnotice("A message from [src.real_name]:[msg]"))
 	for(var/datum/mind/D in SSmapping.retainer.death_knights)
 		to_chat(D, span_boldnotice("A message from [src.real_name]:[msg]"))
-	for(var/mob/dead/observer/rogue/arcaneeye/A in GLOB.mob_list)
+	for(var/mob/dead/observer/eye/arcane/A in GLOB.mob_list)
 		to_chat(A, span_boldnotice("A message from [src.real_name]:[msg]"))
 
-/mob/dead/observer/rogue/arcaneeye/proc/eye_up()
+/mob/dead/observer/eye/arcane/proc/eye_up()
 	set category = "RoleUnique.Arcane Eye"
 	set name = "Move Up"
 
 	if(zMove(UP, TRUE))
 		to_chat(src, span_notice("I move upwards."))
 
-/mob/dead/observer/rogue/arcaneeye/proc/eye_down()
+/mob/dead/observer/eye/arcane/proc/eye_down()
 	set category = "RoleUnique.Arcane Eye"
 	set name = "Move Down"
 
 	if(zMove(DOWN, TRUE))
 		to_chat(src, span_notice("I move down."))
 
-/mob/dead/observer/rogue/arcaneeye/Move(NewLoc, direct)
-	if(updatedir)
-		setDir(direct)//only update dir if we actually need it, so overlays won't spin on base sprites that don't have directions of their own
-	if(NewLoc)
-		var/turf/target_turf = get_turf(NewLoc)
-		if(target_turf)
-			return forceMove(target_turf)
-		return FALSE
-	var/turf/current_turf = get_turf(src)
-	if(!current_turf)
-		return FALSE
-	var/turf/step_turf = get_step(current_turf, direct)
-	if(step_turf)
-		return forceMove(step_turf)
-	return FALSE
-
-/mob/proc/scry(can_reenter_corpse = 1, force_respawn = FALSE, drawskip)
-	stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now
-	var/mob/dead/observer/rogue/arcaneeye/eye = new(src)	// Transfer safety to observer spawning proc.
-	SStgui.on_transfer(src, eye) // Transfer NanoUIs.
-	eye.can_reenter_corpse = can_reenter_corpse
-	eye.vampirelord = src
-	eye.ghostize_time = world.time
-	eye.key = key
-	return eye


### PR DESCRIPTION
## About The Pull Request

1. Cleans up our myriad of weird errant ghost child types and unifies it all. Also removes the actual TG ghosting we had.
2. profane dagger had a bug where the release of a victim wouldn't work. Fixed that.
3. fixed a possible exploit of scried players being able to double-click a turf to jump around.
4. scried players no longer get polled for ghost stuff

## Testing Evidence

tested though a TM for a round or two is preferred

## Why It's Good For The Game

i saw the whole thing and it gave me conniptions. 

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: cleans up ghost mob code.
fix: fixed bugs with the profane dagger that did not actually put the player client in the dagger.
fix: fixed ghost polling for scried clients.
fix: prevents scried clients from jumping around with double click to move turf.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
