### PR TITLE
[Balance] Move Enduring from Construct Racial to Ironman

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2038,11 +2038,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 							H.emote("painscream")
 						else
 							H.emote("pain")
-				if(damage_amount > (H.STACON * 3.5) && !HAS_TRAIT(H, TRAIT_NOPAINSTUN)) //We want this effect only on heavy hits.
+				if(damage_amount > (H.STACON * 3.5) && (!HAS_TRAIT(H, TRAIT_NOPAINSTUN) || !HAS_TRAIT(H, TRAIT_IRONMAN))) //We want this effect only on heavy hits.
 					H.Immobilize(5) //The fastest you can swing a weapon is once each 0.6 seconds, anything higher than 0.5 Immob. opens the door for stunlocking (see: katar).
 					shake_camera(H, 2, 2)
 					H.stuttering += 5
-				if(damage_amount > 10 && !HAS_TRAIT(H, TRAIT_NOPAINSTUN))
+				if(damage_amount > 10 && (!HAS_TRAIT(H, TRAIT_NOPAINSTUN) || !HAS_TRAIT(H, TRAIT_IRONMAN)))
 					H.Slowdown(clamp(damage_amount/10, 1, 5))
 					shake_camera(H, 1, 1)
 				if(H.show_redflash())

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -23,7 +23,6 @@
 	inherent_traits = list(
 		TRAIT_IRONMAN,
 		TRAIT_LIMBATTACHMENT, // this interacts with trait_ironman, making this take a while to reattach
-		TRAIT_NOPAINSTUN, // look into this later, just remembered Ryan merged NoPainSlow (cur. TRAIT_IGNOREDAMAGESLOWDOWN) into NoPainStun, might be good to separate them again for situations where I want my character to collapse from total pain, but not flinch when being hit
 		TRAIT_NOHUNGER,
 		TRAIT_NOBREATH, 
 		TRAIT_TOXIMMUNE, 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -73,7 +73,7 @@
 					emote("painmoan")
 			else
 				if(painpercent >= 100)
-					if(prob(25) && (HAS_TRAIT(src, TRAIT_PSYDONIAN_GRIT) || STAWIL >= 15) && !HAS_TRAIT(src, TRAIT_NOPAINSTUN)) // PSYDONIC WEIGHTED COINFLIP. TWEAK THIS AS THOU WILT. DON'T LET THEM BE BROKEN, PSYDON WILLING. THROW CON-MAXXERS A BONE, TOO.
+					if(prob(25) && (HAS_TRAIT(src, TRAIT_PSYDONIAN_GRIT) || STAWIL >= 15) && (!HAS_TRAIT(src, TRAIT_NOPAINSTUN) || !HAS_TRAIT(src, TRAIT_IRONMAN))) // PSYDONIC WEIGHTED COINFLIP. TWEAK THIS AS THOU WILT. DON'T LET THEM BE BROKEN, PSYDON WILLING. THROW CON-MAXXERS A BONE, TOO.
 						Immobilize(15) // EAT A MICROSTUN. YOU'RE AVOIDING A PAINCRIT.
 						if(HAS_TRAIT(src, TRAIT_PSYDONIAN_GRIT))
 							visible_message(span_info("[src] audibly grits [src.p_their()] teeth, ENDURING through [src.p_their()] pain."), span_info("Through my faith in HIM, I ENDURE."))
@@ -91,7 +91,7 @@
 						mob_timers["painstun"] = world.time + 160
 					if(prob(probby) && HAS_TRAIT(src, TRAIT_NOPAINSTUN) && !HAS_TRAIT(src, TRAIT_LYCANRESILENCE)  && (has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed)))
 						Immobilize(10)
-						emote("painscream")
+						emote("superagony")
 						to_chat(src, span_userdanger("THE SACRED FLAMES, I FEEL PAIN AGAIN!"))
 						stuttering += 5
 						cultslurring += 10 //To indicate this isn't a natural kind of agony

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -172,7 +172,7 @@
 
 /mob/living/proc/handle_random_events()
 	//random painstun
-	if(!stat && !HAS_TRAIT(src, TRAIT_NOPAINSTUN))
+	if(!stat && (!HAS_TRAIT(src, TRAIT_NOPAINSTUN || !HAS_TRAIT(src, TRAIT_IRONMAN))))
 		if(world.time > mob_timers["painstun"] + 600)
 			if(getBruteLoss() + getFireLoss() >= (STAWIL * 10))
 				var/probby = 53 - (STAWIL * 2)

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -680,7 +680,7 @@
 			if(!(c_BP in BPs_to_check))
 				LAZYADD(BPs_to_check, c_BP)
 
-		if((HAS_TRAIT(C_caster, TRAIT_NOPAIN) || HAS_TRAIT(C_caster, TRAIT_NOPAINSTUN)) && HAS_TRAIT(C_caster, TRAIT_BLOODLOSS_IMMUNE))
+		if((HAS_TRAIT(C_caster, TRAIT_NOPAIN) || HAS_TRAIT(C_caster, TRAIT_NOPAINSTUN)) && HAS_TRAIT(C_caster, TRAIT_BLOODLOSS_IMMUNE) && HAS_TRAIT(C_caster, TRAIT_IRONMAN))
 			if(!(c_BP in BPs_to_check))
 				c_BP.receive_damage(targetwound.whp)
 				LAZYADD(BPs_to_check, c_BP)


### PR DESCRIPTION
## About The Pull Request

- Given they have a racial Enduring, this blocks them from being able to take Arcyne Potential. So I moved their pain reactions to TRAIT_TONYSTARK.

## Testing Evidence

<img width="486" height="107" alt="Screenshot_381" src="https://github.com/user-attachments/assets/28083f0f-0ed1-45d7-865f-82ddb9ca6e38" />

## Why It's Good For The Game

Should've adjusted this when that PR came up but only after using it recently I felt how annoying that can get, especially in some roles that depend on Mindlink, or for emergency heals with Mending. 

Although I'll have to say this fix IS debatable.

## Changelog
:cl:
balance: Removed Enduring from Construct, transposing its effects to the racial trait.
/:cl: