### PR TITLE
(sovl removal) you cant hide under flower beds or bedrolls anymore

### DIFF
--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -414,6 +414,8 @@
 	return ..()
 
 /obj/structure/bed/rogue/proc/hideinside(mob/living/user)
+	if(!hidingspot)
+		return
 	var/sneak_level = user.get_skill_level(/datum/skill/misc/sneaking) || 0
 	var/sneaktime = max(10, 50 - (sneak_level * 10)) // Hard caps at 1 second at Expert and above.
 	if(user.loc == src)
@@ -467,6 +469,7 @@
 	attacked_sound = 'sound/foley/cloth_rip.ogg'
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	sleepy = 2
+	hidingspot = FALSE
 
 /obj/structure/bed/rogue/bedroll/attack_hand(mob/user, params)
 	..()


### PR DESCRIPTION
## About The Pull Request
- hidingspot boolean existed but was unused
- added implementation for beds, preventing eoran flowerbeds from being hidden under
- also slapped it on bedrolls bc there were bugs related 2 them
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- i hid under ab ed
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: you can no longer hide under bedrolls or eoran flowerbeds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
