### PR TITLE
fix elementals being trapped in their own creations

### DIFF
--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -313,6 +313,7 @@
 	// Conjured glow
 	R.AddComponent(/datum/component/conjured_item, GLOW_COLOR_EARTHEN)
 	RegisterSignal(R, COMSIG_ITEM_BROKEN, PROC_REF(revert))
+	RegisterSignal(H, COMSIG_LIVING_RESIST, PROC_REF(revert))
 	RegisterSignal(R, COMSIG_ITEM_DROPPED, PROC_REF(revert_perspective))
 	H.forceMove(R)
 	conjured_item = R

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -243,7 +243,7 @@
 
 /datum/action/cooldown/spell/arcyne_forge/elemental
 	name = "Earthen Forge"
-	desc = "Shape your earthen form into a tool or weapon. Shaped items have halved durability. When the item breaks, you will revert to your original form. Cast again to manually revert."
+	desc = "Shape your earthen form into a tool or weapon. When the item breaks, you will revert to your original form. Cast again to manually revert."
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_SAME_Z
 	conjure_options = list(
 		// Staff
@@ -301,8 +301,6 @@
 	var/item_path = conjure_options[choice]
 	var/obj/item/R = new item_path(H.drop_location())
 
-	// Halve durability
-	R.max_integrity = round(R.max_integrity * 0.5)
 	R.obj_integrity = R.max_integrity
 	owner.status_flags |= GODMODE
 	// Mark as conjured — no salvage, no smelting
@@ -330,7 +328,7 @@
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/void // lmao
 	name = "Void Forge"
-	desc = "Shape your ever-malleable form into a tool or weapon. Shaped items have halved durability. When the item breaks, you will revert to your original form. Cast again to manually revert."
+	desc = "Shape your ever-malleable form into a tool or weapon. When the item breaks, you will revert to your original form. Cast again to manually revert."
 
 /datum/action/cooldown/spell/arcyne_forge/elementalt2
 	name = "Greater Earthen Shaping"


### PR DESCRIPTION
## About The Pull Request
elementals can now resist out of their tool form just like all other item-form mobs
also removes the half-dura penalty on t1 arcyne forge, the penalty is that the mob has to stay inside it the whole time it's in use, it should be viable during that time

## Testing Evidence
forgot 2 get screenshots it's 5am but it did test it and it worked

## Why It's Good For The Game
fixing a bug introduced by fixing another bug introduced by

## Changelog

:cl:
fix: Elemental and void familiars can now resist to break out of tool transformations
balance: Tier 1 earthen forge no longer halves the durability of conjured items 
/:cl:
