### PR TITLE
Sectarian -> New Lich Skeleton Cleric Class [Semi-Experimental Class] + Minor Tweaks

### DIFF
--- a/code/__DEFINES/highlight_examine_defines.dm
+++ b/code/__DEFINES/highlight_examine_defines.dm
@@ -1,6 +1,7 @@
 // Zizo items
 #define HERESYDESC_ZIZO_WEAPON "A grim weapon of Zizo's champions"
 #define HERESYDESC_ZIZO_ARMOR "An accursed armor piece of Zizo's champions"
+#define HERESYDESC_ZIZO_CLOTHING "An accursed piece of clothing worn by Zizo's champions"
 #define HERESYDESC_ZIZO_RELIC "A relic of Zizo's grim design"
 #define HERESYDESC_ZIZO_ICON "It bears the grim zcross of Zizo"
 #define HERESYDESC_ZIZO_MISC "A known design of Zizo"

--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -348,6 +348,9 @@
 	item_state = "warlockhood"
 	icon_state = "warlockhood"
 
+/obj/item/clothing/head/roguetown/roguehood/unholy/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_ZIZO_MISC) //So Lich/Necro aren't immedately fragged, but the robes are blatently not normal
+
 /obj/item/clothing/head/roguetown/roguehood/unholy/lich
 	name = "ominous hood"
 	desc = "An otherworldly veil, whispering the constant ponderances of a runic enigma. She watches over you; and Her grin is crooked into one of eternal malice."

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -44,6 +44,9 @@
 	icon_state = "warlock"
 	storage = FALSE
 
+/obj/item/clothing/suit/roguetown/shirt/robe/unholy/get_examine_highlight_status()
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_ZIZO_MISC) //So Lich/Necro aren't immedately fragged, but the robes are blatently not normal
+
 /obj/item/clothing/suit/roguetown/shirt/robe/unholy/lich
 	name = "ominous robes"
 	desc = "An otherworldly veil, whispering a hundred paradoxical answers to the ultimate question. Her hand guides your grandest missive; to bring forth progress, no matter the cost."

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -72,6 +72,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
+	material_category = ARMOR_MAT_LEATHER //So it doesn't make plate armor noises taking damage
 	sewrepair = TRUE
 
 /obj/item/clothing/suit/roguetown/shirt/undershirt/black

--- a/code/modules/clothing/rogueclothes/storage/pouch.dm
+++ b/code/modules/clothing/rogueclothes/storage/pouch.dm
@@ -284,6 +284,21 @@
 		if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_INSERT, A, null, TRUE, TRUE))
 			SSwardrobe.recycle_object(A)
 
+/obj/item/storage/belt/rogue/pouch/coins/aalloy/mid
+
+/obj/item/storage/belt/rogue/pouch/coins/aalloy/mid/get_types_to_preload()
+	var/list/to_preload = list() 
+	to_preload += /obj/item/roguecoin/aalloy/pile
+	return to_preload
+
+/obj/item/storage/belt/rogue/pouch/coins/aalloy/mid/PopulateContents()
+	. = ..()
+	for(var/i in 1 to 2) //hilarious
+		var/obj/item/roguecoin/aalloy/pile/A = SSwardrobe.provide_type(/obj/item/roguecoin/aalloy/pile, loc)
+		if(istype(A))
+			if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_INSERT, A, null, TRUE, TRUE))
+				SSwardrobe.recycle_object(A)
+
 /obj/item/storage/belt/rogue/pouch/coins/aalloy/rich
 
 /obj/item/storage/belt/rogue/pouch/coins/aalloy/rich/get_types_to_preload()

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -959,7 +959,7 @@ LICH SKELETONS
 /obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith/lich
 	name = "decrepit forge gauntlets"
 	desc = "A shirt of rugged silks and leather from beyond your lyfetime, donned as a grasp 'pon the one thing that oft' outlasts through aeon the most; \"Artifice, Progress, Construction\"."
-	color = "#d6bbbb"
+	//no color changes, it already looks good
 
 /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/lich
 	name = "decrepit hijab"

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -876,7 +876,7 @@ LICH SKELETONS
 	H.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite) //SPREAD THE... ROT? turn-player-corpses-into-player-zombies spell. No skeleton mitosis please.
 	//Our Utility Spells
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
-	//No bone chill, Zizo miracle heals (50) damage on undead. They do not need it.
+	//No bone chill, Zizo miracle heals all limbs which is strong enough as is + scales to bones. Lesser formations will be making a lot of those.
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_1, start_maxed = TRUE)	//Major acolyte-level regeneration, capped to T1 since Zizo miracles don't work w/ lich's skeleton spam

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -796,6 +796,8 @@ LICH SKELETONS
 //Cleric skeleton, specialises in ranged casting + lesser magic utility use. They're also able to herald the darkness and snuff out lights.
 //They're quite a potent healer but they struggle with light armor and most of their body being covered by /very/ obvious heretical robes.
 //Can parry somewhat okay in melee, but they're too weak to really /hurt/ someone badly via that. Generally though you're going to taken out by mages/archers pretty decently, this is intended.
+
+//Most importantly, unlike other lich skeletons, these ones really stand out amongst the many. You know who to target on-sight pretty much.
 /datum/advclass/greater_skeleton/lich/occultist
 	name = "Ancient Occultist"
 	tutorial = "Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. O' no matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision be reality. In her name."
@@ -856,6 +858,8 @@ LICH SKELETONS
 	id = /obj/item/clothing/neck/roguetown/psicross/inhumen/paalloy //UP THE Z
 	belt = /obj/item/storage/belt/rogue/leather/rope/upgraded
 
+	//Legs are intended to have no armor, this is their weak-spot. Cut them down and smash their ribs in/cut their head off.
+
 	backl = /obj/item/storage/backpack/rogue/satchel/black
 	backr = /obj/item/rogueweapon/woodstaff/quarterstaff/iron //replace w/ gilbranze once ancient ver added (its literally +3 force w/ steel grade staff vs iron anyway)
 
@@ -868,7 +872,7 @@ LICH SKELETONS
 
 	//Our offensive kit
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/unholyblast)
-	H.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite) //SPREAD THE... ROT? yeah this is the turn-people-into-zombies spell. No skeleton mitosis please.
+	H.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite) //SPREAD THE... ROT? turn-people-into-zombies spell. No skeleton mitosis please.
 	//Our Utility Spells
 	H.mind.AddSpell(new /datum/action/cooldown/spell/convert_heretic) //SPREAD THE WORD
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
@@ -891,7 +895,7 @@ LICH SKELETONS
 /////////////////////////////
 // UNIQUE ITEMS!           //
 /////////////////////////////
-/obj/item/clothing/suit/roguetown/armor/vestments_padded/lich //Zizo acolyte esc-robes
+/obj/item/clothing/suit/roguetown/armor/vestments_padded/lich //Zizo acolyte esc-robes, armor is meant to be the same as padded vestaments
 	name = "decrepit unholy undervestaments"
 	desc = "Roughspan fabrics, silks and burlap from beyond your lyfetyme, wrapped and coiled around the waist uncomfortably tight.</br>Its adorned with inverted psycrosses in the stitchwork, a sworn unbreakable promise against the orders that bind this world to stagnation.</br></br>‎<font color='FF0000'>..Just looking at the fabric makes you feel like you're being watched..</font>"
 	icon_state = "monkvestments" //placeholdery as fuck
@@ -901,7 +905,9 @@ LICH SKELETONS
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_armor.dmi'
 
 /obj/item/clothing/suit/roguetown/armor/vestments_padded/lich/get_examine_highlight_status() //Literally worn by oath-sworn enemies to the Ten and Psydon, there's no subtle-part about this.
-	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_ICON)
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_CLOTHING)
+
+//Do not make this craftable, please. Role Specific. ^
 
 /obj/item/clothing/wrists/roguetown/bracers/cloth/lich
 	name = "decrepit padded wrappings"
@@ -913,9 +919,9 @@ LICH SKELETONS
 
 /obj/item/clothing/head/roguetown/roguehood/lichoccultist
 	name = "decrepit unholy hood"
-	desc = "A padded hood of roughspun fabrics, silks and worn leather from beyond your lyfetime, splinted across creating a cocooon to shroud the face. It bares the sigil of the inverted Psycross upon its crest in defiance to the world.</br></br>‎<font color='FF0000'>..Should you stare too long into it, you could almost glimpse something staring back with eternal malice..</font>"
+	desc = "A padded and reinforced hood of roughspun fabrics, silks and worn leather from beyond your lyfetime, splinted across creating a cocooon to shroud the face. It bares the sigil of the inverted Psycross upon its crest in defiance to the world.</br></br>‎<font color='FF0000'>..Should you stare too long into it, you could almost glimpse something staring back with eternal malice..</font>"
 	color = CLOTHING_BLACK
-	max_integrity = ARMOR_INT_HELMET_LEATHER
+	max_integrity = ARMOR_INT_HELMET_HARDLEATHER //to encourage keeping it
 	armor = ARMOR_LEATHER
 	icon_state = "monkhood" //placeholdery as fuck
 	item_state = "monkhood"
@@ -923,24 +929,32 @@ LICH SKELETONS
 	hidesnoutADJ = FALSE
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEFACIALHAIR	//Does not hide face.
 	salvage_result = /obj/item/natural/cloth
-	salvage_amount = 1
+	salvage_amount = 2 //Padded clothing
 
 /obj/item/clothing/head/roguetown/roguehood/lichoccultist/get_examine_highlight_status() //Literally worn by oath-sworn enemies to the Ten and Psydon, there's no subtle-part about this.
-	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_ICON)
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_CLOTHING)
+
+//Do not make this craftable, please. Role Specific. ^
 
 /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket/lich
 	name = "decrepit sapper jacket"
 	desc = "A jacket of rugged leather with some scraps of fur and roughspun fabrics from beyond your lyfetime, donned by those who are condemned to toil forevermore."
 	color = "#d6bbbb"
 
+//Do not make this craftable, please. Role Specific. ^
+
 /obj/item/clothing/under/roguetown/trou/artipants/lich
 	name = "decrepit sapper trousers"
 	desc = "A set of trousers of leathers and roughspun fabric from beyond your lyfetime, donned by those who are condemned to toil forevermore."
+
+//Do not make this craftable, please. Role Specific. ^
 
 /obj/item/clothing/suit/roguetown/shirt/undershirt/artificer/lich
 	name = "decrepit sapper shirt"
 	desc = "A shirt of roughspun fabrics and leather from beyond your lyfetime, donned by those who are condemned to toil forevermore."
 	color = "#d6bbbb"
+
+//Do not make this craftable, please. Role Specific. ^
 
 /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/lich
 	name = "decrepit hijab"

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -875,7 +875,6 @@ LICH SKELETONS
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/unholyblast)
 	H.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite) //SPREAD THE... ROT? turn-people-into-zombies spell. No skeleton mitosis please.
 	//Our Utility Spells
-	H.mind.AddSpell(new /datum/action/cooldown/spell/convert_heretic) //SPREAD THE WORD
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	//No bone chill, Zizo miracle heals (50) damage on undead. They do not need it.
 

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -905,6 +905,7 @@ LICH SKELETONS
 	icon = 'icons/roguetown/clothing/armor.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/armor.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_armor.dmi'
+	resistance_flags = FIRE_PROOF //All you get in exchange for herecy-marked gear
 
 /obj/item/clothing/suit/roguetown/armor/vestments_padded/lich/get_examine_highlight_status() //Literally worn by oath-sworn enemies to the Ten and Psydon, there's no subtle-part about this.
 	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_CLOTHING)
@@ -932,6 +933,7 @@ LICH SKELETONS
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEFACIALHAIR	//Does not hide face.
 	salvage_result = /obj/item/natural/cloth
 	salvage_amount = 2 //Padded clothing
+	resistance_flags = FIRE_PROOF //All you get in exchange for herecy-marked gear
 
 /obj/item/clothing/head/roguetown/roguehood/lichoccultist/get_examine_highlight_status() //Literally worn by oath-sworn enemies to the Ten and Psydon, there's no subtle-part about this.
 	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_CLOTHING)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -800,7 +800,7 @@ LICH SKELETONS
 //Most importantly, unlike other lich skeletons, these ones really stand out amongst the many. You know who to target on-sight pretty much.
 //Yes the name is a bitter irony because Sectarian means a closed-minded us vs them, mindset. Aka limited or bigoted, but this fits the "slaughter the living so they may walk with her" mindset of skeletons
 /datum/advclass/greater_skeleton/lich/sectarian
-	name = "Ancient Sectarian"
+	name = "Ancient Zizite Sectarian"
 	tutorial = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man.' - Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. No matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision become reality."
 	outfit = /datum/outfit/job/roguetown/greater_skeleton/lich/sectarian
 	maximum_possible_slots = 3 //don't want too many healers for skeletons in a round but we want leniency for when they die and get replaced

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -802,7 +802,7 @@ LICH SKELETONS
 	name = "Ancient Occultist"
 	tutorial = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man.' - Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. No matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision become reality."
 	outfit = /datum/outfit/job/roguetown/greater_skeleton/lich/occultist
-	maximum_possible_slots = 3 //don't want too many healers in a round but we want leniency for when they die and get replaced
+	maximum_possible_slots = 3 //don't want too many healers for skeletons in a round but we want leniency for when they die and get replaced
 
 	category_tags = list(CTAG_LSKELETON)
 
@@ -829,13 +829,13 @@ LICH SKELETONS
 
 	H.adjust_skillrank(/datum/skill/combat/staves, 4, TRUE) //Intended choice of parrying off blows, won't last amazingly long though
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE) //Your worship is not peaceful
+	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE) //Clergy can read, you sort of fill that niché
+	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/magic/holy, 4, TRUE)
 
-	//You're a true devout, a disiple, here's your sovl patron boons
+	//You're a true devout, a disiple, here's your "sovl" patron boons (basically you /have/ artifice potental)
 	H.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/smelting, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/engineering, 2, TRUE)
@@ -858,14 +858,14 @@ LICH SKELETONS
 	id = /obj/item/clothing/neck/roguetown/psicross/inhumen/paalloy //UP THE Z
 	belt = /obj/item/storage/belt/rogue/leather/rope/upgraded/dark
 
-	//Legs are intended to have no armor, this is their weak-spot. Cut them down and smash their ribs in/cut their head off.
+	//Legs are intended to have no armor once the undervestaments go, this is their weak-spot. Cut them down and smash their ribs in/cut their head off/burn them to death.
 
 	backl = /obj/item/storage/backpack/rogue/satchel/black
 	backr = /obj/item/rogueweapon/woodstaff/quarterstaff/iron //replace w/ gilbranze once ancient ver added (its literally +3 force w/ steel grade staff vs iron anyway)
 
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1, //Hilarious
-		/obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy = 3 //SPREAD HER INFLUENCE. ZIZO. ZIZO. ZIZO.
+		/obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy = 4 //SPREAD HER INFLUENCE. ZIZO. ZIZO. ZIZO. (or just wear them all to aurafarm on the Psydonites, IDK)
 	)
 
 	H.adjust_blindness(-3)
@@ -876,6 +876,7 @@ LICH SKELETONS
 	//Our Utility Spells
 	H.mind.AddSpell(new /datum/action/cooldown/spell/convert_heretic) //SPREAD THE WORD
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
+	//No bone chill, Zizo miracle heals (50) damage on undead. They do not need it.
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_1, start_maxed = TRUE)	//Major acolyte-level regeneration, capped to T1 since Zizo miracles don't work w/ lich's skeleton spam

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -858,8 +858,9 @@ LICH SKELETONS
 	gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted/lich //Second weak spot, hands.
 	id = /obj/item/clothing/neck/roguetown/psicross/inhumen/paalloy //UP THE Z
 	belt = /obj/item/storage/belt/rogue/leather/rope/upgraded/dark
+	pants = /obj/item/clothing/under/roguetown/trou/leather/mourning
 
-	//Legs are intended to have no armor once the undervestaments go, this is their weak-spot. Cut them down and smash their ribs in/cut their head off/burn them to death.
+	//Legs are intended to have have weaker armor, this is their weak-spot. Cut them down and smash their ribs in/cut their head off/burn them to death.
 
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff/quarterstaff/iron //replace w/ gilbranze once ancient ver added (its literally +3 force w/ steel grade staff vs iron anyway)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -880,9 +880,6 @@ LICH SKELETONS
 
 	H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/bloodmiracle) //We don't have blood, QOL since we can't use this.
 
-	// Hack for re-ordering
-	H.mind.RemoveSpell(/obj/effect/proc_holder/spell/self/suicidebomb/lesser)
-	H.mind.AddSpell(/obj/effect/proc_holder/spell/self/suicidebomb/lesser)
 	// Reorder undead eyes action to the end
 	var/obj/item/organ/eyes/existing_eyes = H.getorganslot(ORGAN_SLOT_EYES)
 	if(existing_eyes)
@@ -922,6 +919,9 @@ LICH SKELETONS
 	armor = ARMOR_LEATHER
 	icon_state = "monkhood" //placeholdery as fuck
 	item_state = "monkhood"
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
+	hidesnoutADJ = FALSE
+	flags_inv = HIDEEARS|HIDEHAIR|HIDEFACIALHAIR	//Does not hide face.
 	salvage_result = /obj/item/natural/cloth
 	salvage_amount = 1
 

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -834,7 +834,7 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/magic/holy, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/magic/holy, 3, TRUE)
 
 	//You're a true devout, a disiple, here's your "sovl" patron boons (basically you /have/ artifice potental)
 	H.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -12,7 +12,6 @@ LICH SKELETONS
 	vice_restrictions = list(/datum/charflaw/hunted, /datum/charflaw/targeted, /datum/charflaw/wanted)
 
 /datum/outfit/job/roguetown/greater_skeleton/lich
-	belt = /obj/item/storage/belt/rogue/leather/black
 
 /datum/outfit/job/roguetown/greater_skeleton/lich/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -50,6 +49,7 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 
+	//Utility skills, unlyve to serve
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/masonry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
@@ -63,6 +63,7 @@ LICH SKELETONS
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
+	belt = /obj/item/storage/belt/rogue/leather/black
 
 	backl = /obj/item/storage/backpack/rogue/satchel
 
@@ -153,6 +154,7 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 
+	//Utility skills, unlyve to serve
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/masonry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
@@ -167,6 +169,8 @@ LICH SKELETONS
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
 	gloves = /obj/item/clothing/gloves/roguetown/angle
+	belt = /obj/item/storage/belt/rogue/leather/black
+
 	backl = /obj/item/storage/backpack/rogue/satchel
 
 	backpack_contents = list(
@@ -250,6 +254,7 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 
+	//Utility skills, unlyve to serve
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/masonry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
@@ -262,6 +267,8 @@ LICH SKELETONS
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
+	belt = /obj/item/storage/belt/rogue/leather/black
+
 	backl = /obj/item/storage/backpack/rogue/satchel
 
 	backpack_contents = list(
@@ -375,6 +382,7 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 
+	//Utility skills, unlyve to serve (more than everyone else)
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE) //Just give them a little extra for utility.
 	H.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE) //For making traps mostly, since they need it for crafting amythortz, remove if the recipes change.
 	H.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE) //For the alchemy mortar + pestle for explosives, remove once the recipe changes.
@@ -399,6 +407,8 @@ LICH SKELETONS
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
+	belt = /obj/item/storage/belt/rogue/leather //regular looks nicer
+
 	backl = /obj/item/storage/backpack/rogue/backpack
 	backpack_contents = list(
 		/obj/item/rogueweapon/hammer/paalloy = 1,
@@ -463,6 +473,8 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+
+	//Utility skills, unlyve to serve
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/masonry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
@@ -476,6 +488,8 @@ LICH SKELETONS
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
+	belt = /obj/item/storage/belt/rogue/leather/black
+
 	backl = /obj/item/storage/backpack/rogue/satchel
 
 	l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/heavy/paalloy
@@ -543,6 +557,7 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/misc/athletics, 5, TRUE)
 	//Again, their flaw is inability to escape, no climbing here.
 
+	//Utility skills, unlyve to serve
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/masonry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
@@ -557,6 +572,8 @@ LICH SKELETONS
 	gloves = /obj/item/clothing/gloves/roguetown/plate/paalloy
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/paalloy
+	belt = /obj/item/storage/belt/rogue/leather/black
+
 	backl = /obj/item/storage/backpack/rogue/satchel/black
 
 	backpack_contents = list(
@@ -635,6 +652,7 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/magic/arcane, 3, TRUE) //A true Azurcaephan, they know their stuff.
 
+	//Utility skills, unlyve to serve
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/masonry, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
@@ -650,6 +668,8 @@ LICH SKELETONS
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 	backr = /obj/item/rogueweapon/shield/bronze/paalloy
+	belt = /obj/item/storage/belt/rogue/leather/black
+
 	backl = /obj/item/storage/backpack/rogue/satchel
 
 	backpack_contents = list(
@@ -773,9 +793,141 @@ LICH SKELETONS
 
 	H.energy = H.max_energy
 
+//Cleric skeleton, specialises in ranged casting + lesser magic utility use. They're also able to herald the darkness and snuff out lights.
+//They're quite a potent healer but they struggle with light armor and most of their body being covered by /very/ obvious heretical robes.
+//Can parry somewhat okay in melee, but they're too weak to really /hurt/ someone badly via that. Generally though you're going to taken out by mages/archers pretty decently, this is intended.
+/datum/advclass/greater_skeleton/lich/occultist
+	name = "Ancient Occultist"
+	tutorial = "Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. O' no matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision be reality. In her name."
+	outfit = /datum/outfit/job/roguetown/greater_skeleton/lich/occultist
+	maximum_possible_slots = 3 //don't want too many healers in a round but we want leniency for when they die and get replaced
+
+	category_tags = list(CTAG_LSKELETON)
+
+/datum/outfit/job/roguetown/greater_skeleton/lich/occultist/pre_equip(mob/living/carbon/human/H)
+	..()
+
+	H.STASTR = 8
+	H.STASPD = 8
+	H.STACON = 7 //Flimsy vs others, not as non-combat as a sapper though
+	H.STAWIL = 11
+	H.STAINT = 12 //acolyte-esc role, smarter than most skeletons
+	H.STAPER = 10
+
+	//No medium armor because avantyne half-plate exists and we do not want heretic ++
+
+	ADD_TRAIT(H, TRAIT_ARCYNE, TRAIT_GENERIC) //"we have rituos at home"
+	ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC) //Sovl Bonus from heretic
+	ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC) //Flavor, nothing to do w/ zurch, it solely prevents heretics converting them + worse spire if you somehow get an abyssal dream shard (unstable one you throw)
+
+	H.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 4))
+	//Your "rituos", notably weaker than adv missionary as your tradeoff is being actually undead and untirable + puglist build even if journeyman. Your minor aspect is a cantrip more than anything.
+	//No free ward, never. period. Do not, I will find you. They will spend their singular minor aspect if they want one.
+
+
+	H.adjust_skillrank(/datum/skill/combat/staves, 4, TRUE) //Intended choice of parrying off blows, won't last amazingly long though
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE) //Your worship is not peaceful
+	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE) //Clergy can read, you sort of fill that niché
+	H.adjust_skillrank(/datum/skill/magic/holy, 4, TRUE)
+
+	//You're a true devout, a disiple, here's your sovl patron boons
+	H.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/smelting, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/engineering, 2, TRUE)
+
+	//Utility skills, unlyve to serve
+	H.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/masonry, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/sewing, 2, TRUE)
+
+	head = /obj/item/clothing/head/roguetown/roguehood/lichoccultist
+	mask = /obj/item/clothing/mask/rogue/facemask/steel/paalloy //Face protection
+	shirt = /obj/item/clothing/suit/roguetown/armor/vestments_padded/lich //Extra obvious herecy + better goes with the fit
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+	cloak = /obj/item/clothing/cloak/tabard/toga/lich //Goes with the fit, so you get no choice of picks
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/cloth/lich
+	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
+	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
+	gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted/lich
+	id = /obj/item/clothing/neck/roguetown/psicross/inhumen/paalloy //UP THE Z
+	belt = /obj/item/storage/belt/rogue/leather/rope/upgraded
+
+	backl = /obj/item/storage/backpack/rogue/satchel/black
+	backr = /obj/item/rogueweapon/woodstaff/quarterstaff/iron //replace w/ gilbranze once ancient ver added (its literally +3 force w/ steel grade staff vs iron anyway)
+
+	backpack_contents = list(
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1, //Hilarious
+		/obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy = 3 //SPREAD HER INFLUENCE. ZIZO. ZIZO. ZIZO.
+	)
+
+	H.adjust_blindness(-3)
+
+	//Our offensive kit
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/unholyblast)
+	H.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite) //SPREAD THE... ROT? yeah this is the turn-people-into-zombies spell. No skeleton mitosis please.
+	//Our Utility Spells
+	H.mind.AddSpell(new /datum/action/cooldown/spell/convert_heretic) //SPREAD THE WORD
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
+
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_1, start_maxed = TRUE)	//Major acolyte-level regeneration, capped to T1 since Zizo miracles don't work w/ lich's skeleton spam
+	//up this if the miracle set is less about summonspam and knockdowns in future, please. They're meant to be a templar level caster vs heretic wretch.
+	//Starts w/1000 devotion, capped out. Cooldowns still balance this out. On-par w/zeretic spellblade devotion wise + ability (Outside of light snuff).
+
+	H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/bloodmiracle) //We don't have blood, QOL since we can't use this.
+
+	// Hack for re-ordering
+	H.mind.RemoveSpell(/obj/effect/proc_holder/spell/self/suicidebomb/lesser)
+	H.mind.AddSpell(/obj/effect/proc_holder/spell/self/suicidebomb/lesser)
+	// Reorder undead eyes action to the end
+	var/obj/item/organ/eyes/existing_eyes = H.getorganslot(ORGAN_SLOT_EYES)
+	if(existing_eyes)
+		existing_eyes.Remove(H, TRUE)
+		existing_eyes.Insert(H)
+
+	H.energy = H.max_energy
+
 /////////////////////////////
 // UNIQUE ITEMS!           //
 /////////////////////////////
+/obj/item/clothing/suit/roguetown/armor/vestments_padded/lich //Zizo acolyte esc-robes
+	name = "decrepit unholy undervestaments"
+	desc = "Roughspan fabrics, silks and burlap from beyond your lyfetyme, wrapped and coiled around the waist uncomfortably tight.</br>Its adorned with inverted psycrosses in the stitchwork, a sworn unbreakable promise against the orders that bind this world to stagnation.</br></br>‎<font color='FF0000'>..Just looking at the fabric makes you feel like you're being watched..</font>"
+	icon_state = "monkvestments" //placeholdery as fuck
+	item_state = "monkvestments"
+	icon = 'icons/roguetown/clothing/armor.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/armor.dmi'
+	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_armor.dmi'
+
+/obj/item/clothing/suit/roguetown/armor/vestments_padded/lich/get_examine_highlight_status() //Literally worn by oath-sworn enemies to the Ten and Psydon, there's no subtle-part about this.
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_ICON)
+
+/obj/item/clothing/wrists/roguetown/bracers/cloth/lich
+	name = "decrepit padded wrappings"
+	desc = "Roughspan fabrics and burlap from beyond your lyfetyme, wrapped and coiled around the wrists by those who have embraced what they've truly become."
+	color = "#5c5a55"
+
+/obj/item/clothing/gloves/roguetown/bandages/weighted/lich
+	color = "#5c5a55"
+
+/obj/item/clothing/head/roguetown/roguehood/lichoccultist
+	name = "decrepit unholy hood"
+	desc = "A padded hood of roughspun fabrics, silks and worn leather from beyond your lyfetime, splinted across creating a cocooon to shroud the face. It bares the sigil of the inverted Psycross upon its crest in defiance to the world.</br></br>‎<font color='FF0000'>..Should you stare too long into it, you could almost glimpse something staring back with eternal malice..</font>"
+	color = CLOTHING_BLACK
+	max_integrity = ARMOR_INT_HELMET_LEATHER
+	armor = ARMOR_LEATHER
+	icon_state = "monkhood" //placeholdery as fuck
+	item_state = "monkhood"
+	salvage_result = /obj/item/natural/cloth
+	salvage_amount = 1
+
+/obj/item/clothing/head/roguetown/roguehood/lichoccultist/get_examine_highlight_status() //Literally worn by oath-sworn enemies to the Ten and Psydon, there's no subtle-part about this.
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_ICON)
+
 /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket/lich
 	name = "decrepit sapper jacket"
 	desc = "A jacket of rugged leather with some scraps of fur and roughspun fabrics from beyond your lyfetime, donned by those who are condemned to toil forevermore."

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -524,7 +524,7 @@ LICH SKELETONS
 
 	H.energy = H.max_energy
 
-//Stronger sidegrade of the Bulwark. Fully armored juggetnaut with high Intelligence and Perception for baiting and riposting, but extremely low Speed and complete inability to sprint at all. Crack open the armor, overwhelm and they're dead meat.
+//Stronger sidegrade of the Bulwark. Fully armored juggetnaut with high Intelligence, Strength and Perception for overwhelming, fienting and resisting fients, but extremely low Speed and complete inability to sprint at all. Crack open the armor, overwhelm and they're dead meat.
 //They lack the easily ability to escape fights including no climbing skill, they're tough and will tire you very fast. They have good armor off-the-bat. They're sturdy and difficult to tire but archers/mages/swarms of people will hardcounter them in open ground.
 /datum/advclass/greater_skeleton/lich/bulwarkrare
 	name = "Venerated Death Knight"
@@ -606,7 +606,7 @@ LICH SKELETONS
 			cloak = /obj/item/clothing/cloak/tabard/toga/lich
 
 	if(H.mind) //2 slot, irreplacable skeletons.
-		H.mind.AddSpell(new /datum/action/cooldown/spell/mending) //Gets replaced w/weaker version w/rituos armor, balances out.
+		H.mind.AddSpell(new /datum/action/cooldown/spell/mending) //Gets replaced w/weaker version w/ritual armor. it balances out.
 		H.mind.AddSpell(new /datum/action/cooldown/spell/bonemend)
 
 	H.energy = H.max_energy
@@ -798,7 +798,7 @@ LICH SKELETONS
 //Can parry somewhat okay in melee, but they're too weak to really /hurt/ someone badly via that. Generally though you're going to taken out by mages/archers pretty decently, this is intended.
 
 //Most importantly, unlike other lich skeletons, these ones really stand out amongst the many. You know who to target on-sight pretty much.
-//Yes the name is a bitter irony because Sectarian means a closed-minded us vs them, mindset. Aka limited or bigoted, but this fits the "slaughter the living so they may walk with her" mindset of skeletons
+//Yes the name is a bitter irony because Sectarian means a closed-minded us vs them, mindset. Aka limited or bigoted, but this fits the "slaughter the living so they may walk with her" mindset of skeletons.
 /datum/advclass/greater_skeleton/lich/sectarian
 	name = "Ancient Zizite Sectarian"
 	tutorial = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man.' - Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. No matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision become reality."
@@ -821,7 +821,7 @@ LICH SKELETONS
 
 	ADD_TRAIT(H, TRAIT_ARCYNE, TRAIT_GENERIC) //"we have rituos at home"
 	ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC) //Sovl Bonus from heretic
-	ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC) //Flavor, nothing to do w/ zurch, it solely prevents heretics converting them + worse spire if you somehow get an abyssal dream shard (unstable one you throw)
+	ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC) //Flavor, nothing to do w/ zurch, it solely means worse spire if you somehow get an abyssal dream shard (unstable one you throw)
 
 	H.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 4))
 	//Your "rituos", notably weaker than adv missionary as your tradeoff is being actually undead and untirable. Your minor aspect is a cantrip more than anything.
@@ -847,7 +847,7 @@ LICH SKELETONS
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/sewing, 2, TRUE)
 
-	head = /obj/item/clothing/head/roguetown/roguehood/lichoccultist
+	head = /obj/item/clothing/head/roguetown/roguehood/lich_sectarian
 	mask = /obj/item/clothing/mask/rogue/facemask/steel/paalloy //Face protection
 	shirt = /obj/item/clothing/suit/roguetown/armor/vestments_padded/lich //Extra obvious herecy + better goes with the fit
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
@@ -880,7 +880,7 @@ LICH SKELETONS
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_1, start_maxed = TRUE)	//Major acolyte-level regeneration, capped to T1 since Zizo miracles don't work w/ lich's skeleton spam
-	//up this if the miracle set is less about summonspam and knockdowns in future, please. They're meant to be a templar level caster vs heretic wretch.
+	//up this if the miracle set is less about summonspam and knockdowns in future, please. They're meant to be a templar level caster vs heretic wretch. So T2 casters. No revival miracles.
 	//Starts w/1000 devotion, capped out. Cooldowns still balance this out. On-par w/zeretic spellblade devotion wise + ability (Outside of light snuff).
 
 	H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/bloodmiracle) //We don't have blood, QOL since we can't use this.
@@ -919,7 +919,7 @@ LICH SKELETONS
 /obj/item/clothing/gloves/roguetown/bandages/weighted/lich
 	color = "#5c5a55"
 
-/obj/item/clothing/head/roguetown/roguehood/lichoccultist
+/obj/item/clothing/head/roguetown/roguehood/lich_sectarian
 	name = "decrepit unholy hood"
 	desc = "A padded and reinforced hood of roughspun fabrics, silks and worn leather from beyond your lyfetime, splinted across creating a cocooon to shroud the face. It bares the sigil of the inverted Psycross upon its crest in defiance to the world.</br></br>‎<font color='FF0000'>..Should you stare too long into it, you could almost glimpse something staring back with eternal malice..</font>"
 	color = CLOTHING_BLACK

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -802,7 +802,7 @@ LICH SKELETONS
 /datum/advclass/greater_skeleton/lich/sectarian
 	name = "Ancient Sectarian"
 	tutorial = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man.' - Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. No matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision become reality."
-	outfit = /datum/outfit/job/roguetown/greater_skeleton/lich/occultist
+	outfit = /datum/outfit/job/roguetown/greater_skeleton/lich/sectarian
 	maximum_possible_slots = 3 //don't want too many healers for skeletons in a round but we want leniency for when they die and get replaced
 
 	category_tags = list(CTAG_LSKELETON)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -798,6 +798,7 @@ LICH SKELETONS
 //Can parry somewhat okay in melee, but they're too weak to really /hurt/ someone badly via that. Generally though you're going to taken out by mages/archers pretty decently, this is intended.
 
 //Most importantly, unlike other lich skeletons, these ones really stand out amongst the many. You know who to target on-sight pretty much.
+//Yes the name is a bitter irony because Sectarian means a closed-minded us vs them, mindset. Aka limited or bigoted, but this fits the "slaughter the living so they may walk with her" mindset of skeletons
 /datum/advclass/greater_skeleton/lich/sectarian
 	name = "Ancient Sectarian"
 	tutorial = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man.' - Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. No matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision become reality."

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -497,7 +497,7 @@ LICH SKELETONS
 
 	backpack_contents = list(
 		/obj/item/natural/cloth = 1, //For your helm
-		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1 //Hilarious
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy/mid = 1 //Hilarious
 	)
 
 	H.adjust_blindness(-3)
@@ -855,17 +855,17 @@ LICH SKELETONS
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/cloth/lich
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
-	gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted/lich
+	gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted/lich //Second weak spot, hands.
 	id = /obj/item/clothing/neck/roguetown/psicross/inhumen/paalloy //UP THE Z
 	belt = /obj/item/storage/belt/rogue/leather/rope/upgraded/dark
 
 	//Legs are intended to have no armor once the undervestaments go, this is their weak-spot. Cut them down and smash their ribs in/cut their head off/burn them to death.
 
-	backl = /obj/item/storage/backpack/rogue/satchel/black
+	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff/quarterstaff/iron //replace w/ gilbranze once ancient ver added (its literally +3 force w/ steel grade staff vs iron anyway)
 
 	backpack_contents = list(
-		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1, //Hilarious
+		/obj/item/storage/belt/rogue/pouch/coins/aalloy/mid = 1, //Hilarious
 		/obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy = 4 //SPREAD HER INFLUENCE. ZIZO. ZIZO. ZIZO. (or just wear them all to aurafarm on the Psydonites, IDK)
 	)
 
@@ -873,7 +873,7 @@ LICH SKELETONS
 
 	//Our offensive kit
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/unholyblast)
-	H.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite) //SPREAD THE... ROT? turn-people-into-zombies spell. No skeleton mitosis please.
+	H.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite) //SPREAD THE... ROT? turn-player-corpses-into-player-zombies spell. No skeleton mitosis please.
 	//Our Utility Spells
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	//No bone chill, Zizo miracle heals (50) damage on undead. They do not need it.
@@ -885,7 +885,7 @@ LICH SKELETONS
 
 	H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/bloodmiracle) //We don't have blood, QOL since we can't use this.
 
-	// Reorder undead eyes action to the end
+	// Reorder undead eyes action to the end, hacky but makes it easier to focus.
 	var/obj/item/organ/eyes/existing_eyes = H.getorganslot(ORGAN_SLOT_EYES)
 	if(existing_eyes)
 		existing_eyes.Remove(H, TRUE)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -798,15 +798,15 @@ LICH SKELETONS
 //Can parry somewhat okay in melee, but they're too weak to really /hurt/ someone badly via that. Generally though you're going to taken out by mages/archers pretty decently, this is intended.
 
 //Most importantly, unlike other lich skeletons, these ones really stand out amongst the many. You know who to target on-sight pretty much.
-/datum/advclass/greater_skeleton/lich/occultist
-	name = "Ancient Occultist"
+/datum/advclass/greater_skeleton/lich/sectarian
+	name = "Ancient Sectarian"
 	tutorial = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man.' - Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. No matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision become reality."
 	outfit = /datum/outfit/job/roguetown/greater_skeleton/lich/occultist
 	maximum_possible_slots = 3 //don't want too many healers for skeletons in a round but we want leniency for when they die and get replaced
 
 	category_tags = list(CTAG_LSKELETON)
 
-/datum/outfit/job/roguetown/greater_skeleton/lich/occultist/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/greater_skeleton/lich/sectarian/pre_equip(mob/living/carbon/human/H)
 	..()
 
 	H.STASTR = 8

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -404,7 +404,7 @@ LICH SKELETONS
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/artificer/lich
 	pants = /obj/item/clothing/under/roguetown/trou/artipants/lich
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket/lich
-	gloves = /obj/item/clothing/gloves/roguetown/angle
+	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith/lich
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	belt = /obj/item/storage/belt/rogue/leather //regular looks nicer
@@ -800,7 +800,7 @@ LICH SKELETONS
 //Most importantly, unlike other lich skeletons, these ones really stand out amongst the many. You know who to target on-sight pretty much.
 /datum/advclass/greater_skeleton/lich/occultist
 	name = "Ancient Occultist"
-	tutorial = "Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. O' no matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision be reality. In her name."
+	tutorial = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man.' - Amongst the many fallen, few not only take their place not only in reverence but through faith and channeling divinity. No matter how far you've fallen, your faith will be that which shall peirce the heavens - Let Progress be your chariot, let her will be your guide and let your master's vision become reality."
 	outfit = /datum/outfit/job/roguetown/greater_skeleton/lich/occultist
 	maximum_possible_slots = 3 //don't want too many healers in a round but we want leniency for when they die and get replaced
 
@@ -856,7 +856,7 @@ LICH SKELETONS
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted/lich
 	id = /obj/item/clothing/neck/roguetown/psicross/inhumen/paalloy //UP THE Z
-	belt = /obj/item/storage/belt/rogue/leather/rope/upgraded
+	belt = /obj/item/storage/belt/rogue/leather/rope/upgraded/dark
 
 	//Legs are intended to have no armor, this is their weak-spot. Cut them down and smash their ribs in/cut their head off.
 
@@ -955,6 +955,11 @@ LICH SKELETONS
 	color = "#d6bbbb"
 
 //Do not make this craftable, please. Role Specific. ^
+
+/obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith/lich
+	name = "decrepit forge gauntlets"
+	desc = "A shirt of rugged silks and leather from beyond your lyfetime, donned as a grasp 'pon the one thing that oft' outlasts through aeon the most; \"Artifice, Progress, Construction\"."
+	color = "#d6bbbb"
 
 /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/lich
 	name = "decrepit hijab"

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -934,7 +934,7 @@ LICH SKELETONS
 	salvage_amount = 2 //Padded clothing
 	resistance_flags = FIRE_PROOF //All you get in exchange for herecy-marked gear
 
-/obj/item/clothing/head/roguetown/roguehood/lichoccultist/get_examine_highlight_status() //Literally worn by oath-sworn enemies to the Ten and Psydon, there's no subtle-part about this.
+/obj/item/clothing/head/roguetown/roguehood/lich_sectarian/get_examine_highlight_status() //Literally worn by oath-sworn enemies to the Ten and Psydon, there's no subtle-part about this.
 	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_CLOTHING)
 
 //Do not make this craftable, please. Role Specific. ^

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -824,7 +824,7 @@ LICH SKELETONS
 	ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC) //Flavor, nothing to do w/ zurch, it solely prevents heretics converting them + worse spire if you somehow get an abyssal dream shard (unstable one you throw)
 
 	H.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 4))
-	//Your "rituos", notably weaker than adv missionary as your tradeoff is being actually undead and untirable + puglist build even if journeyman. Your minor aspect is a cantrip more than anything.
+	//Your "rituos", notably weaker than adv missionary as your tradeoff is being actually undead and untirable. Your minor aspect is a cantrip more than anything.
 	//No free ward, never. period. Do not, I will find you. They will spend their singular minor aspect if they want one.
 
 


### PR DESCRIPTION
## About The Pull Request

`Forenote: This class is more of an experiment upon how we could balance clerics into the Zizo lich legion, it might be undertuned heavily or maybe slightly overtuned. Worst case we can start w/halving the bonus cap for miracles if the caster is a skeleton but we'll see.`

---

This PR adds "Sectarians" (a rigid, narrow minded fanatical attachment to a group/closed minded group w/ a us vs them mindset, by definition.)

It could also just mean aherent but either way it fits well.

*Yes, an intended bitter irony of definition, war without reason to slaughter and remake the living into undead and slay those whom remain ignorant isn't always as enlightened as it seems.* Who knew! oh well, `ZIZO. ZIZO. ZIZO.`

---

This unique class has `[3]` slots

Think of it as a mixed lite-mage/lite acolyte monk class w/ light armor because that's basically what it is. No dodge expert, no unarmed. Just raw supporting power + aura.

<img width="128" height="142" alt="occultist drip" src="https://github.com/user-attachments/assets/98ead407-4de5-4b8f-ae1a-8b899efbcf8b" />

[`yes it currently re-uses the monk vestament sprites (these robes don't grant the same boons, they're just padded undervestments) and hood sprite but blackened from naledian mercs but the drip is immaculate`]

[`Uniquely, your herecy-marked clothing is fireproof so you've that luxury at least that fire won't destroy your gear`]

Your specialisation is mostly in parrying with a staff, skill wise you have *a unique* access to artificing as a "patron bonus" w/ smelting + engineering but otherwise your skill line is basically similar to adv missionary outside of a few extras + utility skills of skeletons.

Your divine blast is really your only *safe* offensive move, often. Which is intended.
<img width="335" height="402" alt="skills" src="https://github.com/user-attachments/assets/e308aeee-3386-4329-94b9-a454a421ebf0" />

*Miracles have been downtuned to* `Expert` -> `Journeyman` *so that's the only inaccuracy here.*

---

Your statline lingers towards int w/ lower con + str in enchange for divine blast + `(1)` minor spell aspect as a cantrip. Utility wise you still have `(4)` points similar to rituos users. You are locked to using lighter armor that's very obviously heretical on-sight as well.

The hood itself is actually really good armor, the undervestments are just herecy marked but its all you get to cover your legs off-the-bat and likely most of the round too.

<img width="156" height="190" alt="statline" src="https://github.com/user-attachments/assets/8a5c4c76-9ff8-4a67-971e-f41165579a89" />

<img width="692" height="341" alt="zociety robes" src="https://github.com/user-attachments/assets/39e4cab5-5b1c-4d68-a491-f75ade96c4f6" />

*note these robes have a different alarming suspicion reasoning since, this screenshot is semi-old.*


Your devotion limit is `1000` and you have `major` regeneration akin to acolytes, however just like zeretic spellblade you are capped to `teir 1 miracles`, you also don't get bloodheal (you have no blood to give anyway). They get diagnosis and raise deadite but you do not get bone chill (`Zizo lesser miracle already heals 50 damage on undead`).

---

Compared to most lich skeletons, your legs are only protected by your shirt slot so once that goes, your legs are very easily taken out. This is intended.


---
`Other misc changes`
- Sappers use forge gloves, these ones have unique flavor vs blacksmithing ones and are flavored as decrepit. It looks nicer.
- Sappers recieve a leather belt vs other skeletons using the same black leather belt.
- All ominious robes are marked as *suspicious* herecy, a known design of Zizo. A necromancer/lich won't always be on-sight (Unless people see the face or the fit lines up too much) but your armored robes will definitely suspicious enough to warrent the inquisition/clergy getting involved, or maybe the garrison at worst.
- Padded Undervestments no longer make plate noises when hit.
- Mid level ancient alloy coin pouches, lich ballistarries as well as this class get them. It has 2 piles of ancient coin vs 3 of the richer pouch. Because this gag of lich skeletons being actually well paid will never stop being funny.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="693" height="360" alt="gearexamine" src="https://github.com/user-attachments/assets/acd500ff-d1f7-48f7-9351-19a9b3d1ec89" />

The rest is above sire.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

A semi support-cleric class dedicated to the weaker miracles of Zizo to help lich skeletons last just a little bit longer.

Lich is usually pre-occupied in fighting themselves to keep their skeletons afloat and with the addition of `trait_shatter_kill` lich skeletons tend to die far easier than intended, especally when blunt builds get involved and shatter their armor and ribs in a few hits which cripples them. Other skeles will at least be able to get back on their feet with these in the backlines.

This class shouldn't be too overbaring as they're a lot weaker than both missionary/proper spellcaster alike, they can't summon undead either so there won't be too much skeleton spam. Their melee is semi-toned down, the most they can do is fient you and run back into their lines and hope other skeletons can take care of you.

Their robes are pretty decently weak, anyone aiming for the legs will drop you and make you helpless pretty quickly.

---

[3] slots should keep them from being overbaring.

They're also intentionally pretty neutered in melee, their expert skill is meant to be so that you get a window to slip into the backlines if someone rushes you down since you're pretty limited and weak otherwise.

*Not to say you can't frontline, its just a terrible idea to try.*

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added new lich skeleton cleric class, "Sectarian". It has 3 slots and is a mixed lesser-mage/missionary-esc weaker cleric hybrid, designed to heal and support other skeletons.
add: Added a new heretical examine for obvious zizite clothing, currently used for Sectarian attire.
add: Adjusted style for lich skeleton sappers
balance: lich/necromancy/unholy robes are marked as suspicious designs of Zizo. These are only suspicious to give you more RP leeway vs fragging gear like plate armor you have to go out of your own way to get.
balance: lich ballistarries gets a mid-level pouch of ancient coin. Not... anyone would accept that as coinage, right?
fix: padded undervestments no longer make plate armor noises.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
