### PR TITLE
[Hag] - Transmutation spell description & hag tree moss autoharvesting.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_spells.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_spells.dm
@@ -81,6 +81,26 @@
 		boon_html += "</details>"
 		. += boon_html
 
+/obj/effect/proc_holder/spell/invoked/transmutation_rite/get_spell_statistics(mob/living/user)
+	. = ..()
+	. += "THE ART OF GIVING AND TAKING"
+	. += "═══════════════════════════"
+	. += "BOON CAPACITY:"
+	. += "  • Tier 1: Up to 60 points of boons"
+	. += "  • Tier 2: Up to 85 points of boons"
+	. += "  • Tier 3: Up to 110 points of boons"
+	. += ""
+	. += "PROGRESSION:"
+	. += "  • Curse 1 person → Tier 2 (Requires 20 points)"
+	. += "  • Curse 2 people → Tier 3 (Requires 60 points total)"
+	. += ""
+	. += "AFFECTED TARGETS:"
+	. += "  • Positive Boons: 4/5/6 people (scales with tier)"
+	. += ""
+	. += "Use this rite to view the boons that you have granted to allies,"
+	. += "or twist your gifts into curses against your enemies."
+	. += "<span class='notice'>Alt-click to reskin it.</span>"
+
 /obj/effect/proc_holder/spell/invoked/transmutation_rite
 	name = "Transmutation"
 	//var/mob/living/target_victim

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_tree.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_tree.dm
@@ -122,75 +122,72 @@
 		return
 	// Actual Harvesting
 	if(href_list["harvest"])
-	var/path = text2path(href_list["harvest"])
-	var/is_hag = text2num(href_list["hag"])
-	var/list/stock = is_hag ? hag_stock : public_stock
+		var/path = text2path(href_list["harvest"])
+		var/is_hag = text2num(href_list["hag"])
+		var/list/stock = is_hag ? hag_stock : public_stock
 	
-	if(harvesting) return
+		if(harvesting)
+			return
 	
-	harvesting = TRUE
-	var/harvest_count = 0
-	var/current_path = path
+		harvesting = TRUE
+		var/harvest_count = 0
+		var/current_path = path
 	
-	// Keep harvesting until all stock is empty or user stops
-	while(TRUE)
-		// Check if user is still alive and nearby
-		if(!usr || QDELETED(usr) || !usr.canUseTopic(src, BE_CLOSE))
-			break
-			
-		// Check if current path has stock
-		if(stock[current_path] <= 0)
-			// Find any non-empty path
-			var/found = FALSE
-			for(var/p in stock)
-				if(stock[p] > 0)
-					current_path = p
-					found = TRUE
-					break
-			if(!found)
-				break // No more moss available
-		
-		to_chat(usr, span_notice("You continue to knit the moss from the roots..."))
-		
-		if(!do_after(usr, 1 SECONDS, target = src))
-			break // User stopped or was interrupted
-			
-		if(stock[current_path] > 0)
-			stock[current_path]--
-			harvest_count++
-			
-			var/obj/structure/roguemachine/mossmother/destination_tree = null
-			var/is_fey = HAS_TRAIT(usr, TRAIT_FEYTOUCHED)
-			if(is_fey)
-				for(var/obj/structure/roguemachine/mossmother/T in GLOB.hag_trees)
-					var/area/A = get_area(T)
-					if(istype(A, /area/rogue/indoors/shelter/bog_hag))
-						destination_tree = T
+		// Keep harvesting until all stock is empty or user stops
+		while(TRUE)
+			// Check if user is still alive and nearby
+			if(!usr || QDELETED(usr) || !usr.canUseTopic(src, BE_CLOSE))
+				break
+
+			// Check if current path has stock
+			if(stock[current_path] <= 0)
+				// Find any non-empty path
+				var/found = FALSE
+				for(var/p in stock)
+					if(stock[p] > 0)
+						current_path = p
+						found = TRUE
 						break
-						
-			if((is_fey || is_hag) && destination_tree)
-				new current_path(get_turf(destination_tree))
-				if(is_fey && prob(30))
-					to_chat(usr, span_notice("The moss dissolves into the roots, flowing back toward the Hag's hearth as a silent tribute..."))
-				var/obj/effect/temp_visual/heal/H_energy = new /obj/effect/temp_visual/heal_rogue/hag(get_turf(destination_tree))
-				H_energy.color = "#4b5320"
-			else
-				new current_path(get_turf(src))
-				
-		// Small delay between harvests for readability
-		//sleep(1)
-	
-	harvesting = FALSE
-	
-	if(harvest_count > 0)
-		to_chat(usr, span_notice("You harvested [harvest_count] pieces of moss."))
-	else
-		to_chat(usr, span_warning("You stop harvesting."))
-	
-	// Refresh the specific window with updated stock
-	var/datum/browser/popup = new(usr, "moss_window", (is_hag ? "THE VEIL OF ROOTS" : "COMMON BLOSSOMS"), 400, 500)
-	popup.set_content(get_contents(is_hag))
-	popup.open()
+				if(!found)
+					break // No more moss available
+
+			to_chat(usr, span_notice("You continue to knit the moss from the roots..."))
+
+			if(!do_after(usr, 1 SECONDS, target = src))
+				break // User stopped or was interrupted
+
+			if(stock[current_path] > 0)
+				stock[current_path]--
+				harvest_count++
+
+				var/obj/structure/roguemachine/mossmother/destination_tree = null
+				var/is_fey = HAS_TRAIT(usr, TRAIT_FEYTOUCHED)
+				if(is_fey)
+					for(var/obj/structure/roguemachine/mossmother/T in GLOB.hag_trees)
+						var/area/A = get_area(T)
+						if(istype(A, /area/rogue/indoors/shelter/bog_hag))
+							destination_tree = T
+							break
+
+				if((is_fey || is_hag) && destination_tree)
+					new current_path(get_turf(destination_tree))
+					if(is_fey && prob(30))
+						to_chat(usr, span_notice("The moss dissolves into the roots, flowing back toward the Hag's hearth as a silent tribute..."))
+					var/obj/effect/temp_visual/heal/H_energy = new /obj/effect/temp_visual/heal_rogue/hag(get_turf(destination_tree))
+					H_energy.color = "#4b5320"
+				else
+					new current_path(get_turf(src))
+		harvesting = FALSE
+
+		if(harvest_count > 0)
+			to_chat(usr, span_notice("You harvested [harvest_count] pieces of moss."))
+		else
+			to_chat(usr, span_warning("You stop harvesting."))
+
+		// Refresh the specific window with updated stock
+		var/datum/browser/popup = new(usr, "moss_window", (is_hag ? "THE VEIL OF ROOTS" : "COMMON BLOSSOMS"), 400, 500)
+		popup.set_content(get_contents(is_hag))
+		popup.open()
 
 /obj/structure/roguemachine/mossmother/attack_hand(mob/living/user)
 	if(..()) 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_tree.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_tree.dm
@@ -122,42 +122,75 @@
 		return
 	// Actual Harvesting
 	if(href_list["harvest"])
-		var/path = text2path(href_list["harvest"])
-		var/is_hag = text2num(href_list["hag"])
-		var/list/stock = is_hag ? hag_stock : public_stock
+	var/path = text2path(href_list["harvest"])
+	var/is_hag = text2num(href_list["hag"])
+	var/list/stock = is_hag ? hag_stock : public_stock
+	
+	if(harvesting) return
+	
+	harvesting = TRUE
+	var/harvest_count = 0
+	var/current_path = path
+	
+	// Keep harvesting until all stock is empty or user stops
+	while(TRUE)
+		// Check if user is still alive and nearby
+		if(!usr || QDELETED(usr) || !usr.canUseTopic(src, BE_CLOSE))
+			break
+			
+		// Check if current path has stock
+		if(stock[current_path] <= 0)
+			// Find any non-empty path
+			var/found = FALSE
+			for(var/p in stock)
+				if(stock[p] > 0)
+					current_path = p
+					found = TRUE
+					break
+			if(!found)
+				break // No more moss available
 		
-		if(harvesting || stock[path] <= 0) return
-
-		harvesting = TRUE
-		to_chat(usr, span_notice("You begin to carefully knit the moss from the roots..."))
+		to_chat(usr, span_notice("You continue to knit the moss from the roots..."))
 		
-		if(do_after(usr, 1 SECONDS, target = src))
-			if(stock[path] > 0)
-				stock[path]--
-				var/obj/structure/roguemachine/mossmother/destination_tree = null
-				var/is_fey = HAS_TRAIT(usr, TRAIT_FEYTOUCHED)
-				if(is_fey)
-					for(var/obj/structure/roguemachine/mossmother/T in GLOB.hag_trees)
-						var/area/A = get_area(T)
-						if(istype(A, /area/rogue/indoors/shelter/bog_hag))
-							destination_tree = T
-							break
-				if((is_fey || is_hag) && destination_tree)
-					new path(get_turf(destination_tree))
-					if(is_fey && prob(30))
-						to_chat(usr, span_notice("The moss dissolves into the roots, flowing back toward the Hag's hearth as a silent tribute..."))
-					var/obj/effect/temp_visual/heal/H_energy = new /obj/effect/temp_visual/heal_rogue/hag(get_turf(destination_tree))
-					H_energy.color = "#4b5320"
-				else
-					// Standard harvest (Mortal or if the Hut Tree somehow doesn't exist)
-					new path(get_turf(src))
-					to_chat(usr, span_notice("You successfully pluck the moss."))
-
-		harvesting = FALSE
-		// Refresh the specific window
-		var/datum/browser/popup = new(usr, "moss_window", (is_hag ? "THE VEIL OF ROOTS" : "COMMON BLOSSOMS"), 400, 500)
-		popup.set_content(get_contents(is_hag))
-		popup.open()
+		if(!do_after(usr, 1 SECONDS, target = src))
+			break // User stopped or was interrupted
+			
+		if(stock[current_path] > 0)
+			stock[current_path]--
+			harvest_count++
+			
+			var/obj/structure/roguemachine/mossmother/destination_tree = null
+			var/is_fey = HAS_TRAIT(usr, TRAIT_FEYTOUCHED)
+			if(is_fey)
+				for(var/obj/structure/roguemachine/mossmother/T in GLOB.hag_trees)
+					var/area/A = get_area(T)
+					if(istype(A, /area/rogue/indoors/shelter/bog_hag))
+						destination_tree = T
+						break
+						
+			if((is_fey || is_hag) && destination_tree)
+				new current_path(get_turf(destination_tree))
+				if(is_fey && prob(30))
+					to_chat(usr, span_notice("The moss dissolves into the roots, flowing back toward the Hag's hearth as a silent tribute..."))
+				var/obj/effect/temp_visual/heal/H_energy = new /obj/effect/temp_visual/heal_rogue/hag(get_turf(destination_tree))
+				H_energy.color = "#4b5320"
+			else
+				new current_path(get_turf(src))
+				
+		// Small delay between harvests for readability
+		//sleep(1)
+	
+	harvesting = FALSE
+	
+	if(harvest_count > 0)
+		to_chat(usr, span_notice("You harvested [harvest_count] pieces of moss."))
+	else
+		to_chat(usr, span_warning("You stop harvesting."))
+	
+	// Refresh the specific window with updated stock
+	var/datum/browser/popup = new(usr, "moss_window", (is_hag ? "THE VEIL OF ROOTS" : "COMMON BLOSSOMS"), 400, 500)
+	popup.set_content(get_contents(is_hag))
+	popup.open()
 
 /obj/structure/roguemachine/mossmother/attack_hand(mob/living/user)
 	if(..()) 


### PR DESCRIPTION
## About The Pull Request
- Hag transmutation spell now explains how boon tiers work.
- Harvesting moss from a category will now keep harvesting until that category is empty, to reduce the amount of clicks a hag needs to push themselves through from about 50 per serious harvest round to 12. 

## Testing Evidence
<img width="696" height="667" alt="image" src="https://github.com/user-attachments/assets/909c05d6-b987-4b16-bae3-3f0765781313" />
I got zesty with it.

## Why It's Good For The Game
Better explain the role and their powers to hags, as well as making it less tedious to play.

## Changelog

:cl:
add: Hag moss autoharvest.
qol: Hag transmutation now explains the boon tiers better.
/:cl:
