### PR TITLE
[BugFix/Rebalance] Sanity checks the siegebow

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
@@ -212,7 +212,11 @@
 
 	var/turf/T = target
 	if(isturf(target))
-		explosion(T, heavy_impact_range = 0, light_impact_range = 1, flame_range = 0, smoke = FALSE, soundin = pick('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg'))
+		explosion(T, heavy_impact_range = 0, light_impact_range = 0, flame_range = 0, smoke = FALSE, soundin = pick('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg'))
+		loud_message("A loud crash echoes", hearing_distance = 14)
+		if(istype(T, /turf/closed/mineral/rogue/bedrock))
+			return
+		T.turf_integrity -= 1100
 		return
 
 /obj/item/ammo_casing/caseless/rogue/heavy_bolt/blunt


### PR DESCRIPTION
## About The Pull Request

Alters the siegebow in the following ways.

Before: 
Deleted any walls struck

After: 
Deals 1,100 damage to any wall struck (One shots wood, two shots stone)
Deals 0 damage instead if the wall is bedrock 
Causes a loud sound (fourteen tiles of chat log notice) whenever the siegestake hits a turf, to prevent the weapon from being used to silently break into buildings as the explosion noise it provides is actually a lot quieter than you might think.

Damage might need tweaking!

## Testing Evidence

Shot walls, did damage.
Shot bedrock, did no damage.
Checked the chat log, the message was displayed correctly.

## Why It's Good For The Game

Instantly destroying any wall was definitely not intended.
Preserving the ability for the siege bow to be used to destroy fortifications doesn't kill what appears to have been the intended goal of the weapon, making it an actual siege weapon.

## Changelog

:cl:
balance: Siegebows are now louder and deal significant damage to any terrain they collide with.
fix: Siegebows no longer delete (any) turf on contact.
/:cl:
