### PR TITLE
Adds exact type setting to enchanting kits

### DIFF
--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -9,6 +9,8 @@
 	var/list/target_items = list()
 	/// Result item we'll exchange it to. Currently /weapon/ type kits use this as an example they'll copy all the visual data from. Keep this in mind if this never gets properly refactored!
 	var/result_item = null
+	/// Whether we'll be looking for exact types in target_items. This generally should be TRUE unless the user wants the elixir to be used on subtypes as well.
+	var/exact_type = FALSE
 
 /obj/item/enchantingkit/pre_attack(obj/item/I, mob/user)
 	if(!I || !user)
@@ -20,9 +22,17 @@
 	var/R_type = null
 	if(LAZYLEN(target_items))
 		for(var/T in target_items)
-			if(istype(I, T))
-				R_type = target_items[T]
-				break
+			if(exact_type)
+				if(I.type == T)
+					R_type = target_items[T]
+					break
+			else
+				if(istype(I, T))
+					R_type = target_items[T]
+					break
+
+	if(!R_type && exact_type)
+		return .. ()
 
 	if(!R_type && result_item)
 		R_type = result_item

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -32,7 +32,7 @@
 					break
 
 	if(!R_type && exact_type)
-		return .. ()
+		return ..()
 
 	if(!R_type && result_item)
 		R_type = result_item


### PR DESCRIPTION
## About The Pull Request
Previously enchanting kits used an `istype()` check, which resulted in niche cases of unintended subtypes of items being affected by the elixirs. *Generally* this was 'fine' because it just meant a subtype of a given item (usually an upgrade of some kind) would be turned into a downgraded fluff item, but it theoretically could work the other way, too, so it's best to address it.

This now adds a setting that ensures the exact types in the kit are the ones that will be affected.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Hard to show, but tested.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's good for the devs, the game -- idk lol it's very backend.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
