### PR TITLE
Zigs sovl - Prestidigitation

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -51,13 +51,11 @@
 		if(user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
 			var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M)
 			if(cig)
-				if(cig.lit)
-					to_chat(user, span_warning("[cig.name] is already lit!"))
-					return 1
-				if(M == user)
-					cig.attackby(src, user)
-				else
-					cig.light(span_notice("[user] holds [src] out for [M], and lights [cig]."))
+				if(!cig.lit)
+					if(M == user)
+						cig.attackby(src, user)
+					else
+						cig.light(span_notice("[user] holds [src] out for [M], and lights [cig]."))
 				return 1
 	return ..()
 

--- a/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
+++ b/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
@@ -226,6 +226,18 @@
 		S.start()
 		user.visible_message(span_notice("[user] snaps [user.p_their()] fingers, producing a spark!"), span_notice("I will forth a tiny spark with a snap of my fingers."))
 	else
+		if(isliving(thing) && user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
+			var/mob/living/carbon/M = thing
+			var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M)
+
+			if(cig)
+				if(!cig.lit)
+					M.spark_act()
+					if(M == user)
+						cig.light(span_notice("[user] snaps [user.p_their()] fingers, willing a spark to light [user.p_their()] [cig.name]."))
+					else
+						cig.light(span_notice("[user] snaps [user.p_their()] fingers, willing a spark to light [M]'s [cig.name]."))
+				return TRUE
 		thing.spark_act()
 		user.visible_message(span_notice("[user] snaps [user.p_their()] fingers, and a spark leaps forth towards [thing]!"), span_notice("I will forth a tiny spark and direct it towards [thing]."))
 


### PR DESCRIPTION
## About The Pull Request
- Casting Prestidigitation with the intent spark while targeting another character's mouth will light that character's unlit zigarette as if using a lighter.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled and tested.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Magician's Associates can now light each other's zigarettes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Allow lighting another player's zigarette using Prestidigitation's intent spark when targeting their mouth
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
