### PR TITLE
[Fix] Briar curse now does damage to the user instead of the target

### DIFF
--- a/code/datums/magic_items/mythical_items/mythic.dm
+++ b/code/datums/magic_items/mythical_items/mythic.dm
@@ -101,10 +101,10 @@
 	.=..()
 	if(!proximity_flag)
 		return
-	if(isliving(target))
-		var/mob/living/carbon/targeted = target
-		targeted.adjustBruteLoss(10)
-		to_chat(target, span_notice("[source] gouges you with its sharp edges!"))
+	if(isliving(user))
+		var/mob/living/carbon/targeted = user
+		targeted.adjustBruteLoss(5)
+		to_chat(user, span_notice("[source] gouges you with its sharp edges!"))
 
 /datum/magic_item/mythic/rewind
 	name = "Temporal Rewind"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Fixes Briar curse to deal true brute damate to the user instead of the target, on top of adding 10 extra force to regular and wielded. Reduced the true damage dealt to 5 from 10.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="573" height="379" alt="image" src="https://github.com/user-attachments/assets/fd902d34-47d8-448e-ae8b-b6c704eadcda" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

The item said it was cursed, it was not. It is adding the extra damage you get from a crit, AND was doing 10 unsoakable by armor damage that penetrates defenses, now it deals 5 to one self, as I tested even with a cantor and the self 10 brute was brutal.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixes Briar curse to deal true brute damate to the user instead of the target, on top of adding 10 extra force to regular and wielded. Reduced the true damage dealt to 5 from 10.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
