### PR TITLE
[tm for a bit] wildshape now applies tired effects to created mob if original mob was tired

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -110,6 +110,10 @@
 	W.set_nutrition(nutrition)
 	W.set_hydration(hydration)
 
+	// tired debuff transfer
+	if(has_status_effect(/datum/status_effect/debuff/sleepytime))
+		W.apply_status_effect(/datum/status_effect/debuff/sleepytime)
+
 	mind.transfer_to(W)
 	skills?.known_skills = list()
 	skills?.skill_experience = list()
@@ -193,6 +197,10 @@
 
 	W.set_nutrition(nutrition)
 	W.set_hydration(hydration)
+
+// tired debuff transfer
+	if(has_status_effect(/datum/status_effect/debuff/sleepytime))
+		W.apply_status_effect(/datum/status_effect/debuff/sleepytime)
 
 	W.forceMove(get_turf(src))
 	mind.transfer_to(W)


### PR DESCRIPTION
## About The Pull Request
- bug report said that shapeshifting (for druids, specifically) kept making them lose their tired sfx
- i have added an if has status effect apply status effect so that the created wildshape mob gets tired
- same check for turning back into a human
- tm only for a bit as this may affect werewolves and other things (vampires?) in unforeseen ways
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- made a druid and it seemed to work fine...? i'm a little nervous the effect will somehow dupe but hopefully not.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: wildshaping will no longer remove your tired status
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
