### PR TITLE
[Fix] Freifetcher Halfsword block fix

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -461,6 +461,30 @@
 	sheathe_icon = "reform"
 	icon_state = "reformistsword"
 
+/obj/item/rogueweapon/sword/long/etruscan/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the projectile", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, args)
+	var/mob/attacker
+	var/obj/item/I
+	if(attack_type == THROWN_PROJECTILE_ATTACK)
+		if(istype(hitby, /obj/item)) // can't trust mob -> item assignments
+			I = hitby
+		if(I?.thrownby)
+			attacker = I.thrownby
+	if(attack_type == PROJECTILE_ATTACK)
+		var/obj/projectile/P = hitby
+		if(P?.firer)
+			attacker = P.firer
+	if(attacker && istype(attacker))
+		if (!owner.can_see_cone(attacker))
+			return FALSE
+		if(obj_broken)
+			return FALSE
+		if((owner.client?.chargedprog == 100 && owner.used_intent?.tranged) || prob(40)) // let's give it a 40% coverage, it's still something thinner than a shield
+			owner.visible_message(span_danger("[owner] expertly blocks [hitby] with [src]!"))
+			src.take_damage(floor(damage / 4))
+			return TRUE
+	return FALSE
+
 /obj/item/rogueweapon/sword/long/fencerguy
 	name = "grenzelhoftian longsword"
 	desc = "A masterfully smithed, perfectly-balanced longsword that makes it easy for even a beginner to perform basic fencing maneuvers."


### PR DESCRIPTION
## About The Pull Request

- Looks like Etruscan swords didn't have the same HitReaction() as shields, now they do.

## Testing Evidence

<img width="1335" height="620" alt="Screenshot_12" src="https://github.com/user-attachments/assets/4f8efd5c-6ae7-4622-ae3f-0aff9dd17fdc" />

## Why It's Good For The Game

Fug Bixes.

## Changelog
:cl:
fix: frei swords can now block projectiles on halfsword intent's block
/:cl: