### PR TITLE
Idiot proof the start now button

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -536,6 +536,11 @@
 	set desc="Start the round RIGHT NOW"
 	set name="Start Now"
 	if(SSticker.current_state == GAME_STATE_PREGAME || SSticker.current_state == GAME_STATE_STARTUP)
+		var/player_count = length(GLOB.clients)
+		// Idiot proof for accidental click due to focus hijack / testing server
+		if(player_count > 1)
+			if(alert(usr, "There are [player_count] players connected. Are you sure you want to start the round RIGHT NOW?", "Start Now", "Yes", "No") != "Yes")
+				return 0
 		SSticker.start_immediately = TRUE
 		log_admin("[usr.key] has started the game.")
 		var/msg = ""


### PR DESCRIPTION
## About The Pull Request
After the Incident in which my focus was hijacked at the exact second I clicked Start Now while testing on local, I've decided it is an Engineering Problem and not a me problem.

Add a prompt to the Start Now button if there's more than 1 clients connected to ask if you are sure. 

I deliberately put No on the LEFT because that should be the default and the awkwardness is intended.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yeah


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
See above

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added a confirmation prompt to "Start Now" if there's more than one client in game, defaulting to NO on the left against normal intuition, to prevent accidentally starting live server early due to roundstart focus hijack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
