### PR TITLE
Fix Revealing Light, Adds a new T1 enchantment, Fair Seeming

### DIFF
--- a/code/datums/magic_items/magic_item.dm
+++ b/code/datums/magic_items/magic_item.dm
@@ -18,6 +18,7 @@
 	RegisterSignal(i, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 	RegisterSignal(i, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_use))
 	RegisterSignal(i, COMSIG_ITEM_HIT_RESPONSE, PROC_REF(on_hit_response))
+	RegisterSignal(i, COMSIG_ATOM_ATTACK_RIGHT, PROC_REF(attack_right))
 	// If the item is already on a mob, fire on_equip immediately so stat effects apply without re-equip
 	if(isliving(i.loc))
 		var/mob/living/user = i.loc
@@ -49,3 +50,5 @@
 /datum/magic_item/proc/projectile_hit(atom/fired_from, atom/movable/firer, atom/target, Angle)	//effects when shooting a protectile from an enchanted item
 
 /datum/magic_item/proc/on_hit_response(var/obj/item/I, var/mob/living/carbon/human/owner, var/mob/living/carbon/human/attacker)//use for worn items such as armor to have effects on hit.
+
+/datum/magic_item/proc/attack_right(var/obj/item/i, var/mob/living/user) // Use for when you right click on an item (like shimmering lens)

--- a/code/datums/magic_items/mundane_items/mundane.dm
+++ b/code/datums/magic_items/mundane_items/mundane.dm
@@ -48,8 +48,6 @@
 		user.change_stat(STATKEY_WIL, -1)
 		to_chat(user, span_notice("I feel mundane once more"))
 
-
-
 /datum/magic_item/mundane/xylix
 	name = "Xylix's boon"
 	description = "It almost seems to give off the faint sound of laughter."
@@ -96,6 +94,20 @@
 		to_chat(user, span_notice("I grip [i] lightly, and the light fades away"))
 		i.set_light_on(FALSE)
 		i.update_icon()
+	. = ..()
+
+/datum/magic_item/mundane/fairseeming
+	name = "fair seeming"
+	description = "It never seems to gather dirt. (Right click on it to activate the cleaning effect.)"
+	glow_color = "#E6C9F0"
+
+/datum/magic_item/mundane/fairseeming/attack_right(var/obj/item/i, var/mob/living/user)
+	to_chat(user, span_notice("I grip [i] lightly, and a faint shimmer of glamour gathers around me..."))
+	if(do_after(user, 2 SECONDS, target = user))
+		new /obj/effect/temp_visual/cleaning_pulse(get_turf(user))
+		wash_atom(user, CLEAN_STRONG)
+		user.remove_stress(/datum/stressevent/sewertouched)
+		to_chat(user, span_notice("The glamour settles, and I am spotless once more."))
 	. = ..()
 
 /datum/magic_item/mundane/holding

--- a/code/datums/magic_items/mundane_items/mundane.dm
+++ b/code/datums/magic_items/mundane_items/mundane.dm
@@ -75,28 +75,26 @@
 
 /datum/magic_item/mundane/revealinglight
 	name = "revealing light"
-	description = "It emits a shining light."
+	description = "It emits a shining light. (Use right click to light it or dim it)"
 	glow_color = "#FFB347"
 	var/active = FALSE
 
-/datum/magic_item/mundane/revealinglight/on_use(var/obj/item/i, var/mob/living/user)
+/datum/magic_item/mundane/revealinglight/attack_right(var/obj/item/i, var/mob/living/user)
 	if(!active)
 		active = TRUE
 		to_chat(user, span_notice("I grip [i] lightly, and it abruptly lights up with shining light"))
-		if(i.light_system == MOVABLE_LIGHT)
-			// set_light_range() has a signal ordering bug where the movable light
-			// component reads light_outer_range before it is updated.
-			// Workaround: set vars directly, then poke the component via signal.
-			i.light_inner_range = 2
-			i.light_outer_range = 6
-			i.light_power = 2
-			i.light_color = "#3FBAFD"
-			SEND_SIGNAL(i, COMSIG_ATOM_SET_LIGHT_RANGE, 2, 6)
-			SEND_SIGNAL(i, COMSIG_ATOM_SET_LIGHT_POWER, 2)
-			SEND_SIGNAL(i, COMSIG_ATOM_SET_LIGHT_COLOR, "#3FBAFD")
-			i.set_light_on(TRUE)
-		else
-			i.set_light(6, 2, 2, l_color = "#3FBAFD", l_on = TRUE)
+		i.light_system = MOVABLE_LIGHT
+		if(!i.GetComponent(/datum/component/overlay_lighting))
+			i.AddComponent(/datum/component/overlay_lighting)
+		i.set_light_range(10)
+		i.set_light_power(1)
+		i.set_light_color(LIGHT_COLOR_WHITE)
+		i.set_light_on(TRUE)
+		i.update_icon()
+	else
+		active = FALSE
+		to_chat(user, span_notice("I grip [i] lightly, and the light fades away"))
+		i.set_light_on(FALSE)
 		i.update_icon()
 	. = ..()
 

--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -134,6 +134,23 @@ T1 Enchantments below here*/
 	else
 		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
 
+/obj/item/enchantmentscroll/basic/fairseeming
+	name = "enchanting scroll of fair seeming"
+	desc = "A scroll imbued with an enchantment of fair seeming. Allows an enchanted item to clean its owner."
+	component = /datum/magic_item/mundane/fairseeming
+
+/obj/item/enchantmentscroll/basic/fairseeming/attack_obj(obj/item/O, mob/living/user)
+	if(!..())
+		return
+	if(istype(O,/obj/item/clothing)|| istype(O,/obj/item/handmirror))
+		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
+		var/magiceffect= new component
+		O.AddComponent(/datum/component/magic_item, magiceffect)
+		O.name += " of fair seeming"
+		qdel(src)
+	else
+		to_chat(user, span_notice("Nothing happens. Perhaps you can't enchant [O] with this?"))
+
 //T2 Enchantments below
 
 /obj/item/enchantmentscroll/superior/nightvision

--- a/code/modules/roguetown/roguejobs/mages/rituals/enchanting.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/enchanting.dm
@@ -50,6 +50,14 @@
 	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/fae/fairydust = 4)
 	result_atoms = list(/obj/item/enchantmentscroll/basic/xylix)
 
+/datum/runeritual/enchanting/fairseeming
+	name = "Fair Seeming"
+	desc = "Become Spotless!"
+	blacklisted = FALSE
+	tier = 1
+	required_atoms = list(/obj/item/rogueore/cinnabar = 1, /obj/item/paper/scroll = 1, /obj/item/magic/fae/fairydust = 4)
+	result_atoms = list(/obj/item/enchantmentscroll/basic/fairseeming)
+
 /datum/runeritual/enchanting/revealinglight
 	name = "Revealing Light"
 	desc = "Provides light!"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Adds new tech for enchantments that allow to add right click effects on items enchanted.

Fixes Revealing light. Its light now works with weapons, and also calculates as a movable light, so it actually follows the item enchanted, it can also be turned off and on with right click on it.

Revealing Light Enchantment is now based on the light cantrip, making the light to be white and have a higher range, but be less powerful when competing with other effects.

Adds a new T1 Fae enchantment, Fair Seeming. It cleans the user after a 2 second action, even removing the sewer grime. You could get soap for a fraction of the value, but, who am I to tell you how to use your money.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

Light on:

<img width="827" height="727" alt="image" src="https://github.com/user-attachments/assets/4d8217f1-cbc9-4c70-b958-8f82b37eea5b" />

Creating Scroll:

<img width="935" height="592" alt="image" src="https://github.com/user-attachments/assets/0065ab34-b9c0-4c90-bbfb-95f40801994d" />

<img width="633" height="211" alt="image" src="https://github.com/user-attachments/assets/b64c399d-9954-4dd0-bf76-7b7e776c9a16" />

spotless:

<img width="665" height="464" alt="image" src="https://github.com/user-attachments/assets/3121ff51-f2b5-478a-8258-c3bbee590cd9" />

<img width="637" height="344" alt="image" src="https://github.com/user-attachments/assets/5e09e994-b37a-4f52-b008-2f73c7d30c45" />

<img width="623" height="364" alt="image" src="https://github.com/user-attachments/assets/c21b9b93-7f6a-4d1b-9fdf-e09cea1859c9" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Well, making the enchantment system be a bit more flexible should allow for more tools to be added to the game.

Fixing something that was broken, in this case revealing light, makes for a better quality game, as the magic item works as one would had expected. I foresee people winning one more slot of inventory due to this, but nothing too big. It's Frodo's sword

Fair Seeming is a spell exclusivily made for people to waste materials on it, instead of using materials to game the system, get a stat, they instead get a thing thats mostly flavor, and could be solved with soap or a water source, and I think its fun.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Adds new tech for enchantments that allow to add right click effects on items enchanted.
fix: Fixes Revealing light. Its light now works with weapons, and also calculates as a movable light, so it actually follows the item enchanted, it can also be turned off and on with right click on it.
balance: Revealing Light Enchantment is now based on the light cantrip, making the light to be white and have a higher range, but be less powerful when competing with other effects.
add: Adds a new T1 Fae enchantment, Fair Seeming. It cleans the user after a 2 second action, even removing the sewer grime. You could get soap for a fraction of the value, but, who am I to tell you how to use your money.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
