### PR TITLE
[Fix] Mannequin Pants

### DIFF
--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -201,6 +201,7 @@
 	. += "<BR><B>Armor:</B> <A href='byond://?src=[REF(src)];command=item_placement;item_slot=[BODY_ZONE_CHEST]'>[makeStrippingButton(clothing[SLOT_MANNEQUIN_ARMOR])]</A>"
 	. += "<BR><B>Shirt:</B> <A href='byond://?src=[REF(src)];command=item_placement;item_slot=[BODY_ZONE_PRECISE_STOMACH]'>[makeStrippingButton(clothing[SLOT_MANNEQUIN_SHIRT])]</A>"
 	. += "<BR><B>Belt:</B> <A href='byond://?src=[REF(src)];command=item_placement;item_slot=[BODY_ZONE_PRECISE_GROIN]'>[makeStrippingButton(clothing[SLOT_MANNEQUIN_BELT])]</A>"
+	. += "<BR><B>Pants:</B> <A href='byond://?src=[REF(src)];command=item_placement;item_slot=[SLOT_MANNEQUIN_PANTS]'>[makeStrippingButton(clothing[SLOT_MANNEQUIN_PANTS])]</A>" //No direct slot to equip.
 	. += "<BR><B>Ring:</B> <A href='byond://?src=[REF(src)];command=item_placement;item_slot=[SLOT_MANNEQUIN_RING]'>[makeStrippingButton(clothing[SLOT_MANNEQUIN_RING])]</A>" //No direct slot to equip.
 
 /obj/structure/mannequin/attackby(obj/item/I, mob/user)


### PR DESCRIPTION
## About The Pull Request

- Mannequins could spawn equipped with pants, but they're not accessible. Fixes that. Do note that it may not display the pants on the sprite. Intentional.

## Testing Evidence

<img width="515" height="478" alt="Screenshot_1" src="https://github.com/user-attachments/assets/7d1cb6e7-d75e-4cc7-a7ab-e7139a01c79b" />

## Why It's Good For The Game

Fugbixes.

## Changelog
:cl:
fix: fixed mannequins not having pants slot
/:cl: