### PR TITLE
admins and non-gamemode votes no longer require readying up

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -28,6 +28,8 @@ SUBSYSTEM_DEF(vote)
 	var/list/storyteller_vote_log = list()
 	var/list/generated_actions = list()
 	var/static/list/everyone_is_equal = list("custom")
+	/// Vote types that require lobby players to ready up before voting.
+	var/static/list/ready_required_modes = list("gamemode", "storyteller")
 
 /datum/controller/subsystem/vote/fire()	//called by master_controller
 	if(mode)
@@ -375,6 +377,10 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/proc/can_client_vote(client/C)
 	if(isnull(C))
 		return FALSE
+	if(C.holder)
+		return TRUE
+	if(!(mode in ready_required_modes))
+		return TRUE
 	if(istype(C.mob, /mob/dead/new_player))
 		var/mob/dead/new_player/NP = C.mob
 		if(NP.ready != PLAYER_READY_TO_PLAY)


### PR DESCRIPTION
## About The Pull Request

as it says on the tin

## Testing Evidence

should be fine

## Why It's Good For The Game

forgor this

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Admins don't need to ready up to vote.
qol: End round votes can be done from lobby now again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
