### PR TITLE
afaf - hotfix for decorated armor recipes

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -1952,21 +1952,21 @@
 /datum/anvil_recipe/armor/decorated/gilded_cuirass
 	name = "Cuirass, Decorated (+1 Steel Cuirass, +1 Steel)"
 	req_bar = /obj/item/ingot/gold
-	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted, /obj/item/ingot/steel)
+	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/cuirass, /obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/decorated
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 
 /datum/anvil_recipe/armor/decorated/gilded_halfplate
 	name = "Halfplate, Decorated (+1 Steel Halfplate, +1 Steel)"
 	req_bar = /obj/item/ingot/gold
-	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/fluted, /obj/item/ingot/steel)
+	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate, /obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/fluted/decorated
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 
 /datum/anvil_recipe/armor/decorated/gilded_fullplate
 	name = "Plate Armor, Decorated (+1 Steel Plate Armor, +1 Steel)"
 	req_bar = /obj/item/ingot/gold
-	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/full/fluted, /obj/item/ingot/steel)
+	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/full, /obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/fluted/decorated
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 


### PR DESCRIPTION
## About The Pull Request

* Removes the leftover '/fluted' tag from regular decorated armor recipes, proeprly restoring the ability to make them _(at a higher cost)_ with regular steel armor.

## Testing Evidence

Yeah.

## Why It's Good For The Game

* Fixes are good!

## Changelog

:cl:
fix: Decorated steel armor no longer requires fluted armor to make. Whoopsies!
/:cl: