### PR TITLE
[Balance] Tunes down Levy without changing it

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
@@ -48,7 +48,9 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots
+	belt = /obj/item/storage/backpack/rogue/satchel/beltpack
 	beltl = /obj/item/flashlight/flare/torch/lantern
+	backl = /obj/item/storage/backpack/rogue/backpack
 	
 	to_chat(H, span_notice("<b>THE WEAPON I COULD SCROUNGE UP:</b>"))
 	to_chat(H, span_info("<b>THE FAMILY SWORD</b> - Journeyman Swords. Comes with a militia falchion."))
@@ -189,244 +191,93 @@
 	if(H.mind)
 		SStreasury.grant_savings(ECONOMIC_DESTITUTE, H)
 
-	to_chat(H, span_notice("<b>JOB BEFORE THE LEVY?</b>"))
+	to_chat(H, span_notice("<b>WHO YOU WERE BEFORE THE LEVY?</b>"))
 
-	to_chat(H, span_info("<b>UNEMPLOYED, SER!!</b><br>\
+	to_chat(H, span_info("<b>AN AVERAGE JOE, SER!!</b><br>\
 	Traits: None.<br>\
-	Final Stats: +1 CON, +1 STR, +1 WIL, -1 INT, +1 LCK.<br>\
+	Final Stats: No changes.<br>\
 	Skills: No extras.<br>\
-	Equipment: Satchel, Rope, Signal Horn, 4x Triumph Beer.<br><br>"))
+	Equipment: Rope, Signal Horn, 4x Beer.<br><br>"))
 
-	to_chat(H, span_info("<b>A HOMESTEADER, SER!!</b><br>\
-	Traits: Jack of All Trades, Homestead Expert, Smithing Expert, Survival Expert.<br>\
-	Final Stats: +1 CON, +1 STR, +1 WIL, +3 INT, +1 SPD, -1 LCK.<br>\
+	to_chat(H, span_info("<b>A TOUGH SOD, SER!!</b><br>\
+	Traits: Enduring, Steelhearted.<br>\
+	Final Stats: +3 CON, +2 STR, +2 WIL, -2 INT, -2 SPD, -1 LCK.<br>\
 	Skills: No extras.<br>\
-	Equipment: Backpack, Small Shovel, Stone Hammer, Chisel, Handsaw, Hoe, Hunting Knife, Rope, Poor Coin Pouch, Signal Horn, Triumph Beer, Broom, Coal.<br><br>"))
+	Equipment: Rope, Signal Horn, 4x Beer.<br><br>"))
 
-	to_chat(H, span_info("<b>A COOKER-DOC, SER!!</b><br>\
-	Traits: Medicine Expert, Cicerone.<br>\
-	Final Stats: +3 INT, +2 SPD, -1 STR, -1 CON, -1 LCK.<br>\
-	Skills: Medicine (Expert), Cooking (Journeyman), Alchemy (Apprentice). Knows Secular Diagnose.<br>\
-	Equipment: Backpack, Bedroll, Signal Horn, Hunting Knife, Rope, Triumph Beer, Bottle Kit, Calendula Seeds, Healing Juice Recipe, Surgery Bag, Folding Alchemy Cauldron, Coal.<br><br>"))
-
-	to_chat(H, span_info("<b>A THUG, SER!!</b><br>\
-	Traits: No Pain Stun, Steelhearted. Knows Thieves' Cant.<br>\
-	Final Stats: +2 STR, +2 CON, +1 WIL, -1 SPD, -2 INT, -1 LCK.<br>\
-	Skills: Athletics (Journeyman), Maces (Apprentice).<br>\
-	Equipment: Satchel, Cudgel, Signal Horn, Hunting Knife, 2x Triumph Beer.<br><br>"))
-
-	to_chat(H, span_info("<b>A SCAVENGER, SER!!</b><br>\
-	Traits: Dodge Expert, Graverobber.<br>\
+	to_chat(H, span_info("<b>A SKINNY WIMP, SER!!</b><br>\
+	Traits: Dodge Expert.<br>\
 	Final Stats: -3 CON, +1 STR, +1 WIL, -1 INT, +3 SPD, -1 LCK.<br>\
-	Skills: Sneaking (Journeyman), Knives (Journeyman), Sewing (Journeyman), Smelting (Journeyman).<br>\
-	Equipment: Backpack, Combat Knife, Small Shovel, Scissors, Signal Horn, Triumph Beer, Rope, 2x Coal, Iron Ore, Tongs.<br><br>"))
-
-	to_chat(H, span_info("<b>A BATHMAID, SER!!</b><br>\
-	Traits: Empath, Good Lover, Nutcracker. Knows Thieves' Cant.<br>\
-	Final Stats: +2 SPD, -2 INT, +1 LCK.<br>\
-	Skills: Medicine (Novice), Lockpicking (Journeyman), Sneaking (Journeyman), Riding (Master).<br>\
-	Equipment: Satchel, Bath Soap, Gold Hairpin, Signal Horn, Triumph Beer, Rope.<br><br>"))
-
-	to_chat(H, span_info("<b>ALMOST A SQUIRE, SER!!</b><br>\
-	Traits: Squire Repair, Expert Hunter.<br>\
-	Final Stats: +1 CON, +1 STR, +1 WIL, -1 INT, +1 SPD, -1 PER, -1 LCK.<br>\
 	Skills: No extras.<br>\
-	Equipment: Satchel, Rich Coin Pouch, Stone Hammer, Polishing Cream, Armor Brush, Signal Horn, Needle.<br><br>"))
+	Equipment: Rope, Signal Horn, Coal, Iron Ore, Scissors.<br><br>"))
 
-	to_chat(H, span_info("<b>ALMOST AN ARMSMAN, SER!!</b><br>\
-	Traits: Guardsman, Steelhearted.<br>\
-	Final Stats: +2 CON, +1 STR, +2 WIL, -1 INT, -2 PER, -1 LCK.<br>\
-	Skills: Shields (Journeyman).<br>\
-	Equipment: Heater Shield, Beltpack, Chain, Signal Horn, Hunting Knife, Health Potion, Triumph Beer.<br><br>"))
+	to_chat(H, span_info("<b>A SMART COOKIE, SER!!</b><br>\
+	Traits: Jack of All Trades.<br>\
+	Final Stats: +3 INT, +1 SPD.<br>\
+	Skills: No extras.<br>\
+	Equipment: Rope, Signal Horn, Coal, Iron Ore, Bottlin' Kit, Healing Juice Recipe.<br><br>"))
 
 	if(H.mind)
 		var/list/specialties = list(
-			"UNEMPLOYED, SER!!",
-			"A HOMESTEADER, SER!!",
-			"A COOKER-DOC, SER!!",
-			"A THUG, SER!!",
-			"A SCAVENGER, SER!!",
-			"A BATHMAID, SER!!",
-			"ALMOST A SQUIRE, SER!!",
-			"ALMOST AN ARMSMAN, SER!!"
+			"AN AVERAGE JOE, SER!!",
+			"A VAGABOND, SER!!",
+			"A TOUGH SOD, SER!!",
+			"A SKINNY WIMP, SER!!",
+			"A SMART COOKIE, SER!!",
 		)
-		var/specialty_choice = tgui_input_list(H, "Choose your background. (The Levy is not legally obligated to provide tools, equipment, compensation, legal representation, funeral expenses, or refunds. Good luck, and we love you.)", "JOB BEFORE THE LEVY?", specialties)
+		var/specialty_choice = tgui_input_list(H, "What type of a Peasant were ya'?", "FIT BEFORE THE LEVY?", specialties)
 		switch(specialty_choice)
 
-			if("UNEMPLOYED, SER!!") // the real hero. 4 beer packs, no gear, full balls.
-				H.change_stat(STATKEY_LCK, 1)
-				belt = /obj/item/storage/belt/rogue/leather
-				backl = /obj/item/storage/backpack/rogue/satchel
+			if("AN AVERAGE JOE, SER!!")
 				backpack_contents = list(
 					/obj/item/rope = 1,
-					/obj/item/reagent_containers/glass/bottle/rogue/triumphbeer = 4, // this one is for good luck, you'll need it, OHH YOU'LL NEED IT.
 					/obj/item/signal_horn = 1,
+					/obj/item/reagent_containers/glass/bottle/rogue/triumphbeer = 4,
 					)
 
-			if("A HOMESTEADER, SER!!") // basic bitch siege engineer guy, may be mogged by default but ig JoAT lets them be omni-journeyman on all, shrug.
-				ADD_TRAIT(H, TRAIT_JACKOFALLTRADES, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_HOMESTEAD_EXPERT, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_SMITHING_EXPERT, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_SURVIVAL_EXPERT, TRAIT_GENERIC)
-				H.change_stat(STATKEY_INT, 4)
-				H.change_stat(STATKEY_SPD, 1)
-				H.change_stat(STATKEY_LCK, -1)
-				belt = /obj/item/storage/backpack/rogue/satchel/beltpack
-				backl = /obj/item/storage/backpack/rogue/backpack
-				backpack_contents = list(
-					/obj/item/rogueweapon/shovel/small = 1,
-					/obj/item/rogueweapon/hammer/stone = 1,
-					/obj/item/rogueweapon/chisel = 1,
-					/obj/item/rogueweapon/handsaw = 1,
-					/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
-					/obj/item/rogueweapon/huntingknife = 1,
-					/obj/item/rogueweapon/scabbard/sheath = 1,
-					/obj/item/rope = 1,
-					/obj/item/reagent_containers/glass/bottle/rogue/triumphbeer = 1, // this one is for good luck, you'll need it
-					/obj/item/signal_horn = 1,
-					/obj/item/rogueweapon/hoe = 1,
-					/obj/item/broom = 1,
-					/obj/item/rogueore/coal = 1,
-					)
-
-			if("A COOKER-DOC, SER!!") // JESSIE, WE GOTTA COOK!!! -- This is intended to be the Barber-Surgeon's cousin. Low combat potential.
-				ADD_TRAIT(H, TRAIT_MEDICINE_EXPERT, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_CICERONE, TRAIT_GENERIC)
-				H.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
-				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_EXPERT, TRUE) // so secular diagnose gives better info after (if) they hit master
-				H.adjust_skillrank_up_to(/datum/skill/craft/cooking, SKILL_LEVEL_JOURNEYMAN, TRUE) // brew fish potions for field-healing, ser!!!
-				H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, SKILL_LEVEL_APPRENTICE, TRUE) // this is for drug-crafting
-				H.change_stat(STATKEY_INT, 4)
-				H.change_stat(STATKEY_SPD, 2)
-				H.change_stat(STATKEY_LCK, -1)
-				H.change_stat(STATKEY_STR, -1)
-				H.change_stat(STATKEY_WIL, -1)
-				H.change_stat(STATKEY_CON, -1)
-				belt = /obj/item/storage/backpack/rogue/satchel/beltpack
-				backl = /obj/item/storage/backpack/rogue/backpack
-				backpack_contents = list(
-					/obj/item/bedroll = 1,
-					/obj/item/signal_horn = 1,
-					/obj/item/rogueweapon/huntingknife = 1,
-					/obj/item/rogueweapon/scabbard/sheath = 1,
-					/obj/item/rope = 1,
-					/obj/item/reagent_containers/glass/bottle/rogue/triumphbeer = 1, // this one is for good luck, you'll need it
-					/obj/item/bottle_kit = 1,
-					/obj/item/herbseed/calendula = 1,
-					/obj/item/paper/vinegar_healpot_recipe = 1, // give man a fish and he eats for 1 dae, give them the recipeh and they'll eat for lyfe
-					/obj/item/storage/belt/rogue/surgery_bag = 1,
-					/obj/item/rogueore/coal = 1,
-					/obj/item/folding_alchcauldron_stored = 1,
-					)
-
-			if("A THUG, SER!!") // meatball that's dumb and meaty and does nothing but do that, comes with a cudgel to sell that idea better
-				H.grant_language(/datum/language/thievescant)
+			if("A TOUGH SOD, SER!!")
 				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
-				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_APPRENTICE, TRUE)
 				H.change_stat(STATKEY_STR, 1)
-				H.change_stat(STATKEY_CON, 1)
-				H.change_stat(STATKEY_SPD, -1)
-				H.change_stat(STATKEY_INT, -1)
-				H.change_stat(STATKEY_LCK, -1)
-				belt = /obj/item/storage/belt/rogue/leather
-				backl = /obj/item/storage/backpack/rogue/satchel
-				backpack_contents = list(
-					/obj/item/rogueweapon/mace/cudgel = 1,
-					/obj/item/signal_horn = 1,
-					/obj/item/rogueweapon/huntingknife = 1,
-					/obj/item/rogueweapon/scabbard/sheath = 1,
-					/obj/item/reagent_containers/glass/bottle/rogue/triumphbeer = 1, // this one is for good luck, you'll need it. And an extra one because you're going to suffer a lot.
-					)
-
-			if("A SCAVENGER, SER!!") // squishier glass cannon, fast on your feet, mr. back-and-forth man whose specialty is dragging stuff around and being dodgy. also free combat knife!
-				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
-				H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/craft/sewing, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/craft/smelting, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.change_stat(STATKEY_CON, -4)
-				H.change_stat(STATKEY_SPD, 3)
-				H.change_stat(STATKEY_LCK, -1)
-				belt = /obj/item/storage/backpack/rogue/satchel/beltpack
-				backl = /obj/item/storage/backpack/rogue/backpack
-				backpack_contents = list(
-					/obj/item/rogueweapon/huntingknife/combat/iron = 1,
-					/obj/item/rogueweapon/scabbard/sheath = 1,
-					/obj/item/rogueweapon/huntingknife/scissors = 1,
-					/obj/item/rogueweapon/shovel/small = 1,
-					/obj/item/signal_horn = 1,
-					/obj/item/reagent_containers/glass/bottle/rogue/triumphbeer = 1, // this one is for good luck, you'll need it
-					/obj/item/rope = 1,
-					/obj/item/rogueore/coal = 2,
-					/obj/item/rogueore/iron = 1,
-					/obj/item/rogueweapon/tongs = 1,
-					)
-
-			if("A BATHMAID, SER!!") // requested, basically copying 'some' qualities from the bathmaid, but not all, idk what riding will do for them but it's funny to imagine a bathmaiden on a hog with a whip, as people commented
-				H.grant_language(/datum/language/thievescant)
-				ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_NUTCRACKER, TRAIT_GENERIC)
-				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/misc/lockpicking, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/misc/riding, SKILL_LEVEL_MASTER, TRUE) // sigh
-				H.change_stat(STATKEY_SPD, 2)
-				H.change_stat(STATKEY_INT, -1)
-				H.change_stat(STATKEY_CON, -1)
-				H.change_stat(STATKEY_STR, -1)
-				H.change_stat(STATKEY_WIL, -1)
-				H.change_stat(STATKEY_LCK, 1)
-				belt = /obj/item/storage/belt/rogue/leather
-				backl = /obj/item/storage/backpack/rogue/satchel
-				backpack_contents = list(
-					/obj/item/soap/bath = 1,
-					/obj/item/lockpick/goldpin = 1,
-					/obj/item/signal_horn = 1,
-					/obj/item/rogueweapon/huntingknife = 1,
-					/obj/item/rogueweapon/scabbard/sheath = 1,
-					/obj/item/rope = 1,
-					)
-
-			if("ALMOST A SQUIRE, SER!!") // probably should start richer to show that this is prolly the most prestigious among the group
-				ADD_TRAIT(H, TRAIT_SQUIRE_REPAIR, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_EXPERT_HUNTER, TRAIT_GENERIC)
-				H.change_stat(STATKEY_SPD, 1)
-				H.change_stat(STATKEY_PER, -1)
-				H.change_stat(STATKEY_LCK, -1)
-				belt = /obj/item/storage/belt/rogue/leather
-				backl = /obj/item/storage/backpack/rogue/satchel
-				backpack_contents = list(
-					/obj/item/rogueweapon/hammer/stone = 1,
-					/obj/item/polishing_cream = 1,
-					/obj/item/armor_brush = 1,
-					/obj/item/signal_horn = 1,
-					/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
-					/obj/item/needle/thorn = 1,
-					)
-
-			if("ALMOST AN ARMSMAN, SER!!") // this is probably going to be the poster boy, but what can we do
-				ADD_TRAIT(H, TRAIT_GUARDSMAN, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
-				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.change_stat(STATKEY_CON, 1)
+				H.change_stat(STATKEY_CON, 2)
 				H.change_stat(STATKEY_WIL, 1)
-				H.change_stat(STATKEY_PER, -2)
+				H.change_stat(STATKEY_INT, -1)
+				H.change_stat(STATKEY_SPD, -2)
 				H.change_stat(STATKEY_LCK, -1)
-				belt = /obj/item/storage/backpack/rogue/satchel/beltpack
-				backl = /obj/item/rogueweapon/shield/heater
 				backpack_contents = list(
-					/obj/item/rope/chain = 1,
+					/obj/item/rope = 1,
 					/obj/item/signal_horn = 1,
-					/obj/item/rogueweapon/huntingknife = 1,
-					/obj/item/rogueweapon/scabbard/sheath = 1,
-					/obj/item/reagent_containers/glass/bottle/rogue/healthpotnew = 1, // armsmen get a little extra from their folks in the garrison
-					/obj/item/reagent_containers/glass/bottle/rogue/triumphbeer = 1, // this one is for good luck, you'll need it
+					/obj/item/reagent_containers/glass/bottle/rogue/triumphbeer = 4,
 					)
 
+			if("A SKINNY WIMP, SER!!")
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+				H.change_stat(STATKEY_CON, -4)
+				H.change_stat(STATKEY_LCK, -1)
+				H.change_stat(STATKEY_SPD, 3)
+				backpack_contents = list(
+					/obj/item/rope = 1,
+					/obj/item/signal_horn = 1,
+					/obj/item/rogueore/coal = 1,
+					/obj/item/rogueore/iron = 1,
+					/obj/item/rogueweapon/huntingknife/scissors = 1,
+					)
+
+			if("A SMART COOKIE, SER!!")
+				ADD_TRAIT(H, TRAIT_JACKOFALLTRADES, TRAIT_GENERIC)
+				H.change_stat(STATKEY_STR, -1)
+				H.change_stat(STATKEY_CON, -1)
+				H.change_stat(STATKEY_WIL, -1)
+				H.change_stat(STATKEY_INT, 4)
+				H.change_stat(STATKEY_SPD, 1)
+				backpack_contents = list(
+					/obj/item/rope = 1,
+					/obj/item/signal_horn = 1,
+					/obj/item/rogueore/coal = 1,
+					/obj/item/rogueore/iron = 1,
+					/obj/item/bottle_kit = 1,
+					/obj/item/paper/vinegar_healpot_recipe = 1,
+					)
 
 //A note for the Doc!
 /obj/item/paper/vinegar_healpot_recipe

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
@@ -220,7 +220,6 @@
 	if(H.mind)
 		var/list/specialties = list(
 			"AN AVERAGE JOE, SER!!",
-			"A VAGABOND, SER!!",
 			"A TOUGH SOD, SER!!",
 			"A SKINNY WIMP, SER!!",
 			"A SMART COOKIE, SER!!",


### PR DESCRIPTION
## About The Pull Request

- Streamlines the backstories into just four archetypes. 'Average, Tough, Skinny and Smartie'. Each still come with one particular trait to each, stats were shuffled around to better reflect it. No bonus skills. Everything's now to be grinded for.

## Testing Evidence

<img width="934" height="591" alt="Screenshot_366" src="https://github.com/user-attachments/assets/e63bdafd-cd35-4557-bd5a-53a23b77bc64" />

## Why It's Good For The Game

The less destructive alternative to what's going to come. I'm willing to further tweak this based on feedback.

## Changelog
:cl:
balance: Nerfs Levy and streamlines their choices.
/:cl: