### PR TITLE
Makes it possible to layer a hauberk and fluted cuirass

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -216,6 +216,17 @@
 	item_state = "ancientcuirasshauberk"
 	max_integrity = ARMOR_INT_CHEST_PLATE_STEELLIGHT
 
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/fluted
+	slot_flags = ITEM_SLOT_ARMOR
+	armor_class = ARMOR_CLASS_HEAVY
+	armor = ARMOR_PLATE
+	name = "fluted plate-and-maille"
+	desc = "A beautiful steel cuirass, decorated with fluting and worn atop thick chainmaille. While it falters against \
+	arrows and bolts, these interlinked layers are superb at warding off the blows of swords and axes."
+	icon_state = "ornatehauberk"
+	item_state = "ornatehauberk"
+	max_integrity = ARMOR_INT_CHEST_PLATE_STEELLIGHT
+
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/ornate
 	slot_flags = ITEM_SLOT_ARMOR
 	armor_class = ARMOR_CLASS_HEAVY
@@ -270,6 +281,15 @@
 	result = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy/heavy)
 	reqs = list(/obj/item/clothing/suit/roguetown/armor/plate/cuirass/paalloy = 1,
 	            /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy = 1)
+	craftdiff = 0 //Note that its Decrepit-tier variant is intended to largely be used by mobs and not players; hence, the lack of a crafting recipe.
+	req_table = TRUE //If someone wants to add that in post, hwoever, I don't mind. You can easily do so by copy-pasting the format, here.
+	bypass_dupe_test = TRUE
+
+/datum/crafting_recipe/roguetown/survival/flutedmailledhauberk
+	name = "layer a fluted cuirass atop hauberk"
+	result = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/fluted)
+	reqs = list(/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted = 1,
+	            /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk = 1)
 	craftdiff = 0 //Note that its Decrepit-tier variant is intended to largely be used by mobs and not players; hence, the lack of a crafting recipe.
 	req_table = TRUE //If someone wants to add that in post, hwoever, I don't mind. You can easily do so by copy-pasting the format, here.
 	bypass_dupe_test = TRUE


### PR DESCRIPTION
## About The Pull Request

You can layer a cuirass AND psydonic cuirasses with hauberks, so now you can do it with a fluted cuirass. 

## Testing Evidence

ii can spawn the item in and i can craft it.

## Why It's Good For The Game

You can do it with the other cuirasses in game, plus psydonic and fluted cuirasses use the same sprites so i dont see why fluted cuirasses should be left out. Since a fluted cuirass is the same integ as a regular cuirass, the resulting hauberk layering gives the same integ as a cuirass + hauberk combo.

## Changelog

:cl:
add: Makes it possible to layer a fluted cuirass with a hauberk

/:cl:

