### PR TITLE
[TM/Fix] Nukes Zombified from orbit

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -512,25 +512,12 @@
 	. = ..()
 	owner.remove_stress(/datum/stressevent/resurrected)
 
-// /datum/status_effect/debuff/revived_addendum
-//	id = "revived_addendum"
-//	alert_type = /atom/movable/screen/alert/status_effect/debuff/revived_addendum
-//	duration = 5 MINUTES		//If timed right, it should naturally end alongside the 'Death's Door' debuff. Purely cosmetic, for the sake of keeping some continuity with the effects of resurrection.
-
-//	/atom/movable/screen/alert/status_effect/debuff/revived_addendum
-//	name = "Resurr.."
-//	desc = "You can feel yourself, in both body and soul, becoming fully grounded once more. Tyme will tell if you'll lyve to see tomorrow, however, or if this is merely an intermission.."
-//	icon_state = "revived_addendum"
-
-// /datum/status_effect/debuff/revived/on_remove()
-//	owner.apply_status_effect(/datum/status_effect/debuff/revival_addendum) //Cosmetic continuance, to ensure it ends with the 'Permadeath' debuff.*/ //Readd when someone can figure out how to un-errorify this.
-//	. = ..()
-
 /datum/status_effect/debuff/rotted
 	id = "rotted_body" //For de-rot - your body ROTTED. Harsher penalty for longer, can be fully off-set with a cure-rot potion.
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/rotted
 	effectedstats = list(STATKEY_STR = -2, STATKEY_PER = -2, STATKEY_INT = -2, STATKEY_WIL = -2, STATKEY_CON = -2, STATKEY_SPD = -2, STATKEY_LCK = -2)
 	duration = 30 MINUTES	// Back to a temporary 30 minute duration. It hurts.
+	examine_text = "<font color='#2c8b00'>SUBJECTPRONOUN looks frail and unnaturally pale, moving with the hesitant stiffness of one whose body has only recently remembered how to live.</font>"
 
 /atom/movable/screen/alert/status_effect/debuff/rotted
 	name = "Atrophia"
@@ -541,6 +528,7 @@
 	id = "rotted_zombie" //Replaces the flat-stat change, this should ONLY apply to zombies who have been dead for some time. Makes them easier to kill.
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/rotted_zombie
 	effectedstats = list(STATKEY_CON = -8) //No duration = infinate in time - this is removed on de-rot miricle OR de-rot surgery. Won't be applied unless you've been a zombie for ~20 min.
+	examine_text = "<font color='#2c8b00'>SUBJECTPRONOUN's flesh bears the unmistakable signs of unnatural decay. An ill omen whispers that this corpse may yet walk again.</font>"
 
 /atom/movable/screen/alert/status_effect/debuff/rotted_zombie
 	name = "Decomposing"
@@ -551,6 +539,7 @@
 	id = "permadeath"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/permadeath
 	duration = 10 MINUTES //Effectively determines how long a character is threatened with permadeath. Kicks into gear once the initial deathmark-imposed grace period completes. Timed to match Revival Sickness.
+	examine_text = "<font color='#b40000'>SUBJECTPRONOUN appears haunted by an unseen burden. It feels as though their spirit hangs by the thinnest of threads. Another death may well be their last.</font>"
 
 /atom/movable/screen/alert/status_effect/debuff/permadeath
 	name = "Death's Door"
@@ -1148,13 +1137,13 @@
 	if(!ishuman(owner))
 		return FALSE
 	var/mob/living/carbon/human/H = owner
-	var/datum/physiology/phy = H.physiology 
+	var/datum/physiology/phy = H.physiology
 	var/con_mod = H.STACON - 10
 	// con mod needs to be greater than 1 for scaling
 	if(con_mod > 0)
 		// ensure their gotten con mod does not go below 1 or exceed the bleedrate cap.
 		con_mod = clamp(con_mod, 1, CONSTITUTION_BLEEDRATE_CAP - 10)
-		// this ""equalizes"" high con ppl into bleeding more, but they SHOULD generally still 
+		// this ""equalizes"" high con ppl into bleeding more, but they SHOULD generally still
 		// bleed less than if they had just 10 con. remember: this numbers gets sent THRU their con score after.
 		phy.bleed_mod = 1.15 + (con_mod * 0.1) // at 15 con you'll bleed from a wound by .825
 	else
@@ -1166,7 +1155,7 @@
 	if(!ishuman(owner))
 		return FALSE
 	var/mob/living/carbon/human/H = owner
-	var/datum/physiology/phy = H.physiology 
+	var/datum/physiology/phy = H.physiology
 	phy.bleed_mod = initial(phy.bleed_mod) // con can lower from the bleeding so we want it to just directly be set back to the initial
 	H.visible_message(span_warning("[owner] has their wounds calm..."), span_warning("My wounds stop bleeding so heavily!"))
 
@@ -1185,7 +1174,7 @@
 	if(!ishuman(owner))
 		return FALSE
 	var/mob/living/carbon/human/H = owner
-	var/datum/physiology/phy = H.physiology 
+	var/datum/physiology/phy = H.physiology
 	var/pain_mod = phy.pain_mod
 	phy.pain_mod = pain_mod * 1.15 // this then gets reduced by wil, among other things. change as needed.
 	H.visible_message(span_warning("[owner] looks to be in great pain, their wounds BLACKENING!"), span_danger("EVERYTHING HURTS!! MY WOUNDS PAIN HAS INCREASED!!"))
@@ -1195,7 +1184,7 @@
 	if(!ishuman(owner))
 		return FALSE
 	var/mob/living/carbon/human/H = owner
-	var/datum/physiology/phy = H.physiology 
+	var/datum/physiology/phy = H.physiology
 	var/pain_mod = phy.pain_mod
 	phy.pain_mod = pain_mod / 1.15 // this should be a define fuuuck
 	H.visible_message(span_warning("[owner]'s wounds suddenly return to normal!"), span_warning("My magickally induced pain subsides!"))

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -78,79 +78,6 @@
 	if(istype(examined_datum, /datum/antagonist/lich))
 		return span_boldnotice("Another deadite.")
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/atom/movable/screen/alert/status_effect/buff/zombified //Our stat handling "buff
-	name = "zombified"
-	desc = "HUNGER, MUST, HAVE, FLESH"
-	icon_state = "poison"
-
-/datum/status_effect/buff/zombified
-	id = "zombified"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/zombified
-
-/datum/status_effect/buff/zombified/on_apply()
-  /*So how does this work, simply put - we check if you have X stat, if not we take our number and take away your stat from this
-
-  That means we always have the stat change number as our buff/debuff to change your stats to this, its quite a fussy thing to work with
-  But this means that we can keep applying this buff until you de-zombify, constantly changing your statline.
-  Its janky and frankly I would much rather we re-factored buffs to modify an "effective" statline
-
-  As we can then change your "true" statline for antag roles properly currently our only "reasonable" method that we have is using buffs
-  to inefficently do math to figure out our difference and pray it works, this...
-
-  isn't super effective as you can imagine and isn't without flaw. - A good example is debuff/buff before turning will...
-  change our statline since this doesn't update, this is unfortnately an issue with buffs but this is the closet to fixing it..
-
-  Blame Blackstone era roguecode's statcaps for /not/ having a seperated /true/ statline vs buffed one.
-  */
-
-	effectedstats = list(
-		STATKEY_STR = (14 - owner.STASTR),
-		STATKEY_SPD = (5 - owner.STASPD),
-		STATKEY_INT = (1 - owner.STAINT),
-		STATKEY_CON = (12 - owner.STACON),
-		STATKEY_WIL = (13 - owner.STAWIL),
-		STATKEY_PER = (13 - owner.STAPER)
-		)
-	. = ..()
-	return TRUE
-
-/datum/status_effect/buff/zombified/on_remove()
-	. = ..()
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-//Housekeeping/saving variables from pre-zombie
-
-/*Death transformation process goes:
-	death ->
-	/mob/living/carbon/human/death(gibbed) ->
-	zombie_check_can_convert() ->
-	zombie.on_gain() ->
-	rotting.dm process ->
-	time passes ->
-	zombie.wake_zombie() ->
-	transform
-*/
-/*
-	Deadite transformation is 2 ways. First is on the initial bite (low chance) and second is on being chewed on.
-
-	Initial bite is: other_mobs.dm, /mob/living/carbon/onbite(mob/living/carbon/human/user) ->
-	bite_victim.zombie_infect_attempt() ->
-	attempt_zombie_infection(src, "bite", ZOMBIE_BITE_CONVERSION_TIME) -> rng check here
-	time passes ->
-	wake_zombie.
-
-	Wound transformation goes: grabbing.dm, /obj/item/grabbing/bite/proc/bitelimb(mob/living/carbon/human/user) ->
-	/datum/wound/proc/zombie_infect_attempt() ->
-	human_owner.attempt_zombie_infection(src, "wound", zombie_infection_time) ->
-	time passes ->
-	wake_zombie
-
-	Infection transformation process goes -> infection -> timered transform in zombie_infect_attempt() [drink red/holy water and kill timer?] -> /datum/antagonist/zombie/proc/wake_zombie -> zombietransform
-*/
-
 /datum/antagonist/zombie/on_gain(admin_granted = FALSE)
 	var/mob/living/carbon/human/zombie = owner?.current
 	if(zombie)
@@ -201,7 +128,6 @@
 									 // There is a better way to maintain it but needs overhaul. Will cover the two methods of zombie
 		GLOB.alive_mob_list += zombie// in both cure rot and medicine.
 
-		zombie.remove_status_effect(/datum/status_effect/buff/zombified)
 		zombie.cmode_music = cmode_music
 
 		for(var/trait in traits_zombie)
@@ -250,7 +176,6 @@
 
 	revived = TRUE //so we can die for real later
 	add_antag_hud(antag_hud_type, antag_hud_name, owner.current) //Easier for zombies to tell, fellow zombies.
-	zombie.apply_status_effect(/datum/status_effect/buff/zombified) //Handle our stats
 
 	zombie.grant_language(/datum/language/undead) //Now we give you the language.
 	var/datum/language_holder/language_holder = zombie.get_language_holder()
@@ -382,6 +307,7 @@
 	zombie.update_sight()
 	zombie.reload_fullscreen()
 	zombie.handle_blood()
+	zombie.refresh_blood_debuffs()
 	transform_zombie()
 	if(zombie.stat >= DEAD)
 		//could not revive

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -95,14 +95,14 @@
   That means we always have the stat change number as our buff/debuff to change your stats to this, its quite a fussy thing to work with
   But this means that we can keep applying this buff until you de-zombify, constantly changing your statline.
   Its janky and frankly I would much rather we re-factored buffs to modify an "effective" statline
-  
+
   As we can then change your "true" statline for antag roles properly currently our only "reasonable" method that we have is using buffs
   to inefficently do math to figure out our difference and pray it works, this...
-  
+
   isn't super effective as you can imagine and isn't without flaw. - A good example is debuff/buff before turning will...
   change our statline since this doesn't update, this is unfortnately an issue with buffs but this is the closet to fixing it..
 
-  Blame Blackstone era roguecode's statcaps for /not/ having a seperated /true/ statline vs buffed one. 
+  Blame Blackstone era roguecode's statcaps for /not/ having a seperated /true/ statline vs buffed one.
   */
 
 	effectedstats = list(
@@ -381,6 +381,7 @@
 	zombie.update_mobility()
 	zombie.update_sight()
 	zombie.reload_fullscreen()
+	zombie.handle_blood()
 	transform_zombie()
 	if(zombie.stat >= DEAD)
 		//could not revive
@@ -482,7 +483,7 @@
 	ADD_TRAIT(owner, TRAIT_IGNORESLOWDOWN, id)
 	ADD_TRAIT(owner, TRAIT_LONGSTRIDER, id)
 	ADD_TRAIT(owner, TRAIT_STRONG_GRABBER, id)
-	to_chat(owner, span_userdanger("I feel my body tense up immensely in response to this hunger, tendrils of darkness crawling under my skin.")) 
+	to_chat(owner, span_userdanger("I feel my body tense up immensely in response to this hunger, tendrils of darkness crawling under my skin."))
 
 /datum/status_effect/debuff/deadite_grace/on_remove()
 	. = ..()

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -14,10 +14,41 @@
 	if(stat != DEAD && bleed_rate)
 		to_chat(src, span_warning("The blood soaks through my bandage."))
 
+/mob/living/carbon/proc/refresh_blood_debuffs()
+	remove_status_effect(/datum/status_effect/debuff/bleeding)
+	remove_status_effect(/datum/status_effect/debuff/bleedingworse)
+	remove_status_effect(/datum/status_effect/debuff/bleedingworst)
+
+	switch(blood_volume)
+		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
+			if(prob(3))
+				to_chat(src, span_warning("I feel dizzy."))
+			remove_status_effect(/datum/status_effect/debuff/bleedingworse)
+			remove_status_effect(/datum/status_effect/debuff/bleedingworst)
+			apply_status_effect(/datum/status_effect/debuff/bleeding)
+
+		if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
+			if(prob(3))
+				blur_eyes(6)
+				to_chat(src, span_warning("I feel faint."))
+			remove_status_effect(/datum/status_effect/debuff/bleeding)
+			remove_status_effect(/datum/status_effect/debuff/bleedingworst)
+			apply_status_effect(/datum/status_effect/debuff/bleedingworse)
+
+		if(0 to BLOOD_VOLUME_BAD)
+			if(prob(3))
+				blur_eyes(6)
+				to_chat(src, span_warning("I feel faint."))
+			if(prob(3))
+				to_chat(src, span_warning("I feel drained."))
+			remove_status_effect(/datum/status_effect/debuff/bleeding)
+			remove_status_effect(/datum/status_effect/debuff/bleedingworse)
+			apply_status_effect(/datum/status_effect/debuff/bleedingworst)
+
 /mob/living/proc/handle_blood()
 	if((bodytemperature <= TCRYO) || HAS_TRAIT(src, TRAIT_HUSK)) //cryosleep or husked people do not pump the blood.
 		return
-	
+
 	blood_volume = min(blood_volume, BLOOD_VOLUME_MAXIMUM)
 	//Effects of bloodloss - only run if we're not actually dead.
 	if (stat != DEAD)
@@ -71,7 +102,7 @@
 /mob/living/carbon/handle_blood()
 	if((bodytemperature <= TCRYO) || HAS_TRAIT(src, TRAIT_HUSK)) //cryosleep or husked people do not pump the blood.
 		return
-	
+
 	blood_volume = min(blood_volume, BLOOD_VOLUME_MAXIMUM)
 	if(dna?.species)
 		if(NOBLOOD in dna.species.species_traits)


### PR DESCRIPTION
## About The Pull Request

- Deletes most of the buffs that cause you to get modified stats as a Deadite, because when you get resurrected, sometimes it permanently removes your stats for no reason at all. They'll still suffer from Atrophy and NORMAL debuffs, however. As those never did cause problems.

## Testing Evidence

I'll need this TM'd for a while so people can tell me if we get any weird bugs and then act on them.

## Why It's Good For The Game

No more losing stats forever I guess.

## Changelog
:cl:
del: Nukes Deadite snapshot buffs/debuffs.
/:cl: