### PR TITLE
Alchemy Anti-Gamer & Affordance Adjustment, Anniversary Edition

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -100,25 +100,44 @@
 	var/alert_group = ALERT_STATUS //decides where on the screen the alert shows up, if it's a debuff, status effect, or buff
 	nomouseover = FALSE
 	var/atom/movable/screen/maptext_holder/maptext_holder
+	var/last_countdown_text //Cached countdown string so we don't rewrite maptext every fast-process tick
+
+//At or above this, the countdown shows whole minutes ("27m"); below it, M:SS or Ns
+#define ALERT_COUNTDOWN_CUTOFF (3 MINUTES)
 
 /atom/movable/screen/alert/proc/update_countdown(remaining_deciseconds)
-	if(remaining_deciseconds <= 0 || remaining_deciseconds >= 3 MINUTES)
+	if(remaining_deciseconds <= 0)
 		if(istype(maptext_holder))
 			maptext_holder.maptext = null
+		last_countdown_text = null
 		return
+
+	var/countdown_text
+	if(remaining_deciseconds >= ALERT_COUNTDOWN_CUTOFF)
+		var/mins_left = max(round(remaining_deciseconds / (1 MINUTES), 1), 1)
+		countdown_text = "[mins_left]m"
+	else
+		var/seconds_left = round(remaining_deciseconds / (1 SECONDS), 0.1)
+		if(seconds_left >= 60)
+			var/mins = round(seconds_left / 60)
+			var/secs = round(seconds_left) % 60
+			countdown_text = "[mins]:[secs < 10 ? "0[secs]" : "[secs]"]"
+		else
+			countdown_text = "[seconds_left]s"
+
+	if(countdown_text == last_countdown_text)
+		return
+	last_countdown_text = countdown_text
+
 	if(!istype(maptext_holder))
 		maptext_holder = new(src)
 		maptext_holder.x = 4
 		maptext_holder.y = 0
 		maptext_holder.color = "#800000"
 		vis_contents.Add(maptext_holder)
-	var/seconds_left = round(remaining_deciseconds / (1 SECONDS), 0.1)
-	if(seconds_left >= 60)
-		var/mins = round(seconds_left / 60)
-		var/secs = round(seconds_left) % 60
-		maptext_holder.maptext = MAPTEXT("[mins]:[secs < 10 ? "0[secs]" : "[secs]"]")
-	else
-		maptext_holder.maptext = MAPTEXT("[seconds_left]s")
+	maptext_holder.maptext = MAPTEXT(countdown_text)
+
+#undef ALERT_COUNTDOWN_CUTOFF
 
 //Gas alerts
 /atom/movable/screen/alert/not_enough_oxy

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -188,6 +188,13 @@
 	if(desc)
 		inspec += "<br>[desc]"
 
+	for(var/S in attached_effect?.effectedstats)
+		if(attached_effect.effectedstats[S] > 0)
+			inspec += "<br><span class='purple'>[S]</span> \Roman [attached_effect.effectedstats[S]]"
+		if(attached_effect.effectedstats[S] < 0)
+			var/newnum = attached_effect.effectedstats[S] * -1
+			inspec += "<br><span class='danger'>[S]</span> \Roman [newnum]"
+
 	if(attached_effect && attached_effect.duration != -1 && attached_effect.duration > world.time)
 		var/remaining = attached_effect.duration - world.time
 		var/total_secs = round(remaining / (1 SECONDS))
@@ -198,14 +205,7 @@
 			timestring = "[mins]:[secs < 10 ? "0[secs]" : "[secs]"]"
 		else
 			timestring = "[total_secs]s"
-		inspec += "<br><span class='notice'>Time remaining: [timestring]</span>"
-
-	for(var/S in attached_effect?.effectedstats)
-		if(attached_effect.effectedstats[S] > 0)
-			inspec += "<br><span class='purple'>[S]</span> \Roman [attached_effect.effectedstats[S]]"
-		if(attached_effect.effectedstats[S] < 0)
-			var/newnum = attached_effect.effectedstats[S] * -1
-			inspec += "<br><span class='danger'>[S]</span> \Roman [newnum]"
+		inspec += "<br><span class='smallnotice'>Time remaining: [timestring]</span>"
 
 	inspec += "<br>----------------------"
 	to_chat(user, "[inspec.Join()]")

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -188,6 +188,18 @@
 	if(desc)
 		inspec += "<br>[desc]"
 
+	if(attached_effect && attached_effect.duration != -1 && attached_effect.duration > world.time)
+		var/remaining = attached_effect.duration - world.time
+		var/total_secs = round(remaining / (1 SECONDS))
+		var/timestring
+		if(total_secs >= 60)
+			var/mins = round(total_secs / 60)
+			var/secs = total_secs % 60
+			timestring = "[mins]:[secs < 10 ? "0[secs]" : "[secs]"]"
+		else
+			timestring = "[total_secs]s"
+		inspec += "<br><span class='notice'>Time remaining: [timestring]</span>"
+
 	for(var/S in attached_effect?.effectedstats)
 		if(attached_effect.effectedstats[S] > 0)
 			inspec += "<br><span class='purple'>[S]</span> \Roman [attached_effect.effectedstats[S]]"

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -106,7 +106,7 @@
 	var/true_added = added
 	if(added > 0)
 		if(HAS_TRAIT(src, TRAIT_FORTITUDE))
-			added = added * 0.75
+			added = added * 0.85
 
 	if(added < 0 && HAS_TRAIT(src, TRAIT_FROZEN_STAMINA))
 		added = 0

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
@@ -62,15 +62,15 @@
 	output_reagents = list(/datum/reagent/medicine/strongmana = 90)
 
 /datum/alch_cauldron_recipe/stamina_potion
-	name = "Elixir of Stamina"
+	name = "Elixir of Fortitude"
 	smells_like = "fresh air"
-	output_reagents = list(/datum/reagent/medicine/stampot = 90)
+	output_reagents = list(/datum/reagent/medicine/stampot = 30)
 
 /datum/alch_cauldron_recipe/big_stamina_potion
-	name = "Elixir of Stamina (Strong)"
+	name = "Elixir of Fortitude (Strong)"
 	smells_like = "clean winds"
 	skill_required = SKILL_LEVEL_JOURNEYMAN
-	output_reagents = list(/datum/reagent/medicine/strongstam = 90)
+	output_reagents = list(/datum/reagent/medicine/strongstam = 30)
 
 /datum/alch_cauldron_recipe/restoration_potion
 	name = "Elixir of Restoration"

--- a/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
@@ -36,7 +36,7 @@
 /datum/status_effect/buff/alch/statbuff/strengthpot
 	id = "strpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
-	effectedstats = list(STATKEY_STR = 3)
+	effectedstats = list(STATKEY_STR = 2, STATKEY_LCK = -1, STATKEY_INT = -1)
 
 /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
 	name = STATKEY_STR
@@ -45,7 +45,7 @@
 /datum/status_effect/buff/alch/statbuff/perceptionpot
 	id = "perpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
-	effectedstats = list(STATKEY_PER = 3)
+	effectedstats = list(STATKEY_PER = 3, STATKEY_LCK = -1, STATKEY_SPD = -1)
 
 /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
 	name = STATKEY_PER
@@ -54,7 +54,7 @@
 /datum/status_effect/buff/alch/statbuff/intelligencepot
 	id = "intpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
-	effectedstats = list(STATKEY_INT = 3)
+	effectedstats = list(STATKEY_INT = 3, STATKEY_LCK = -1, STATKEY_STR = -1)
 
 /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
 	name = STATKEY_INT
@@ -63,7 +63,7 @@
 /datum/status_effect/buff/alch/statbuff/constitutionpot
 	id = "conpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
-	effectedstats = list(STATKEY_CON = 3)
+	effectedstats = list(STATKEY_CON = 3, STATKEY_LCK = -1, STATKEY_STR = -1)
 
 /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
 	name = STATKEY_CON
@@ -72,7 +72,7 @@
 /datum/status_effect/buff/alch/statbuff/endurancepot
 	id = "endpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
-	effectedstats = list(STATKEY_WIL = 3)
+	effectedstats = list(STATKEY_WIL = 3, STATKEY_LCK = -1, STATKEY_SPD = -1)
 
 /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
 	name = STATKEY_WIL
@@ -81,7 +81,7 @@
 /datum/status_effect/buff/alch/statbuff/speedpot
 	id = "spdpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/speedpot
-	effectedstats = list(STATKEY_SPD = 3)
+	effectedstats = list(STATKEY_SPD = 2, STATKEY_LCK = -1, STATKEY_WIL = -1)
 
 /atom/movable/screen/alert/status_effect/buff/alch/speedpot
 	name = STATKEY_SPD

--- a/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
@@ -4,10 +4,16 @@
 
 // A new system for statbuff, that increases the duration based on how much is consumed, capping it out
 // The long duration and trade off is meant to make it more viable to take as a PVE supplement, combined with the lower statweight
+#define STATBUFF_FILTER "statbuff_glow"
+
 /datum/status_effect/buff/alch/statbuff
 	duration = 1 MINUTES
 	var/max_duration = 27 MINUTES
 	// 27 drams in the small vial so this is what I am using for the neat number
+	// Outline shown on the buffed mob, mirroring the augmentation buffs. Each stat pot overrides its own colour.
+	var/outline_colour = "#008000"
+	// Compact effect text ballooned over the drinker on gain. Each pot sets its own.
+	var/buff_flavor
 
 /datum/status_effect/buff/alch/statbuff/on_creation(mob/living/new_owner, added_duration = 1 MINUTES)
 	duration = min(added_duration, max_duration)
@@ -32,11 +38,23 @@
 		to_clear += other
 	for(var/datum/status_effect/buff/alch/statbuff/loser in to_clear)
 		qdel(loser)
+	if(!owner.get_filter(STATBUFF_FILTER))
+		owner.add_filter(STATBUFF_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 50, "size" = 1))
+	if(buff_flavor)
+		owner.balloon_alert_to_viewers("<font color='[outline_colour]'>[buff_flavor]</font>")
+
+/datum/status_effect/buff/alch/statbuff/on_remove()
+	. = ..()
+	owner.remove_filter(STATBUFF_FILTER)
+
+#undef STATBUFF_FILTER
 
 /datum/status_effect/buff/alch/statbuff/strengthpot
 	id = "strpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
 	effectedstats = list(STATKEY_STR = 2, STATKEY_LCK = -1, STATKEY_INT = -1)
+	outline_colour = "#ff9000"
+	buff_flavor = "strength (str +2, for -1, int -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
 	name = STATKEY_STR
@@ -46,6 +64,8 @@
 	id = "perpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
 	effectedstats = list(STATKEY_PER = 3, STATKEY_LCK = -1, STATKEY_SPD = -1)
+	outline_colour = "#45c8ff"
+	buff_flavor = "perception (per +3, for -1, spd -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
 	name = STATKEY_PER
@@ -55,6 +75,8 @@
 	id = "intpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
 	effectedstats = list(STATKEY_INT = 3, STATKEY_LCK = -1, STATKEY_STR = -1)
+	outline_colour = "#7b5cff"
+	buff_flavor = "intelligence (int +3, for -1, str -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
 	name = STATKEY_INT
@@ -64,6 +86,8 @@
 	id = "conpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
 	effectedstats = list(STATKEY_CON = 3, STATKEY_LCK = -1, STATKEY_STR = -1)
+	outline_colour = "#a0522d"
+	buff_flavor = "constitution (con +3, for -1, str -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
 	name = STATKEY_CON
@@ -73,6 +97,8 @@
 	id = "endpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
 	effectedstats = list(STATKEY_WIL = 3, STATKEY_LCK = -1, STATKEY_SPD = -1)
+	outline_colour = "#d63384"
+	buff_flavor = "willpower (wil +3, for -1, spd -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
 	name = STATKEY_WIL
@@ -82,6 +108,8 @@
 	id = "spdpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/speedpot
 	effectedstats = list(STATKEY_SPD = 2, STATKEY_LCK = -1, STATKEY_WIL = -1)
+	outline_colour = "#00d9b5"
+	buff_flavor = "speed (spd +2, for -1, wil -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/speedpot
 	name = STATKEY_SPD
@@ -91,6 +119,8 @@
 	id = "forpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/fortunepot
 	effectedstats = list(STATKEY_LCK = 3)
+	outline_colour = "#ffd700"
+	buff_flavor = "fortune (for +3)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/fortunepot
 	name = STATKEY_LCK
@@ -101,6 +131,7 @@
 	id = "fortitudepot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/fortitude
 	max_duration = 3 MINUTES
+	buff_flavor = "fortitude (-15% stam)!"
 
 /datum/status_effect/buff/alch/statbuff/fortitude/on_apply()
 	. = ..()

--- a/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
@@ -2,74 +2,121 @@
 	desc = "Power rushes through your veins."
 	icon_state = "buff"
 
-/datum/status_effect/buff/alch/strengthpot
+// A new system for statbuff, that increases the duration based on how much is consumed, capping it out
+// The long duration and trade off is meant to make it more viable to take as a PVE supplement, combined with the lower statweight
+/datum/status_effect/buff/alch/statbuff
+	duration = 1 MINUTES
+	var/max_duration = 27 MINUTES
+	// 27 drams in the small vial so this is what I am using for the neat number
+
+/datum/status_effect/buff/alch/statbuff/on_creation(mob/living/new_owner, added_duration = 1 MINUTES)
+	duration = min(added_duration, max_duration)
+	return ..()
+
+/datum/status_effect/buff/alch/statbuff/refresh(mob/living/new_owner, added_duration = 1 MINUTES)
+	add_duration(added_duration)
+
+/datum/status_effect/buff/alch/statbuff/proc/add_duration(amount)
+	if(duration == -1)
+		return
+	duration = min(duration + amount, world.time + max_duration)
+
+/datum/status_effect/buff/alch/statbuff/on_apply()
+	. = ..()
+	if(!.)
+		return
+	var/list/to_clear = list()
+	for(var/datum/status_effect/buff/alch/statbuff/other in owner.status_effects)
+		if(other == src)
+			continue
+		to_clear += other
+	for(var/datum/status_effect/buff/alch/statbuff/loser in to_clear)
+		qdel(loser)
+
+/datum/status_effect/buff/alch/statbuff/strengthpot
 	id = "strpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
 	effectedstats = list(STATKEY_STR = 3)
-	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
 	name = STATKEY_STR
 	icon_state = "buff"
 
-/datum/status_effect/buff/alch/perceptionpot
+/datum/status_effect/buff/alch/statbuff/perceptionpot
 	id = "perpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
 	effectedstats = list(STATKEY_PER = 3)
-	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
 	name = STATKEY_PER
 	icon_state = "buff"
 
-/datum/status_effect/buff/alch/intelligencepot
+/datum/status_effect/buff/alch/statbuff/intelligencepot
 	id = "intpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
 	effectedstats = list(STATKEY_INT = 3)
-	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
 	name = STATKEY_INT
 	icon_state = "buff"
 
-/datum/status_effect/buff/alch/constitutionpot
+/datum/status_effect/buff/alch/statbuff/constitutionpot
 	id = "conpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
 	effectedstats = list(STATKEY_CON = 3)
-	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
 	name = STATKEY_CON
 	icon_state = "buff"
 
-/datum/status_effect/buff/alch/endurancepot
+/datum/status_effect/buff/alch/statbuff/endurancepot
 	id = "endpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
 	effectedstats = list(STATKEY_WIL = 3)
-	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
 	name = STATKEY_WIL
 	icon_state = "buff"
 
-/datum/status_effect/buff/alch/speedpot
+/datum/status_effect/buff/alch/statbuff/speedpot
 	id = "spdpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/speedpot
 	effectedstats = list(STATKEY_SPD = 3)
-	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/speedpot
 	name = STATKEY_SPD
 	icon_state = "buff"
 
-/datum/status_effect/buff/alch/fortunepot
+/datum/status_effect/buff/alch/statbuff/fortunepot
 	id = "forpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/fortunepot
 	effectedstats = list(STATKEY_LCK = 3)
-	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/fortunepot
 	name = STATKEY_LCK
+	icon_state = "buff"
+
+// Cap this out at 3 minutes, compete it with actual stat buffs, and with the attached buff nerfed to 15%.
+/datum/status_effect/buff/alch/statbuff/fortitude
+	id = "fortitudepot"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/fortitude
+	max_duration = 3 MINUTES
+
+/datum/status_effect/buff/alch/statbuff/fortitude/on_apply()
+	. = ..()
+	if(!.)
+		return
+	ADD_TRAIT(owner, TRAIT_FORTITUDE, src)
+	to_chat(owner, span_warning("My body feels lighter..."))
+
+/datum/status_effect/buff/alch/statbuff/fortitude/on_remove()
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_FORTITUDE, src)
+	to_chat(owner, span_warning("The weight of the world rests upon my shoulders once more."))
+
+/atom/movable/screen/alert/status_effect/buff/alch/fortitude
+	name = "Fortitude"
+	desc = "My humors have been hardened to the fatigues of the body. (-15% Stamina Usage)"
 	icon_state = "buff"
 
 //////////////////////

--- a/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
@@ -8,11 +8,8 @@
 
 /datum/status_effect/buff/alch/statbuff
 	duration = 1 MINUTES
-	var/max_duration = 27 MINUTES
-	// 27 drams in the small vial so this is what I am using for the neat number
-	// Outline shown on the buffed mob, mirroring the augmentation buffs. Each stat pot overrides its own colour.
+	var/max_duration = 10 MINUTES
 	var/outline_colour = "#008000"
-	// Compact effect text ballooned over the drinker on gain. Each pot sets its own.
 	var/buff_flavor
 
 /datum/status_effect/buff/alch/statbuff/on_creation(mob/living/new_owner, added_duration = 1 MINUTES)
@@ -52,9 +49,9 @@
 /datum/status_effect/buff/alch/statbuff/strengthpot
 	id = "strpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
-	effectedstats = list(STATKEY_STR = 2, STATKEY_LCK = -1, STATKEY_INT = -1)
+	effectedstats = list(STATKEY_STR = 2, STATKEY_LCK = -1, STATKEY_INT = -1, STATKEY_PER = -1)
 	outline_colour = "#ff9000"
-	buff_flavor = "strength (str +2, for -1, int -1)!"
+	buff_flavor = "strength (str +2, for -1, int -1, per -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
 	name = STATKEY_STR
@@ -63,9 +60,9 @@
 /datum/status_effect/buff/alch/statbuff/perceptionpot
 	id = "perpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
-	effectedstats = list(STATKEY_PER = 3, STATKEY_LCK = -1, STATKEY_SPD = -1)
+	effectedstats = list(STATKEY_PER = 2, STATKEY_LCK = -1)
 	outline_colour = "#45c8ff"
-	buff_flavor = "perception (per +3, for -1, spd -1)!"
+	buff_flavor = "perception (per +2, for -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
 	name = STATKEY_PER
@@ -74,9 +71,9 @@
 /datum/status_effect/buff/alch/statbuff/intelligencepot
 	id = "intpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
-	effectedstats = list(STATKEY_INT = 3, STATKEY_LCK = -1, STATKEY_STR = -1)
+	effectedstats = list(STATKEY_INT = 2, STATKEY_LCK = -1)
 	outline_colour = "#7b5cff"
-	buff_flavor = "intelligence (int +3, for -1, str -1)!"
+	buff_flavor = "intelligence (int +2, for -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
 	name = STATKEY_INT
@@ -85,9 +82,9 @@
 /datum/status_effect/buff/alch/statbuff/constitutionpot
 	id = "conpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
-	effectedstats = list(STATKEY_CON = 3, STATKEY_LCK = -1, STATKEY_STR = -1)
+	effectedstats = list(STATKEY_CON = 2, STATKEY_LCK = -1)
 	outline_colour = "#a0522d"
-	buff_flavor = "constitution (con +3, for -1, str -1)!"
+	buff_flavor = "constitution (con +2, for -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
 	name = STATKEY_CON
@@ -96,9 +93,9 @@
 /datum/status_effect/buff/alch/statbuff/endurancepot
 	id = "endpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
-	effectedstats = list(STATKEY_WIL = 3, STATKEY_LCK = -1, STATKEY_SPD = -1)
+	effectedstats = list(STATKEY_WIL = 2, STATKEY_LCK = -1)
 	outline_colour = "#d63384"
-	buff_flavor = "willpower (wil +3, for -1, spd -1)!"
+	buff_flavor = "willpower (wil +2, for -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
 	name = STATKEY_WIL
@@ -107,9 +104,9 @@
 /datum/status_effect/buff/alch/statbuff/speedpot
 	id = "spdpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/speedpot
-	effectedstats = list(STATKEY_SPD = 2, STATKEY_LCK = -1, STATKEY_WIL = -1)
+	effectedstats = list(STATKEY_SPD = 2, STATKEY_LCK = -1, STATKEY_WIL = -1, STATKEY_CON = -1)
 	outline_colour = "#00d9b5"
-	buff_flavor = "speed (spd +2, for -1, wil -1)!"
+	buff_flavor = "speed (spd +2, for -1, wil -1, con -1)!"
 
 /atom/movable/screen/alert/status_effect/buff/alch/speedpot
 	name = STATKEY_SPD
@@ -126,11 +123,9 @@
 	name = STATKEY_LCK
 	icon_state = "buff"
 
-// Cap this out at 3 minutes, compete it with actual stat buffs, and with the attached buff nerfed to 15%.
 /datum/status_effect/buff/alch/statbuff/fortitude
 	id = "fortitudepot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/fortitude
-	max_duration = 3 MINUTES
 	buff_flavor = "fortitude (-15% stam)!"
 
 /datum/status_effect/buff/alch/statbuff/fortitude/on_apply()

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -162,9 +162,10 @@
 		M.energy_add(60)
 	..()
 
+// Stamina potion no longer grant green bar directly which led to it being far too powerful when abused
 /datum/reagent/medicine/stampot
 	name = "Stamina Potion"
-	description = "Gradually regenerates stamina."
+	description = "Hardens the humors against fatigue, granting Fortitude for a short while."
 	reagent_state = LIQUID
 	color = "#129c00"
 	taste_description = "sweet tea"
@@ -175,16 +176,14 @@
 	conflicting_reagent_types = list(/datum/reagent/medicine/strongstam)
 
 /datum/reagent/medicine/stampot/on_mob_life(mob/living/carbon/M)
-	if(volume >= 60)
-		M.reagents.remove_reagent(/datum/reagent/medicine/stampot, 2) //No walking around having pre-buffed on it to have infinite stamina for Baothans.
-	if(volume > 0.99)
-		M.stamina_add(-20)
-	..()
-	. = 1
+	if(volume > 0)
+		M.apply_status_effect(/datum/status_effect/buff/alch/statbuff/fortitude, volume * (3 MINUTES / 50))
+		holder.remove_reagent(type, volume)
+	return TRUE
 
 /datum/reagent/medicine/strongstam
 	name = "Strong Stamina Potion"
-	description = "Rapidly regenerates stamina."
+	description = "Rapidly hardens the humors against fatigue, granting Fortitude for a short while."
 	color = "#13df00"
 	taste_description = "sparkly static"
 	scent_description = "grass"
@@ -192,12 +191,10 @@
 	conflicting_reagent_types = list(/datum/reagent/medicine/stampot)
 
 /datum/reagent/medicine/strongstam/on_mob_life(mob/living/carbon/M)
-	if(volume >= 60)
-		M.reagents.remove_reagent(/datum/reagent/medicine/strongstam, 2) //No walking around having pre-buffed on it to have infinite stamina for Baothans.
-	if(volume > 0.99)
-		M.stamina_add(-50)
-	..()
-	. = 1
+	if(volume > 0)
+		M.apply_status_effect(/datum/status_effect/buff/alch/statbuff/fortitude, volume * (3 MINUTES / 25))
+		holder.remove_reagent(type, volume)
+	return TRUE
 
 /** Design Note: Antidotes are meant to last as long as the poison, and purge them much quicker
  Having a 1 to 1 antidote to poison where you have to tailor defense to an increasing amount of attack
@@ -245,16 +242,6 @@
 	..()
 	. = 1
 
-/* Buff potions
-	Previously, it would apply a status effect to the mob lasting for 93 / 300 seconds and remove everything
-	However it meant that putting it in an alchemical vial was a trap as it sipped 9 units instead of 5 units that is the required minimum.
-	And removed any excessive potion inside the body. This has been changed to apply a 3 seconds buff to the mob, but have much lower
-	metabolization rate, so that the duration of the buff depends on how long you last.
-	Roughly tested. At Metabolization Rate 1. 10 units sip (1/3 of a vial) last 20 seconds.
-	To make this somewhat equal to the old system, base metabolization rate is 0.1 - making it last 200 seconds - 600 seconds if you sip an entire vial.
-	This is 2x on weaker potions (Intelligence, Fortune). However, overdose threshold is now 30 units so you can only drink one vial at once.
-	And potion stacking is not possible without neutralizing itself.
-*/
 /datum/reagent/buff
 	description = ""
 	reagent_state = LIQUID
@@ -263,6 +250,16 @@
 	// All stat buffs conflict with each other: only one buff potion's effect can be active at a time.
 	// (Self is excluded by the purge logic, so a buff never purges itself despite matching its own parent type.)
 	conflicting_reagent_types = list(/datum/reagent/buff)
+	var/buff_type
+	var/duration_per_unit = 1 MINUTES
+
+/datum/reagent/buff/on_mob_life(mob/living/carbon/M)
+	if(!buff_type)
+		return ..()
+	if(volume > 0)
+		M.apply_status_effect(buff_type, volume * duration_per_unit)
+		holder.remove_reagent(type, volume)
+	return TRUE
 
 /datum/reagent/buff/overdose_process(mob/living/carbon/M)
 	. = ..()
@@ -275,72 +272,48 @@
 	color = "#ff9000"
 	taste_description = "old meat"
 	scent_description = "meat"
-
-/datum/reagent/buff/strength/on_mob_life(mob/living/carbon/M)
-	M.apply_status_effect(/datum/status_effect/buff/alch/strengthpot)
-	return ..()
+	buff_type = /datum/status_effect/buff/alch/statbuff/strengthpot
 
 /datum/reagent/buff/perception
 	name = STATKEY_PER
 	color = "#ffff00"
 	taste_description = "cat piss"
 	scent_description = "urine"
-	metabolization_rate = REAGENTS_METABOLISM * 0.05
-
-/datum/reagent/buff/perception/on_mob_life(mob/living/carbon/M)
-	M.apply_status_effect(/datum/status_effect/buff/alch/perceptionpot)
-	return ..()
+	buff_type = /datum/status_effect/buff/alch/statbuff/perceptionpot
 
 /datum/reagent/buff/intelligence
 	name = STATKEY_INT
 	color = "#438127"
 	taste_description = "bog water"
 	scent_description = "moss"
-	metabolization_rate = REAGENTS_METABOLISM * 0.05
-
-/datum/reagent/buff/intelligence/on_mob_life(mob/living/carbon/M)
-	M.apply_status_effect(/datum/status_effect/buff/alch/intelligencepot)
-	return ..()
+	buff_type = /datum/status_effect/buff/alch/statbuff/intelligencepot
 
 /datum/reagent/buff/constitution
 	name = STATKEY_CON
 	color = "#130604"
 	taste_description = "bile"
 	scent_description = "vomit"
-
-/datum/reagent/buff/constitution/on_mob_life(mob/living/carbon/M)
-	M.apply_status_effect(/datum/status_effect/buff/alch/constitutionpot)
-	return ..()
+	buff_type = /datum/status_effect/buff/alch/statbuff/constitutionpot
 
 /datum/reagent/buff/endurance
 	name = STATKEY_WIL
 	color = "#ffff00"
 	taste_description = "oversweetened milk"
-
-/datum/reagent/buff/endurance/on_mob_life(mob/living/carbon/M)
-	M.apply_status_effect(/datum/status_effect/buff/alch/endurancepot)
-	return ..()
+	buff_type = /datum/status_effect/buff/alch/statbuff/endurancepot
 
 /datum/reagent/buff/speed
 	name = STATKEY_SPD
 	color = "#ffff00"
 	taste_description = "raw egg yolk"
 	scent_description = "sweat"
-
-/datum/reagent/buff/speed/on_mob_life(mob/living/carbon/M)
-	M.apply_status_effect(/datum/status_effect/buff/alch/speedpot)
-	return ..()
+	buff_type = /datum/status_effect/buff/alch/statbuff/speedpot
 
 /datum/reagent/buff/fortune
 	name = STATKEY_LCK
 	color = "#ffff00"
 	taste_description = "sour lemons"
 	scent_description = "citrus"
-	metabolization_rate = REAGENTS_METABOLISM * 0.05
-
-/datum/reagent/buff/fortune/on_mob_life(mob/living/carbon/M)
-	M.apply_status_effect(/datum/status_effect/buff/alch/fortunepot)
-	return ..()
+	buff_type = /datum/status_effect/buff/alch/statbuff/fortunepot
 
 /* Ruined Potion
 	When two conflicting potions end up in the same container (or the same body),

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -177,7 +177,7 @@
 
 /datum/reagent/medicine/stampot/on_mob_life(mob/living/carbon/M)
 	if(volume > 0)
-		M.apply_status_effect(/datum/status_effect/buff/alch/statbuff/fortitude, volume * (3 MINUTES / 50))
+		M.apply_status_effect(/datum/status_effect/buff/alch/statbuff/fortitude, volume * 20 SECONDS)
 		holder.remove_reagent(type, volume)
 	return TRUE
 
@@ -192,7 +192,7 @@
 
 /datum/reagent/medicine/strongstam/on_mob_life(mob/living/carbon/M)
 	if(volume > 0)
-		M.apply_status_effect(/datum/status_effect/buff/alch/statbuff/fortitude, volume * (3 MINUTES / 25))
+		M.apply_status_effect(/datum/status_effect/buff/alch/statbuff/fortitude, volume * 40 SECONDS)
 		holder.remove_reagent(type, volume)
 	return TRUE
 

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -164,7 +164,7 @@
 
 // Stamina potion no longer grant green bar directly which led to it being far too powerful when abused
 /datum/reagent/medicine/stampot
-	name = "Stamina Potion"
+	name = "Fortitude Potion"
 	description = "Hardens the humors against fatigue, granting Fortitude for a short while."
 	reagent_state = LIQUID
 	color = "#129c00"
@@ -182,7 +182,7 @@
 	return TRUE
 
 /datum/reagent/medicine/strongstam
-	name = "Strong Stamina Potion"
+	name = "Strong Fortitude Potion"
 	description = "Rapidly hardens the humors against fatigue, granting Fortitude for a short while."
 	color = "#13df00"
 	taste_description = "sparkly static"

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -43,10 +43,10 @@
 	list_reagents = list(/datum/reagent/medicine/strongmana = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/stampot
-	list_reagents = list(/datum/reagent/medicine/stampot = 50)
+	list_reagents = list(/datum/reagent/medicine/stampot = 30)
 
 /obj/item/reagent_containers/glass/bottle/rogue/strongstampot
-	list_reagents = list(/datum/reagent/medicine/strongstam = 50)
+	list_reagents = list(/datum/reagent/medicine/strongstam = 30)
 
 /obj/item/reagent_containers/glass/bottle/rogue/antidote
 	list_reagents = list(/datum/reagent/medicine/antidote = 50)

--- a/code/modules/spells/spell_types/wizard/augmentation/augmentation_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/augmentation/augmentation_status_effects.dm
@@ -164,7 +164,7 @@
 
 /atom/movable/screen/alert/status_effect/buff/fortitude
 	name = "Fortitude"
-	desc = "My humors have been hardened to the fatigues of the body. (-25% Stamina Usage)"
+	desc = "My humors have been hardened to the fatigues of the body. (-15% Stamina Usage)"
 	icon_state = "buff"
 
 #define FORTITUDE_FILTER "fortitude_glow"
@@ -182,7 +182,7 @@
 
 /datum/status_effect/buff/fortitude/on_apply()
 	. = ..()
-	owner.balloon_alert_to_viewers("<font color='[outline_colour]'>fortitude (-25% stam)!</font>")
+	owner.balloon_alert_to_viewers("<font color='[outline_colour]'>fortitude (-15% stam)!</font>")
 	var/filter = owner.get_filter(FORTITUDE_FILTER)
 	if (!filter)
 		owner.add_filter(FORTITUDE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 50, "size" = 1))

--- a/code/modules/spells/spell_types/wizard/augmentation/fortitude.dm
+++ b/code/modules/spells/spell_types/wizard/augmentation/fortitude.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/augment_buff/fortitude
 	name = "Fortitude"
-	desc = "Harden one's humors to the fatigues of the body. (-25% Stamina Usage)"
+	desc = "Harden one's humors to the fatigues of the body. (-15% Stamina Usage)"
 	button_icon_state = "fortitude"
 
 	invocations = list("Tenax")


### PR DESCRIPTION
## About The Pull Request
The guy who bought you statbuff anti stacking, shot Baothan potion stacking nearly exactly 1 year ago brings back the 2nd version of the same PR. https://github.com/Azure-Peak/Azure-Peak/pull/2373

I am open to constructive feedback if this is felt as too hard. My main goal is to crack down on Alchemy powergaming (I'll do another PR to reduce Alchemy Expert proliferation) and make it more useful for PVE and with some trade off for PVP. 

It also attempts to make the mechanics slightly more transparent to user and people it is used against.

- All statbuff potions, instead of granting the renewed buff for 3 seconds, instead increase the duration of your status effect by 1 minute per dram, up to 10 minutes, which is capped out. My goal is to make duration far more transparent, easier to calculate and balance and also make it more useful for PVE instead of a one off pop before PVP to slime your opponents out
- Statbuff potions still purge eachother
- Ingesting stat buff potions now show a pop up alert of your stat buffs 
- Stamina Potions no longer straight up grant you green stamina and allow you to utterly slime out opponent with certain intents. Instead, it grants you fortitude. This counts as a type of stat buff potion and will purge any other type of stat buff potions! 
- Fortitude Potions now yields **30 units**, lasts up to **10 minutes**. And weak potion give you 10 minutes duration, while strong one gives you 20 minutes (capped, so you need to resip, it is more efficient volume wise but you will have to space out your sip to not waste it).
- Statbuff potions now give outline like the old augmentation spells.
- Stamina Potions renamed Fortitude Potions internally. No typepath changes

In addition, all stat potions but fortitude and luck now have a downside. They are weighted to be positive stat wise if you count statweight, but I don't know if I went too harsh. This follows the thematic of mental trade for physical and vice versa. We'll see: 
- Str: +2, -1 for, -1 int, -1 per
- Per: +2 Per, -1 for
- Int: +2 Int, -1 for
- Con: +2 Con, -1 for
- Wil: +2 Wil, -1 For,
- Spd: +2 Spd, -1 For, -1 Wil, -1 Con
- For: +3 For
- Fortitude: -15% 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="147" height="100" alt="dreamseeker_HNdhrGfNXe" src="https://github.com/user-attachments/assets/e53ca8db-5de2-4a9c-87e5-bec279adc743" />
<img width="226" height="131" alt="dreamseeker_G6jqbX1T5W" src="https://github.com/user-attachments/assets/a1bb2867-d424-4e77-80d3-9c26013b5318" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I do not wishes to kill off alchemy and incentives to engage with the system or buy from alchemy producer, even though there's currently far too many of them. 

This PR aims to tune down the EFFECT of having access to the most powerful, in combat alchemy system. I am aware we should find out ways to make stats not stack but it requires a thorough refactor I do not have time for. This system, regardless of whether a new anti stat stacking system come up, should clamp down on the most egregious effects of alchemy powergaming. 

Food buffs incident and Augmentation mage's saga have already shown straight stat buffs to be unteneable. This too, follow on from the same principles

Exhibit A:
<img width="652" height="472" alt="Discord_r5sNKnO5xi" src="https://github.com/user-attachments/assets/00544270-6b22-4216-a5b1-951bcd0be601" />


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: All statbuff potions, instead of granting the renewed buff for 3 seconds, instead increase the duration of your status effect by 1 minute, up to 27 minutes, which is capped out. My goal is to make duration far more transparent, easier to calculate and balance and also make it more useful for PVE instead of a one off pop before PVP to slime your opponents out
balance: Statbuff potions still purge eachother
add: Ingesting stat buff potions now show a pop up alert of your stat buffs 
add: Stamina Potions no longer straight up grant you green stamina and allow you to utterly slime out opponent with certain intents. Instead, it grants you fortitude. This counts as a type of stat buff potion and will purge any other type of stat buff potions! **Fortitude buff can uniquely only stack to 3 minutes.**
add: Statbuff potions now give outline like the old augmentation spells.
add: Stamina Potions renamed Fortitude Potions internally. No typepath changes
add: Fortitude Potions now yields **30 units**, lasts up to **10 minutes**. And weak potion give you 10 minutes duration, while strong one gives you 20 minutes  (capped, so you need to resip, it is more efficient volume wise but you will have to space out your sip to not waste it).
add: All statbuff potion except fortitude and fortune now have a distinct downside. Balance might be adjusted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
