### PR TITLE
[Fix] Light Sunderbolts outputted as normal Sunderbolts

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
@@ -64,10 +64,25 @@
 	name = "light sunderbolt"
 	desc = "A compact silver-tipped bolt, containing a small vial of holy water. Though it inflicts lesser wounds on living flesh, it exceeds when \
 	employed against the unholy; a snap and a crack, followed by a fiery surprise. </br>'One baptism for the remission of sins.'"
-	projectile_type = /obj/projectile/bullet/reusable/bolt/holy //Most of the effectiveness comes from the debuffs, rather than the damage itself. Simple, but sweet.
+	projectile_type = /obj/projectile/bullet/reusable/bolt/light/holy //Most of the effectiveness comes from the debuffs, rather than the damage itself. Simple, but sweet.
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust)
 	caliber = "lightbolt"
 	icon_state = "light_bolt_holywater"
+
+/obj/projectile/bullet/reusable/bolt/light/holy
+	name = "light sunderbolt"
+	damage = 35
+	icon_state = "bolthwater_proj"
+	ammo_type = /obj/item/ammo_casing/caseless/rogue/bolt/lightholy
+	embedchance = 100
+	poisontype = /datum/reagent/water/blessed
+	poisonamount = 7
+	is_silver_proj = TRUE
+	npc_simple_damage_mult = 5
+	speed = 0.8
+	min_range = MIN_BOLT_RANGE - 1
+	max_range = MAX_BOLT_RANGE - 1
+	dam_falloff_factor = DAM_FALLOFF_BOLT
 
 /obj/projectile/bullet/reusable/bolt
 	name = "bolt"


### PR DESCRIPTION
## About The Pull Request

- Fixes an oversight where after firing a Light Sunderbolt from a Slurbow, it would transform into a normal Sunderbolt without the proper /light path.

## Testing Evidence

<img width="1085" height="584" alt="Screenshot_7" src="https://github.com/user-attachments/assets/7c019af1-f3b9-4ed1-8cf9-afff669ccee5" />

## Why It's Good For The Game

Fug Bixes.

## Changelog
:cl:
fix: fixed light sunderbolts
/:cl: