### PR TITLE
[QoL / Exploit] Fix exploit with loadout items, changes triumph items logic

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -44,18 +44,11 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		apply_dnr_trait(character, player)
 	if(player.prefs.qsr_pref)
 		apply_qsr_trait(character, player)
-	var/triumph_discount_remaining = is_donator(player.ckey) ? 3 : 0 // donators get first 3 triumph points free
+	character.mind.triumph_discount_remaining = is_donator(player.ckey) ? 3 : 0 // donators get first 3 triumph points free, spent on retrieval
 	for(var/item_name in player.prefs.gear_list)
 		var/datum/loadout_item/LI = GLOB.loadout_items_by_name[item_name]
 		if(!LI)
 			continue
-		if(LI.triumph_cost)
-			var/discounted_cost = max(0, LI.triumph_cost - triumph_discount_remaining)
-			if(discounted_cost > 0 && character.get_triumphs() < discounted_cost)
-				continue
-			triumph_discount_remaining = max(0, triumph_discount_remaining - LI.triumph_cost)
-			if(discounted_cost > 0)
-				character.adjust_triumphs(-discounted_cost)
 		character.mind.special_items[LI.name] = LI.path
 	var/datum/job/assigned_job = SSjob.GetJob(character.mind?.assigned_role)
 	if(assigned_job)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -138,6 +138,9 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	var/has_bomb = FALSE
 	var/has_drug_delivery = FALSE
 
+	/// Triumph discount for donators
+	var/triumph_discount_remaining = 0
+
 /datum/mind/New(key)
 	key = key
 	soulOwner = src
@@ -1242,27 +1245,31 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	personal_objectives.Cut()
 
 /proc/handle_special_items_retrieval(mob/user, atom/host_object)
-	// Attempts to retrieve an item from a player's stash, and applies any base colors, where preferable.
 	if(user.mind && isliving(user))
 		if(user.mind.special_items && user.mind.special_items.len)
 			var/item = input(user, "What will I take?", "STASH") as null|anything in user.mind.special_items
 			if(item)
 				if(user.Adjacent(host_object))
 					if(user.mind.special_items[item])
+						var/datum/loadout_item/LI = GLOB.loadout_items_by_name[item]
+						if(LI?.triumph_cost)
+							var/discounted_cost = max(0, LI.triumph_cost - user.mind.triumph_discount_remaining)
+							if(discounted_cost > 0 && user.get_triumphs() < discounted_cost)
+								to_chat(user, span_warning("I can't afford [item] — I'd need [discounted_cost] more triumph."))
+								return
+							user.mind.triumph_discount_remaining = max(0, user.mind.triumph_discount_remaining - LI.triumph_cost)
+							if(discounted_cost > 0)
+								user.adjust_triumphs(-discounted_cost)
 						var/path2item = user.mind.special_items[item]
 						user.mind.special_items -= item
 						var/obj/item/I = new path2item(user.loc)
 						user.put_in_hands(I)
-						// Apply loadout-specific properties only if this is a loadout item
+						if(!LI?.triumph_cost)
+							I.special_item = TRUE
+							I.smeltresult = /obj/item/ash
+							I.salvage_result = /obj/item/ash
 						var/list/metadata = user.client?.prefs?.gear_list?[item]
 						if(islist(metadata))
-							// Free loadout items cannot be sold, smelted, or salvaged (triumph items are exempt)
-							var/datum/loadout_item/LI = GLOB.loadout_items_by_name[item]
-							if(!LI?.triumph_cost)
-								I.special_item = TRUE
-								I.smeltresult = /obj/item/ash
-								I.salvage_result = /obj/item/ash
-							// Apply metadata (color, custom name, custom desc)
 							if(metadata["color"])
 								I.add_atom_colour(metadata["color"], FIXED_COLOUR_PRIORITY)
 							if(metadata["detail_color"] && I.detail_tag)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1259,7 +1259,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 							// Free loadout items cannot be sold, smelted, or salvaged (triumph items are exempt)
 							var/datum/loadout_item/LI = GLOB.loadout_items_by_name[item]
 							if(!LI?.triumph_cost)
-								I.sellprice = 0
+								I.special_item = TRUE
 								I.smeltresult = /obj/item/ash
 								I.salvage_result = /obj/item/ash
 							// Apply metadata (color, custom name, custom desc)

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -30,6 +30,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/static_price = FALSE
 	var/looted = FALSE
 	var/no_loot_taint = FALSE
+	/// An item spawned via the handle_special_items_retrieval proc, that is not triumph
+	var/special_item = FALSE
 
 /atom/movable/proc/randomize_price()
 	if(sellprice)
@@ -39,6 +41,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	return sellprice
 
 /atom/movable/proc/get_real_price()
+	if (special_item)
+		return 0
 	if(sellprice == initial(sellprice))
 		randomize_price()
 	if(!static_price && !sellprice && initial(sellprice) == 0)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Triumph cost for loadout items is now deducted when the item is actually retrieved from storage, not at round start, while preserving the donator discount pool across all retrievals in the round.

Fixed loadout items from still being sellable when they arent bought with triumph.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

Exploit solved evidence:

<img width="1401" height="579" alt="image" src="https://github.com/user-attachments/assets/40967352-8c82-4448-892e-25f0fdce8dbc" />

before:

<img width="634" height="861" alt="image" src="https://github.com/user-attachments/assets/f5e8c8b9-e8eb-434b-9de9-132980568ff3" />


Triumph change:

<img width="590" height="127" alt="image" src="https://github.com/user-attachments/assets/53a8671b-b064-436f-8623-316fb266d2f8" />

<img width="472" height="248" alt="image" src="https://github.com/user-attachments/assets/bc3918e8-ce79-4e74-b9e9-a12865cc3cfc" />

<img width="340" height="79" alt="image" src="https://github.com/user-attachments/assets/296d678b-27c3-4b5a-81c1-295504fcdf46" />

entering and leaving keeps the amount the same

<img width="612" height="98" alt="image" src="https://github.com/user-attachments/assets/f7b37501-b79f-4b12-8c06-1466f474223f" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Well, there is a big ass message about free loadout items not giving you money, so, it was clearly not intended for this to happen.

<img width="599" height="54" alt="image" src="https://github.com/user-attachments/assets/18718a6c-3fb5-4637-b666-d6bf81ea18f5" />

Thus the code was fixed, at a level it shouldnt crop up again hopefully.

Regarding the triumph changes, the logic was simple, sometimes you join at the start of the round, and you will make use of the 50 triumph worth items you had, other times, you would join 2 hours in, or even instead of rolling a pauper, you roll duke, and the 17 points of triumph you spent on having a waterskin, short satchel and scabbard will feel pretty silly, so instead of having to adjust all your loadout, you pay for what you use, not what you might use.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Triumph cost for loadout items is now deducted when the item is actually retrieved from storage, not at round start, while preserving the donator discount pool across all retrievals in the round.
fix: Fixed loadout items from still being sellable when they arent bought with triumph.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
