### PR TITLE
updates mauls strength requirements

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -26,7 +26,7 @@
 	var/maxrange = 4
 
 /datum/intent/mace/smash/spec_on_apply_effect(mob/living/H, mob/living/user, params)
-	var/chungus_khan_str = user.STASTR 
+	var/chungus_khan_str = user.STASTR
 	if(H.has_status_effect(/datum/status_effect/debuff/yeetcd))
 		return // Recently knocked back, cannot be knocked back again yet
 	if(chungus_khan_str < 10)
@@ -417,7 +417,7 @@
 	damfactor = 1.25
 	intent_intdamage_factor = 0.4 //Reduces integrity damage modifier from +60% to -60%.
 	swingdelay = 6 //Slower than a strike, quicker than a chop or old-school smash.
-	icon_state = "inthresh"	
+	icon_state = "inthresh"
 	desc = "A slow-swinging strike that can cripple unarmored limbs with tremendous force. </br>Deals TWIST damage instead of BLUNT damage. Critical hits cause DISLOCATIONS, instead of FRACTURES. </br>DISLOCATED ARMS and HANDS cannot wield, grab, or use anything. </br>DISLOCATED LEGS and FEET prevent the target from standing."
 
 /obj/item/rogueweapon/mace/cudgel/flanged
@@ -545,7 +545,7 @@
 	force = 25
 	force_wielded = 30
 	minstr = 7
-	wdefense = 5 
+	wdefense = 5
 	wbalance = WBALANCE_SWIFT
 	resistance_flags = FIRE_PROOF
 	icon_state = "psycudgel"
@@ -928,12 +928,11 @@
 	damfactor = 0.9
 	item_d_type = "stab"
 
-//Mauls. Woe. Most characters will not be able to engage with this, beyond hobbling.
-//Why? The unique strength lockout. The minimum strength is not a suggestion.
+//Mauls. Woe.
 /obj/item/rogueweapon/mace/maul
 	force = 12 //Don't one-hand this.
 	force_wielded = 32 //-3 compared to grand mace(steel goden). Better intents.
-	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/bash/ranged) 
+	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/bash/ranged)
 	gripped_intents = list(/datum/intent/mace/smash/crush, /datum/intent/mace/strike/grand, /datum/intent/mace/sweep, /datum/intent/effect/hobble)
 	name = "maul"
 	desc = "Who would need something this large? It looks like it was made for tearing down walls, rather than men."
@@ -943,7 +942,7 @@
 	swingsound = BLUNTWOOSH_HUGE
 	slot_flags = null//No.
 	smelt_bar_num = 2
-	minstr = 14
+	minstr = 11
 	wdefense = 3
 	pixel_y = -16
 	pixel_x = -16
@@ -952,7 +951,6 @@
 	//dropshrink = 0.6
 	bigboy = TRUE
 	gripsprite = TRUE
-	minstr_req = TRUE //You MUST have the required strength. No exceptions.
 
 /obj/item/rogueweapon/mace/maul/getonmobprop(tag)
 	. = ..()
@@ -970,7 +968,6 @@
 	icon_state = "cross"
 	force_wielded = 34 // -1 compared to grand mace.
 	smeltresult = /obj/item/ingot/steel
-	minstr = 15
 	wdefense_wbonus = 4 // from 6
 	smelt_bar_num = 3
 
@@ -1193,7 +1190,7 @@
 		var/obj/effect/temp_visual/spore/old_spores = locate(/obj/effect/temp_visual/spore) in cloud_turf
 		if(old_spores)
 			qdel(old_spores)
-		new /obj/effect/temp_visual/spore(cloud_turf) 
+		new /obj/effect/temp_visual/spore(cloud_turf)
 
 /datum/component/mushroom_mace/proc/mushroom_boom(mob/living/target, mob/living/user)
 	var/turf/T = get_turf(target)


### PR DESCRIPTION
## About The Pull Request

Mauls seem to have been untouched over the years when changes were made to strength requirements, and have been sitting at a forced strength requirement of **14** and **15**

I have removed the forced strength requirement, and lowered the strength requirement to match the grand mace which has more force then this.

## Testing Evidence

Pretty simple line-change

## Why It's Good For The Game

They are the only weapons outside of very special weapons that have a minimum strength requirement, and their strength requirement is so obscenely high that it is unusable for nearly everyone, and that just seems bad. There is also no indication of them having such an obscenely high strength requirement in the shop, so anyone buying it would be completely SOL of funds unless they already had knowledge of its frankly insane strength requirement.

## Changelog

:cl:
balance: mauls no longer require herculean strength to use them
/:cl: