### PR TITLE
Partal Shatterkill Reversion

### DIFF
--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 	var/disabling = FALSE
 	/// If TRUE, this is a crit wound
 	var/critical = FALSE
-	/// Some wounds cause instant death for SHATTER_KILL, which is basically critical weakness but softer
+	/// Some wounds cause instant death for SHATTER_KILL, which is basically critical weakness but softer, unique part is that we handle chest-wounds w/ unique traitcheck
 	var/shatter_wound = FALSE
 	/// Some wounds cause instant death for CRITICAL_WEAKNESS
 	var/mortal = FALSE
@@ -450,7 +450,7 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 		severityval = clamp(severityval, 0, 5)
 		if(severityval)
 			severity = severityval
-		
+
 	name = "[newname  ? "[newname] " : ""][initial(name)]"	//[adjective] [name], aka, "gnarly slash" or "slash"
 	if(name != oldname)
 		owner.visible_message(span_red("The [oldname] on [owner]'s [lowertext(bodyzone2readablezone(bodypart_to_zone(bodypart_owner)))] gets worse!"))

--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -262,7 +262,7 @@
 	)
 	mortal = FALSE
 	whp = 50
-	bleed_rate = 5				//Lower than others, still bad though. 
+	bleed_rate = 5				//Lower than others, still bad though.
 	clotting_threshold = 0.3	//Slightly higher still
 	clotting_rate = 0.1			//Slower clotting, not bad though for bleeder wound.
 
@@ -327,7 +327,6 @@
 	bleed_rate = 25				//Higher than artery
 	clotting_threshold = 1		//Will always bleed bad
 	clotting_rate = 1			//Good clotting rate; within 24 ticks (~3 seconds) will lower heavily.
-	shatter_wound = TRUE //Lethal for all skeles, workaround for their spammability and feeling seemingly unkillable for mace users
 
 /datum/wound/fracture/chest/on_mob_gain(mob/living/affected)
 	. = ..()
@@ -336,6 +335,20 @@
 		var/mob/living/carbon/CA = affected
 		if(HAS_TRAIT(CA, TRAIT_CRITICAL_WEAKNESS) && (NOBLOOD in CA.dna.species.species_traits))
 			CA.death()
+		if(HAS_TRAIT(CA, TRAIT_SHATTER_KILL)) // Player skeletons lose leg-mobility -> go for the skull to finish them off
+			ADD_TRAIT(affected, TRAIT_PARALYSIS_R_LEG, "[type]")
+			ADD_TRAIT(affected, TRAIT_PARALYSIS_L_LEG, "[type]")
+			if(iscarbon(affected))
+				var/mob/living/carbon/carbon_affected = affected
+				carbon_affected.update_disabled_bodyparts()
+
+/datum/wound/fracture/chest/on_mob_loss(mob/living/affected)
+	. = ..()
+	REMOVE_TRAIT(affected, TRAIT_PARALYSIS_R_LEG, "[type]")
+	REMOVE_TRAIT(affected, TRAIT_PARALYSIS_L_LEG, "[type]")
+	if(iscarbon(affected))
+		var/mob/living/carbon/carbon_affected = affected
+		carbon_affected.update_disabled_bodyparts()
 
 /datum/wound/fracture/chest/on_life()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Re-Does `TRAIT_SHATTER_KILL` instead of immedately oneshotting you w/ rib fractures, the trait works a bit differently:

- it retains that **second-stage** `skull cracks` will still kill you instantly. (Not first-stage)
- rib fractures instead apply a different effect of **completely disabling your legs until fixed**.

---

This should hopefully lessen the rocket-tag you have to deal with when you're fighting an abjucator with that absolutely cracked maul, or having to deal w/ a disiple using their master-unarmed fist fighting.

But even outside of the inquisition this should make advs and garrison who just exclusively switch to melee a little bit more reasonably weaker. They'll still be rather effective against you, but they'll have to actually finish you off, giving you a window to be saved or hurt them in the legs enough to maybe kill them.

---

`First rule:`
`Aim for the head, double tap.`

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

- Loaded it up
- Built it
- Screamed internally at some error this new setup I have that fucks up my TGUI and makes me want to strangle myself
- Spawned in via dchat and aghost instead
- Gave myself the trait
- Rib fracture -> Legs Paralyised
- Chugged a ton of red
- Was able to stand
- Smashed my skull twice
- `M O R T I S`

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

You have to actually aim areas other than chest to kill a skeleton instead of turning on `intent -> swift` and just spamming chest w/ grand mace, E'gads!

*But seriously, this has made skeletons alarmingly too weak. This'll give you a small recovery window and prevent you completely dying to mistakes. You'll still be severely crippled but you can go out with a bang at least, literally!*

*It also returns the ability to actually bait people in combat because everyone won't just aim chest, they'll have to be creative and engage with the combat system like you do.*

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: trait_shatterkill has been re-tuned. Skeletons no longer die to rib fractures, instead it disables their legs. Aim for the head on shamblers, sire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
