### PR TITLE
[BugFix] Siegebow zombie wall fix

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
@@ -228,7 +228,7 @@
 	var/turf/T = target
 	if(isturf(target))
 		explosion(T, heavy_impact_range = 0, light_impact_range = 0, flame_range = 0, smoke = FALSE, soundin = pick('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg'))
-		loud_message("A loud crash echoes from the", hearing_distance = 14)
+		loud_message("A loud crash echoes", hearing_distance = 14)
 		return
 
 /obj/item/ammo_casing/caseless/rogue/heavy_bolt/blunt

--- a/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
@@ -228,10 +228,7 @@
 	var/turf/T = target
 	if(isturf(target))
 		explosion(T, heavy_impact_range = 0, light_impact_range = 0, flame_range = 0, smoke = FALSE, soundin = pick('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg'))
-		loud_message("A loud crash echoes", hearing_distance = 14)
-		if(istype(T, /turf/closed/mineral/rogue/bedrock))
-			return
-		T.turf_integrity -= 1100
+		loud_message("A loud crash echoes from the", hearing_distance = 14)
 		return
 
 /obj/item/ammo_casing/caseless/rogue/heavy_bolt/blunt


### PR DESCRIPTION
## About The Pull Request

If the siegebow doesn't destroy a wall in the first hit, it creates a zombie wall that becomes immortal.
This fixes the bug I introduced and now siegebows destroy walls as intended. Whoopsie :)

## Testing Evidence

I shot a bunch of walls, they all died as expected. Zero zombie walls.

## Why It's Good For The Game

Fixes a bug

## Changelog

:cl:
fix: Fixes siege bow zombie walls
/:cl:
