### PR TITLE
[Event] Re enables zizo's pet cemetery

### DIFF
--- a/code/modules/events/god_intervention/zizo.dm
+++ b/code/modules/events/god_intervention/zizo.dm
@@ -13,13 +13,11 @@
 
 /datum/round_event_control/zizo_pet_cementery
 	name = "Zizo's Pet Cementery"
-	track = EVENT_TRACK_INTERVENTION
 	typepath = /datum/round_event/zizo_pet_cementery
-	weight = 8
+	weight = 6
 	earliest_start = 25 MINUTES
 	max_occurrences = 2
 	min_players = 35
-	allowed_storytellers = list(/datum/storyteller/zizo)
 
 /datum/round_event/zizo_pet_cementery/start()
 	//Long duration but you might not even notice it.


### PR DESCRIPTION
## About The Pull Request
- Reenables Zizo's pet cemetery, which causes all deadite-able corpses to deadite, and deadite quickly when it rolls.
- Adjusted the weight downwards a bit to compensate for it being able to run on any round type.
- Runs on the moderate event track.

## Testing Evidence
Simply lets the inheritance of the basetype take over, should work fine.

## Why It's Good For The Game
The even was never meant to be disabled, but when storytellers got reworked, so did the event get disabled in the crossfire since zizo is no longer a storyteller that -can- roll as gamemodes have taken over. I'm simply re-enabling it.

## Changelog

:cl:
fix: zizo's pet cemetery event being unable to run
/:cl:
