### PR TITLE
Adds Dual-Wielding to Twin-Shamhirs Sahir

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_sahir.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_sahir.dm
@@ -64,6 +64,7 @@
 		H.set_blindness(0)
 		switch(weapon_choice)
 			if("Twin Shamshirs")
+				ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC)
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				beltl = /obj/item/rogueweapon/scabbard/sword
 				beltr = /obj/item/rogueweapon/scabbard/sword


### PR DESCRIPTION
## About The Pull Request

Added the dual wield trait to the Desert Rider Sahir subclass when they pick the dual shamshir as their starting weapons. 

## Testing Evidence

I tested the Sahir when choosing the Shamshirs to test whether the dual-wielding worked as intended, which it did.

Then I tested the Sahir when choosing the Staff, to test whether they benefited from the trait if they didn't take the Shamshirs, which they didn't.

And finally, for posterity, I checked another subclass; the Janissary. Just to make sure the previous negative test result wasn't a fluke. Which thankfully it wasn't.

<details>
<summary>Screenshot Evidence of Above Behaviour </summary>
<img width="798" height="405" alt="PickedShamshir" src="https://github.com/user-attachments/assets/6a4b92fd-2bea-4bda-9e92-3fcfe0c8725a" />

<img width="775" height="469" alt="PickedStaff" src="https://github.com/user-attachments/assets/4fd96f99-cf2c-428a-a063-cfdc0ceb43e2" />

<img width="797" height="629" alt="PickedJannisary" src="https://github.com/user-attachments/assets/0d5a3652-6b3d-4fbb-b519-202585fa8667" />
</details>


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

This brings the subclass to parity with the Almah subclass, which gains dual wielding capabilities when they dual shamshirs.
Why would they lug around a spare sword if they couldn't use it?

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: added Dual Wielding for the Sahir subclass when they pick Dual Shamshirs as their starting weapon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
