### PR TITLE
Add Dual Wield to Zeybek with Twin Shamshirs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_zeybek.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_zeybek.dm
@@ -67,6 +67,7 @@
 		H.set_blindness(0)
 		switch(weapon_choice)
 			if("Shamshirs and Javelin")
+				ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC)
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 				backl = /obj/item/quiver/javelin/iron


### PR DESCRIPTION
## About The Pull Request

Running it back at adding dual wield to desert riders —  This time with the Zeybek. 

## Testing Evidence

I tested the Zeybek subclass while picking twin shamshirs. This should enable dual-wielding; and it did.
I then tested the Zeybek subclass when picking the whip and knife. This shouldn't enable dual-wielding; and it didn't.
And finally, I tested the Sahir subclass, which I have learned <i>really</i> shouldn't have dual-wielding; and it didn't.

<details>
<summary><b>Testing Evidence</b></summary>
<img width="792" height="463" alt="PickedDual" src="https://github.com/user-attachments/assets/ebe2ff83-a24a-4f6c-b818-3d0a94083cdc" />
<img width="796" height="402" alt="PickedWhip" src="https://github.com/user-attachments/assets/0f84decb-34bd-42e2-b250-bd53e9c7e43d" />
<img width="669" height="293" alt="PickedSahir" src="https://github.com/user-attachments/assets/0a5e874a-f79a-47f2-9a90-a718f12df6fe" />

</details>

## Why It's Good For The Game
Creates parity with the Almah subclass.
Hopefully because they're not a mage this will <b>actually</b> be parity with Almah, instead of doing what I did before in creating an unbeatable monster.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: added Dual Wield to Zeybek when they choose twin shamshirs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
