### PR TITLE
Woodcutting typecheck fix

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -39,7 +39,7 @@ T1 Enchantments below here*/
 /obj/item/enchantmentscroll/basic/woodcut/attack_obj(obj/item/O, mob/living/user)
 	if(!..())
 		return
-	if(istype(O,/obj/item/rogueweapon/stoneaxe) || istype(O,/obj/item/rogueweapon/halberd) || istype(O,/obj/item/rogueweapon/greataxe))
+	if(istype(O,/obj/item/rogueweapon/stoneaxe) || istype(O,/obj/item/rogueweapon/halberd) || istype(O,/obj/item/rogueweapon/greataxe) || istype(O,/obj/item/rogueweapon/pick/bronze))
 		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
 		var/magiceffect= new component
 		O.AddComponent(/datum/component/magic_item, magiceffect)

--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -39,7 +39,7 @@ T1 Enchantments below here*/
 /obj/item/enchantmentscroll/basic/woodcut/attack_obj(obj/item/O, mob/living/user)
 	if(!..())
 		return
-	if(istype(O,/obj/item/rogueweapon/stoneaxe))
+	if(istype(O,/obj/item/rogueweapon/stoneaxe) || istype(O,/obj/item/rogueweapon/halberd) || istype(O,/obj/item/rogueweapon/greataxe))
 		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
 		var/magiceffect= new component
 		O.AddComponent(/datum/component/magic_item, magiceffect)


### PR DESCRIPTION
## About The Pull Request
Certain things that are at least "significantly axe-like" and are therefore oft used to cut down trees - greataxes, halberds, poleaxes, etc - but were not parented to stoneaxe could not have the woodcutting enchantment applied to them, despite it functioning perfectly fine on them. This PR fixes this by expanding the check to include the greataxe and halberd types, which also bundles in poleaxes and bardiches and basically everything else that is "an axe +".

## Testing Evidence
compiles. it's 2 typechecks added to an extant typecheck

## Why It's Good For The Game
Going to be honest: this is almost never going to see use. HOWEVER, it came up in a round earlier - someone wanted woodcutting on their halberd, and we were surprised that it didn't work. It's suboptimal for fragging since you can't go back and put, like, infernal flame on it, but for utility it's nice to have, and that's probably something we should be encouraging? Axes are way cheaper than halberds so like most advs will already have something that can do this.

## Changelog

:cl:
add: The woodcutting enchantment can now be applied to more 'axe-like' weapons: greataxes, halberds, poleaxes, etc. Previously, it could only be applied to specific types of axes (the one-handed, non-weapon kind mostly).
/:cl: