### PR TITLE
[Fix] Prosthetics Oddities

### DIFF
--- a/code/modules/roguetown/roguejobs/engineer/prosthetic.dm
+++ b/code/modules/roguetown/roguejobs/engineer/prosthetic.dm
@@ -349,6 +349,7 @@
 	brute_reduction = 0
 	burn_reduction = 0
 	max_damage = 40
+	organ_slowdown = 0.05 // -5%
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
 	anvilrepair = /datum/skill/craft/carpentry
@@ -366,7 +367,7 @@
 	max_damage = 150
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
-	organ_slowdown = 1.2
+	organ_slowdown = 0.2 // -20%
 	brute_reduction = 5
 	burn_reduction = 5
 	anvilrepair = /datum/skill/craft/engineering
@@ -384,7 +385,7 @@
 	max_damage = 200
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
-	organ_slowdown = 1.1
+	organ_slowdown = 0.1 // -10%
 	brute_reduction = 10
 	burn_reduction = 10
 	anvilrepair = /datum/skill/craft/engineering
@@ -404,6 +405,7 @@
 	max_damage = 220
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
+	organ_slowdown = 0.15 // -15%
 	anvilrepair = /datum/skill/craft/engineering
 	smeltresult = /obj/item/ingot/bronze
 
@@ -438,6 +440,7 @@
 	brute_reduction = 0
 	burn_reduction = 0
 	max_damage = 40
+	organ_slowdown = 0.05 // -5%
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
 	anvilrepair = /datum/skill/craft/carpentry
@@ -456,7 +459,7 @@
 	max_damage = 150
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
-	organ_slowdown = 1.2
+	organ_slowdown = 0.2 // -20%
 	brute_reduction = 5
 	burn_reduction = 5
 	anvilrepair = /datum/skill/craft/engineering
@@ -475,7 +478,7 @@
 	max_damage = 200
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
-	organ_slowdown = 1.1
+	organ_slowdown = 0.1 // -10%
 	brute_reduction = 10
 	burn_reduction = 10
 	anvilrepair = /datum/skill/craft/engineering
@@ -496,6 +499,7 @@
 	max_damage = 220
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
+	organ_slowdown = 0.15 // -15%
 	anvilrepair = /datum/skill/craft/engineering
 	smeltresult = /obj/item/ingot/bronze
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -85,7 +85,7 @@
 	var/skeletonized = FALSE
 
 	var/fingers = TRUE
-	var/organ_slowdown = 0 // Its here because this is first shared definition between two leg organ paths
+	var/organ_slowdown = 0 // Its here because this is first shared definition between two leg organ paths // NOTE for future: The value starts at 0, example flavor of -10% is 0.1, so on.
 	var/is_prosthetic = FALSE
 
 	/// Visaul markings to be rendered alongside the bodypart

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -342,30 +342,33 @@
 
 /datum/virtue/utility/bronzelimbs/apply_to_human(mob/living/carbon/human/recipient)
 	. = ..()
-	if(triumph_check(recipient))
-		var/obj/item/bodypart/to_attach
-		var/zone
-		for(var/choice in picked_choices)
-			switch(choice)
-				if("Right Arm")
-					to_attach = /obj/item/bodypart/r_arm/prosthetic/bronzeright
-					zone = BODY_ZONE_R_ARM
-				if("Left Arm")
-					to_attach = /obj/item/bodypart/l_arm/prosthetic/bronzeleft
-					zone = BODY_ZONE_L_ARM
-				if("Right Leg")
-					to_attach = /obj/item/bodypart/r_leg/prosthetic/bronzeright
-					zone = BODY_ZONE_R_LEG
-				if("Left Leg")
-					to_attach = /obj/item/bodypart/l_leg/prosthetic/bronzeleft
-					zone = BODY_ZONE_L_LEG
-			var/obj/item/bodypart/O = recipient.get_bodypart(zone)
-			if(O)
-				O.drop_limb()
-				qdel(O)
-			if(recipient.charflaws.len)
-				var/obj/item/bodypart/BP = new to_attach()
-				BP.attach_limb(recipient)
+	if(!triumph_check(recipient))
+		to_chat(recipient, span_warning("Sorry Ser, we don't \"give\" credit. Come back when you're a little, mmmmm... TRIUMPHant."))
+		return
+	for(var/choice in picked_choices)
+		var/to_attach = null
+		var/zone = null
+		switch(choice)
+			if("Right Arm")
+				to_attach = /obj/item/bodypart/r_arm/prosthetic/bronzeright
+				zone = BODY_ZONE_R_ARM
+			if("Left Arm")
+				to_attach = /obj/item/bodypart/l_arm/prosthetic/bronzeleft
+				zone = BODY_ZONE_L_ARM
+			if("Right Leg")
+				to_attach = /obj/item/bodypart/r_leg/prosthetic/bronzeright
+				zone = BODY_ZONE_R_LEG
+			if("Left Leg")
+				to_attach = /obj/item/bodypart/l_leg/prosthetic/bronzeleft
+				zone = BODY_ZONE_L_LEG
+		if(!to_attach || !zone)
+			continue
+		var/obj/item/bodypart/old_limb = recipient.get_bodypart(zone)
+		if(old_limb)
+			old_limb.drop_limb()
+			qdel(old_limb)
+		var/obj/item/bodypart/new_limb = new to_attach()
+		new_limb.attach_limb(recipient)
 
 /datum/virtue/utility/woodwalker
 	name = "Woodwalker"


### PR DESCRIPTION
## About The Pull Request

- Fixes the movespeed penalty being set wrongly to 110% when the value should have been 10%, etc.
- Fixes an additional weirdness that was making you spawn without your bronze limbs, they just qdel'd and you stood there like a nugget by refactoring the proc. (Likely was caused when we got Overclock added).

## Testing Evidence

<img width="276" height="243" alt="Screenshot_3" src="https://github.com/user-attachments/assets/10bfcc12-610c-4c0c-aca1-6b7ff1d37c95" />

## Why It's Good For The Game

Fug Bixes.

## Changelog
:cl:
fix: fixed prosthetics having the wrong speed malus value, and weirdness with Bronze Limbs virtue
/:cl: