### PR TITLE
[Abyssor] - Updates tidal spire to have a funky fishing pool

### DIFF
--- a/code/__HELPERS/fishing_hunting.dm
+++ b/code/__HELPERS/fishing_hunting.dm
@@ -3,6 +3,8 @@
 	/turf/open/water/cleanshallow,\
 	/turf/open/water/ocean,\
 	/turf/open/water/ocean/deep,\
+	/turf/open/water/ocean/deep/dark,\
+	/turf/open/water/ocean/abyssal,\
 	/turf/open/water/swamp,\
 	/turf/open/water/swamp/deep )
 
@@ -136,3 +138,68 @@
 
 /proc/createCageFishWeightListModlist(list/fishingMods)
 	return createCageFishWeightList(fishingMods["commonFishingMod"],fishingMods["rareFishingMod"],fishingMods["treasureFishingMod"],fishingMods["trashFishingMod"],fishingMods["dangerFishingMod"],fishingMods["ceruleanFishingMod"],fishingMods["cheeseFishingMod"])
+
+/proc/createAbyssalSeaFishWeightList(commonMod, rareMod, treasureMod, trashMod, dangerMod, ceruleanMod, cheeseMod)
+	var/weightList = list(
+		// --- Fish ---
+		/obj/item/reagent_containers/food/snacks/fish/carp = 270 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/sunny = 340 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/salmon = 180 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/eel = 180 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/black_bass = 150 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/sturgeon = 200 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/cod = 310 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 220 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/sole = 350 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 210 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/bass = 310 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 190 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/salmon/black_headed = 40 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/flounder = 200 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/mackerel = 210 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/beaksnapper = 100 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/swamp_shrimp = 200 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/swamp_mother = 100 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/zizo_abberation = 20 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/mudskipper = 200 * commonMod,
+		/obj/item/natural/worms/leech = 180 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/oyster = 250 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/shrimp = 250 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/crab = 250 * rareMod,
+		/obj/item/roguegem/oyster = 50 * rareMod,
+		/obj/item/clothing/head/roguetown/octopus = 36 * rareMod,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 170 * rareMod + 250 * commonMod,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 60 * rareMod + 300 * ceruleanMod,
+
+		// --- Rare Fish ---
+		/obj/item/reagent_containers/food/snacks/fish/creepy_eel = 10 * rareMod + 20 * ceruleanMod,
+		/obj/item/reagent_containers/food/snacks/fish/creepy_squid = 10 * rareMod + 20 * ceruleanMod,
+		/obj/item/reagent_containers/food/snacks/fish/creepy_shark = 10 * rareMod + 20 * ceruleanMod,
+
+		// --- Treasure Pool ---
+		/obj/item/reagent_containers/glass/bottle/rogue/wine = 3 * treasureMod + 60 * ceruleanMod,
+		/obj/item/clothing/ring/gold = 4 * treasureMod + 90 * ceruleanMod,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 3 * treasureMod + 175 * ceruleanMod,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 60 * ceruleanMod,
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 15 * ceruleanMod,
+
+		// --- Trash Pool ---
+		/obj/item/grown/log/tree/stick = 102 * trashMod,
+		/obj/item/natural/cloth = 2 * trashMod,
+		/obj/item/ammo_casing/caseless/rogue/arrow = 2 * trashMod,
+		/obj/item/reagent_containers/glass/bottle/rogue = 3 * trashMod,
+
+		// --- Rodent menace ---
+		/obj/item/reagent_containers/food/snacks/smallrat = 5 + 75 * cheeseMod,
+		/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 5 * cheeseMod,
+
+		// --- Danger / Monsters ---
+		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 90,
+		/mob/living/carbon/human/species/goblin/npc/sea = 50 * dangerMod,
+		/mob/living/simple_animal/hostile/rogue/deepone = 50 * dangerMod,
+		/mob/living/simple_animal/hostile/rogue/deepone/spit = 50 * dangerMod
+	)
+	return counterlist_ceiling(weightList)
+
+/proc/createAbyssalSeaFishWeightListModlist(list/fishingMods)
+	return createAbyssalSeaFishWeightList(fishingMods["commonFishingMod"], fishingMods["rareFishingMod"], fishingMods["treasureFishingMod"], fishingMods["trashFishingMod"], fishingMods["dangerFishingMod"], fishingMods["ceruleanFishingMod"], fishingMods["cheeseFishingMod"])

--- a/code/game/objects/items/ritualcircles.dm
+++ b/code/game/objects/items/ritualcircles.dm
@@ -874,7 +874,7 @@
 	var/max_fiends = 3
 	// Holds all the turf data so it can be unconverted.
 	var/list/turf_data = list()
-	var/expansion_timer = 3 MINUTES
+	var/expansion_timer = 2 MINUTES
 	var/next_expansion_time = 0
 	var/spawn_timer = 45 SECONDS
 	var/next_fiend_time = 0
@@ -897,7 +897,7 @@
 	icon_state = "crystal_spire_tidal"
 	max_integrity = 300
 	max_fiends = 0
-	turf_to_use = /turf/open/water/ocean/deep
+	turf_to_use = /turf/open/water/ocean/abyssal
 
 /obj/structure/crystal_spire/Initialize()
 	. = ..()
@@ -932,6 +932,42 @@
 			awakened = TRUE
 		expand_radius()
 		next_expansion_time = world.time + expansion_timer
+
+/obj/structure/crystal_spire/tidal/convert_surroundings()
+	start_conversion()
+	var/turf/center = get_turf(src)
+	var/radius_sq = current_radius * current_radius
+
+	for(var/turf/T in spiral_range_turfs(current_radius, center))
+		// Skip if already converted
+		if(istype(T, turf_to_use) || istype(T, /turf/open/water/ocean/deep/dark))
+			continue
+		if(T.density)
+			continue
+		if(istransparentturf(T))
+			continue
+
+		var/dx = abs(T.x - center.x)
+		var/dy = abs(T.y - center.y)
+		var/dist_sq = dx*dx + dy*dy
+
+		if(dist_sq <= radius_sq)
+			turf_data[T] = T.type
+
+			// Inner rings become abyssal ocean
+			if(current_radius <= 3)
+				T.ChangeTurf(turf_to_use, flags = CHANGETURF_IGNORE_AIR)
+			// Outer ring becomes deep ocean
+			else
+				T.ChangeTurf(/turf/open/water/ocean/deep/dark, flags = CHANGETURF_IGNORE_AIR)
+
+			playsound(T, 'sound/magic/fleshtostone.ogg', 30, TRUE)
+			sleep(5)
+
+	// Stop processing if fully expanded
+	if(current_radius >= max_radius)
+		STOP_PROCESSING(SSobj, src)
+	end_conversion()
 
 /obj/structure/crystal_spire/Destroy()
 	for(var/turf/T in turf_data)
@@ -1002,41 +1038,8 @@
 
 	end_conversion()
 
-/obj/structure/crystal_spire/tidal/convert_surroundings()
-	start_conversion()
-	var/turf/center = get_turf(src)
-	var/radius_sq = current_radius * current_radius
-
-	for(var/turf/T in spiral_range_turfs(current_radius, center))
-		// Skip if already converted
-		// Additionally, we don't want this to be a reliable breaching tool, so ignore dense stuff and open spaces!
-		if(istype(T, turf_to_use))
-			continue
-		if(T.density)
-			continue
-		if(istransparentturf(T))
-			continue
-
-		// Calculate distance from center
-		var/dx = abs(T.x - center.x)
-		var/dy = abs(T.y - center.y)
-		var/dist_sq = dx*dx + dy*dy
-
-		// Convert all tiles within circular radius. More circular than normal spires.
-		if(dist_sq <= radius_sq)
-			turf_data[T] = T.type
-			T.ChangeTurf(turf_to_use, flags = CHANGETURF_IGNORE_AIR)
-			playsound(T, 'sound/magic/fleshtostone.ogg', 30, TRUE)
-			//Faster since it's less harmful.
-			sleep(5)
-
-	// Stop processing if fully expanded
-	if(current_radius >= max_radius)
-		STOP_PROCESSING(SSobj, src)
-	end_conversion()
-
 /obj/structure/crystal_spire/proc/expand_radius()
-	if(current_radius >= max_radius)
+	if(converting || current_radius >= max_radius)
 		return
 
 	current_radius++

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -643,6 +643,20 @@
 	swim_skill = TRUE
 	wash_in = TRUE
 
+/turf/open/water/ocean/deep/dark
+	water_color = "#000211"
+
+/turf/open/water/ocean/abyssal
+	name = "darkwater"
+	desc = "Water from another realm, it's impossibly deep, like everything below the surface isn't fully within this plane."
+	icon_state = "water"
+	icon = 'icons/turf/roguefloor.dmi'
+	water_level = 3
+	water_color = "#000211"
+	slowdown = 8
+	swim_skill = TRUE
+	wash_in = FALSE
+
 /turf/open/water/pond
 	name = "pond"
 	desc = "Still and alarmingly idyllic water. Covered in concerning overgrowth of duckweed."

--- a/code/modules/mob/living/simple_animal/hostile/deepone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/deepone.dm
@@ -15,7 +15,15 @@
 	STASTR = 13
 	STASPD = 9
 	maxHealth = DEEPONE_HEALTH
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/crab = 5, /obj/item/alch/viscera = 2)
+	botched_butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/crab = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/crab = 2,
+						   /obj/item/reagent_containers/food/snacks/rogue/meat/crab = 2,
+						   /obj/item/reagent_containers/food/snacks/rogue/meat/crab = 1,
+						   /obj/item/alch/viscera = 2)
+	perfect_butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/crab = 2,
+						   /obj/item/reagent_containers/food/snacks/rogue/meat/crab = 2,
+						   /obj/item/reagent_containers/food/snacks/rogue/meat/crab = 2,
+						   /obj/item/alch/viscera = 2)
 	health = DEEPONE_HEALTH
 	harm_intent_damage = 20
 	melee_damage_lower = 10

--- a/code/modules/roguetown/roguejobs/fisher/fishing.dm
+++ b/code/modules/roguetown/roguejobs/fisher/fishing.dm
@@ -1,7 +1,8 @@
 /proc/getfishingloot(var/mob/living/carbon/human/fisherman, var/list/modlist, turf/target, var/skill_power = 1)
 	var/frwt = list(/turf/open/water/river, /turf/open/water/cleanshallow, /turf/open/water/pond)
 	var/salwt_coast = list(/turf/open/water/ocean)
-	var/salwt_deep = list(/turf/open/water/ocean/deep)
+	var/salwt_deep = list(/turf/open/water/ocean/deep, /turf/open/water/ocean/deep/dark)
+	var/salwt_abyssal = list(/turf/open/water/ocean/abyssal)
 	var/mud = list(/turf/open/water/swamp, /turf/open/water/swamp/deep)
 	if(ishuman(fisherman))
 		if(fisherman.patron.type == /datum/patron/divine/abyssor)
@@ -25,6 +26,8 @@
 		fishingloot = pickweightAllowZero(createCoastalSeaFishWeightListModlist(modlist))
 	else if(target.type in salwt_deep)
 		fishingloot = pickweightAllowZero(createDeepSeaFishWeightListModlist(modlist))
+	else if(target.type in salwt_abyssal)
+		fishingloot = pickweightAllowZero(createAbyssalSeaFishWeightListModlist(modlist))
 	else if(target.type in mud)
 		fishingloot = pickweightAllowZero(createMudFishWeightListModlist(modlist))
 	return fishingloot


### PR DESCRIPTION
## About The Pull Request
Tidal spires now spawn darkwater to better emulate the water being drawn from the dream.
Darkwater has all fishing pools combined!
The outer edge of tidal spries is still ocean water to allow old use.

- Fixes spires expanding to their maximum radius on the second expansion.
- Lowered expansion time from 3 to 2 minutes to compensate for this fix. It's slower than before, but only twice as slow rather than three times.
- Unatomized change to make deep ones have a proper butchery pool...

## Testing Evidence
<img width="1910" height="1033" alt="image" src="https://github.com/user-attachments/assets/a68aa928-f12a-4e64-8dee-9ad671d3893b" />

## Why It's Good For The Game
Makes tidal spires have a bit more utility by providing a wide variety of fishes, so it has more use other than enabling abyssor water miracles, but also providing more utility rather than just walking over to the ocean.
It's more thematic this way.

## Changelog

:cl:
add: Abyssor's power shifts, tidal spires now produce darkwater.
/:cl:

