### PR TITLE
Remove Frei damage floor

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -195,7 +195,6 @@
 	damfactor = 1.2
 	penfactor = PEN_LIGHT // Master cut — cuts are for damaging armor, not penning it. Leave pen to the stabbin'
 	max_intent_damage = 36
-	min_intent_damage = 31
 	swingdelay = 2 //sure
 
 /datum/intent/sword/thrust/long/master


### PR DESCRIPTION
## About The Pull Request

Freifechter sword intents no longer have a minimum damage floor.

## Testing Evidence

numbers change

## Why It's Good For The Game

Most Freifechter mains exclusively run Wary because of that specific gimmick of having a set minimum damage they can deal. This effectively allows them to dodge any downsides of having low STR aside from charging and grabs, both of which can be relatively easily avoided or punished. 

## Changelog
balance: Freifechter Lancer swords no longer have a set minimum damage treshold.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
