### PR TITLE
Updoot icon

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1903,7 +1903,6 @@ generate/load female uniform sprites matching all previously decided variables
 		. += "not_coloured"
 
 	. += gender
-	. += age
 
 	for(var/obj/item/bodypart/BP as anything in bodyparts)
 		. += BP.body_zone
@@ -1917,8 +1916,6 @@ generate/load female uniform sprites matching all previously decided variables
 			. += "rotted"
 		if(BP.skeletonized)
 			. += "skeletonized"
-		if(BP.dmg_overlay_type)
-			. += BP.dmg_overlay_type
 
 	if(HAS_TRAIT(src, TRAIT_HUSK))
 		. += "husk"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -60,7 +60,7 @@ There are several things that need to be remembered:
 //HAIR OVERLAY
 /mob/living/carbon/human/update_hair()
 	rebuild_obscured_flags()
-	update_body_parts(TRUE)
+	update_body_parts()
 	return
 
 /mob/living/carbon/human/update_body()
@@ -1916,7 +1916,10 @@ generate/load female uniform sprites matching all previously decided variables
 			. += "rotted"
 		if(BP.skeletonized)
 			. += "skeletonized"
+		for(var/datum/bodypart_feature/feature as anything in BP.bodypart_features)
+			. += feature.get_cache_key()
 
+	. += "[obscured_flags]"
 	if(HAS_TRAIT(src, TRAIT_HUSK))
 		. += "husk"
 	return jointext(., "-")

--- a/code/modules/surgery/bodyparts/bodypart_features/_bodypart_feature.dm
+++ b/code/modules/surgery/bodyparts/bodypart_features/_bodypart_feature.dm
@@ -31,6 +31,9 @@
 		bodypart_overlays(standing)
 	return appearances
 
+/datum/bodypart_feature/proc/get_cache_key()
+	return "[accessory_type]-[accessory_colors]"
+
 /// Sets an accessory type and optionally colors too.
 /datum/bodypart_feature/proc/set_accessory_type(new_accessory_type, colors, owner)
 	accessory_type = new_accessory_type

--- a/code/modules/surgery/bodyparts/bodypart_features/features.dm
+++ b/code/modules/surgery/bodyparts/bodypart_features/features.dm
@@ -22,6 +22,9 @@
 	add_gradient_overlay(standing, hair_dye_gradient, hair_dye_color)
 	add_custom_overlay(standing)
 
+/datum/bodypart_feature/hair/get_cache_key()
+	return "[accessory_type]-[accessory_colors]-[natural_gradient]-[natural_color]-[hair_dye_gradient]-[hair_dye_color]-[custom_mask_version]"
+
 /datum/bodypart_feature/hair/proc/get_custom_mask()
 	var/list/custom_masks = hairmask_layers_fast(colormasks)
 	if(custom_masks)


### PR DESCRIPTION
## About The Pull Request
- Remove unused damoverlay and age keys from icon. Probably not useful
- Stopped update_hair from forcing a full body redraw, by adding in sprite accessories and hair cache key icon. **Might not work and might not help performance**

TM only. Our server performance is dire due to an inflow of players above our previous height so I'm going to try some of the more difficult optimizations I am not well versed in.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Basic sanity check
<img width="214" height="189" alt="dreamseeker_Kg7HgATmBi" src="https://github.com/user-attachments/assets/9a630112-b316-403a-8c7f-21d2e6db0be8" />
<img width="267" height="205" alt="dreamseeker_q8GwlEmJgr" src="https://github.com/user-attachments/assets/5ac8cebd-2801-4ab7-b776-bb698cdadb2a" />
<img width="98" height="134" alt="dreamseeker_aMvqYGMdH4" src="https://github.com/user-attachments/assets/19b83ce3-5c01-428f-b0b4-c6dfc01e199c" />
<img width="117" height="163" alt="dreamseeker_9eYLzC3WOy" src="https://github.com/user-attachments/assets/91d02cd5-eec6-4432-9c60-b834ba492f56" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Noc I need my TIDI


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Remove unused damoverlay and age keys from icon. Probably not useful
fix: Stopped update_hair from forcing a full body redraw, by adding in sprite accessories and hair cache key icon to save performance. Report any oddities
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
