### PR TITLE
Naledi Origin no longer grants instant stress and debuff

### DIFF
--- a/code/modules/virtues/origin.dm
+++ b/code/modules/virtues/origin.dm
@@ -107,8 +107,6 @@
 		if("Strict (Naledi Complex)")
 			ADD_TRAIT(H, TRAIT_NALEDI, TRAIT_GENERIC)
 			mask_type = /obj/item/clothing/mask/rogue/lordmask/naledi/lesser
-			H.apply_status_effect(/datum/status_effect/debuff/lost_naledi_mask)
-			H.add_stress(/datum/stressevent/naledimasklost)
 		else
 			mask_type = /obj/item/clothing/mask/rogue/lordmask/tarnished
 	H.mind.special_items["Naledian Mask"] = mask_type


### PR DESCRIPTION
## About The Pull Request
While the user does spawn without the mask on and it's placed in their stash, it's probably more sane to give the player leniency even after they picked the option.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I no longer spawn in with the mask debuffs.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fewer ahelps, it's still just about as opt-in, as taking the mask out and putting it on / off will trigger all the appropriate effects.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Naledi origin Strict choice will no longer instantly grant the related mask debuffs. The mask still spawns in the player's stash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
