### PR TITLE
Councillors lose Stewardry key except for Cofferers, who cannot take crafting virtues

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -64,6 +64,7 @@
 	tutorial = "Whether born into wealth, or earned through working up from the bottom, you have quite the reserve of mammon at your disposal. Use your silver-tongue to acquire more, or buy more favour with the court. You may be the lowest rung of the ladder, but that rung still towers over everyone else in town."
 	outfit = /datum/outfit/job/roguetown/councillor/cofferer
 	category_tags = list(CTAG_COUNCILLOR)
+	virtue_limits = list(/datum/virtue/utility/skilled, /datum/virtue/utility/apprentice) // You are the only one with direct Steward access, and therefore should not be able to easily self cheese
 	subclass_stats = list(
 		STATKEY_WIL = 2,
 		STATKEY_INT = 2,
@@ -151,7 +152,6 @@
 	saiga_shoes = /obj/item/clothing/shoes/roguetown/horseshoes/steel
 	backl = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/keyring/steward
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel
 	cloak = /obj/item/clothing/cloak/half/red
 	backpack_contents = list(
@@ -190,7 +190,6 @@
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backr = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/keyring/steward
 	beltr = /obj/item/quiver/arrows
 	cloak = /obj/item/clothing/cloak/half/red
 	backpack_contents = list(
@@ -216,8 +215,6 @@
 	saiga_shoes = /obj/item/clothing/shoes/roguetown/horseshoes/steel
 	backl = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather
-	// Less money of their own, but does need funds to oversee defenses
-	beltl = /obj/item/storage/keyring/steward
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel
 	cloak = /obj/item/clothing/cloak/half/red
 	backpack_contents = list(


### PR DESCRIPTION
## About The Pull Request
Too many Councillors walking in and being ATM. Only Cofferers, which is a NotSteward class, will be allowed the key and they will not be allowed to take crafting virtues to clamp down on ease of powergaming. 

Duke, Prince and Hand still have access but I don't see a need to hit them (for obvious reasons). I want to keep the ability to do Councillor thing without being completely tied to the Stewardry.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yae

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
See above

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Councillors lose Stewardry key except for Cofferers, who cannot take crafting virtues
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
