### PR TITLE
some archer nerfs n some projectile buffs

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -1162,7 +1162,7 @@
 	armor_penetration = PEN_MEDIUM
 	wdefense = 1
 	icon_state = "throw_knifei"
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 25, "embedded_fall_chance" = 10)
+	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 80, "embedded_fall_chance" = 10)
 	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/cut, /datum/intent/dagger/chop)
 	smeltresult = null
 	thrown_damage_flag = "piercing"		//Checks piercing type like an arrow.

--- a/code/game/objects/items/rogueweapons/ranged/_ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/_ammo.dm
@@ -8,6 +8,33 @@
 	. = ..()
 	. += span_info("Projectiles have maximum and minimum falloff ranges, with particular falloff factors for damage.")
 	. += span_info("If the target is hit between the maximum and minimum tile range, then the full force is delivered.")
+	. += get_sweetspot_examine()
+
+/// Returns examine lines describing the sweetspot (full-force range) of this casing's projectile, or an empty list if it has none.
+/obj/item/ammo_casing/proc/get_sweetspot_examine(subject = "This projectile")
+	var/sweet_min
+	var/sweet_max
+	var/falloff
+	if(BB)
+		sweet_min = BB.min_range
+		sweet_max = BB.max_range
+		falloff = BB.dam_falloff_factor
+	else if(projectile_type)
+		var/obj/projectile/proj = projectile_type
+		sweet_min = initial(proj.min_range)
+		sweet_max = initial(proj.max_range)
+		falloff = initial(proj.dam_falloff_factor)
+	. = list()
+	if(!sweet_min && !sweet_max)
+		return
+	if(sweet_min && sweet_max)
+		. += span_info("[subject] has a sweetspot between <b>[sweet_min]</b> and <b>[sweet_max]</b> tiles, where it delivers full force.")
+	else if(sweet_max)
+		. += span_info("[subject] has a sweetspot up to <b>[sweet_max]</b> tiles, where it delivers full force.")
+	else
+		. += span_info("[subject] has a sweetspot beyond <b>[sweet_min]</b> tiles, where it delivers full force.")
+	if(falloff != 1)
+		. += span_info("Outside the sweetspot, its damage is reduced to <b>[falloff * 100]%</b>.")
 
 /obj/item/ammo_casing/caseless/rogue/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
@@ -128,7 +128,7 @@
 /obj/projectile/bullet/reusable/arrow/iron
 	name = "broadhead arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/iron
-	damage = 50
+	damage = 55
 	armor_penetration = PEN_LIGHT
 	flag = "piercing"
 	embedchance = 30
@@ -139,7 +139,7 @@
 	name = "decrepit broadhead arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/iron/aalloy
 	icon_state = "ancientarrow_proj"
-	damage = 50
+	damage = 55
 	armor_penetration = PEN_LIGHT
 	flag = "piercing"
 
@@ -150,7 +150,7 @@
 	name = "bodkin arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/steel
 	accuracy = 75
-	damage = 25
+	damage = 30
 	armor_penetration = PEN_HEAVY
 	embedchance = 80 // Easy embeds!
 	npc_simple_damage_mult = 3
@@ -161,7 +161,7 @@
 	name = "ancient bodkin arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/steel/paalloy
 	icon_state = "ancientarrow_proj"
-	damage = 30
+	damage = 35
 	armor_penetration = PEN_HEAVY
 	embedchance = 60
 

--- a/code/game/objects/items/rogueweapons/ranged/bows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/bows.dm
@@ -123,6 +123,7 @@
 	var/spill_ammo_on_drop = TRUE
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/get_mechanics_examine(mob/user)
+	. = ..()
 	. += span_info("Bows increase in damage and accuracy the higher your <b>PERCEPTION</b>.")
 	. += span_info("Bows with a heavy draw, such as longbows, have an increased draw time for characters with low <b>STRENGTH</b>.")
 

--- a/code/game/objects/items/rogueweapons/ranged/slings.dm
+++ b/code/game/objects/items/rogueweapons/ranged/slings.dm
@@ -106,6 +106,7 @@
 	var/bonus_stone_force = 0 //above comment is relevant. a magical stone's bonus force is kept on the sling itself and changed accordingly
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/sling/get_mechanics_examine(mob/user)
+	. = ..()
 	. += span_info("Slings increase in damage and accuracy the higher your <b>PERCEPTION</b> and <b>STRENGTH</b>.")
 	. += span_info("Slings can be loaded directly from a pouch while your offhand is occupied by another item.")
 

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -18,6 +18,11 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/proc/get_npc_chargetime(mob/living/user)
 	return ARCHER_NPC_SIMULATED_CHARGETIME
 
+/obj/item/gun/ballistic/revolver/grenadelauncher/get_mechanics_examine(mob/user)
+	. = ..()
+	if(chambered)
+		. += chambered.get_sweetspot_examine("The loaded [chambered.name]")
+
 /obj/item/gun/ballistic/revolver/grenadelauncher/attackby(obj/item/A, mob/user, params)
 	. = ..()
 	if(istype(A, /obj/item/ammo_box) || istype(A, /obj/item/ammo_casing))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -159,9 +159,9 @@
 	var/accuracy = 65 //How likely the project will hit it's intended target area. Decreases over distance moved, increased from perception.
 	var/bonus_accuracy = 0 //bonus accuracy that cannot be affected by range drop off.
 
-	/// Min tile distance for full damage/AP.
+	/// Min tile distance for full damage.
 	var/min_range = 0
-	/// Max tile distance for full damage/AP.
+	/// Max tile distance for full damage.
 	var/max_range = 0
 	/// Falloff factor for damage. Multiplicative.
 	var/dam_falloff_factor = 1


### PR DESCRIPTION
## About The Pull Request
Bodkins and broadheads do +5 more damage. Knives get 80% embedchance (they became useless when i fixed embeds)

You can now examine a projectile or the weapon with the projectile chambered to check and see their sweetspot + damage reduction.

## Testing Evidence

in game testing

## Why It's Good For The Game

not gonna do the DE kill just yet ig.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Throwing knives have 80% embed chance.
balance: Broadheads and Bodkins do +5 damage.
qol: Examining a projectile, or a bow/xbow with a projectile will show you the sweetspot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
