### PR TITLE
[Fix] Apothecary has the wrong skill

### DIFF
--- a/code/modules/jobs/job_types/roguetown/burghers/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/apothecary.dm
@@ -52,7 +52,7 @@
 	)
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE, //enhances survival chances.
+		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE, //enhances survival chances.
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_NOVICE,


### PR DESCRIPTION
## About The Pull Request

- Apothecary has Polearms instead of Staves, and spawn with a staff. Either oversight, someone trying to cheese the system, or at some point polearms and staves got separated but this was never updated.

## Testing Evidence

1 value change.

## Why It's Good For The Game

Consistency. 

## Changelog
:cl:
fix: Apothecary gets staves instead of polearms
/:cl: