### PR TITLE
Smelting 'improvements'

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -164,7 +164,7 @@
 - #B8B8B8, #C2C2C2, #CCCCCC, #D6D6D6, #E2E2E2, #EFEFEF, #FFFFFF
 - For kite shield I specifically applied dark edges to the side to create the illusion of edge
 - This was done with Aseprite's Replace Color tool. Wooden Shield has 7 colors, Kite & Heater had 8, and Iron had something like 15. I compressed the rest's range.
-- Iron Shield had like 7 colors that were just a tiny variation with one pixel it felt like - so I just compressed literally all of them into E2E2E2 with no actual loss of fidelity. 
+- Iron Shield had like 7 colors that were just a tiny variation with one pixel it felt like - so I just compressed literally all of them into E2E2E2 with no actual loss of fidelity.
 - If you want edge, boss, rims etc. to be dynamically excluded just paint them transparent.
 - This applies a shading and 3D depth to a flat heraldry, and allows us to in the future uses heraldry across multiple shields. For now, since I have no art skills I cannot retroactively convert the existing per shield heraldry to a flat heraldry that is then, applied dynamically on top.
 - But once artist catch up to my work this will enables us to share 1 heraldry across 4 or more shields with very simple work.
@@ -364,7 +364,7 @@
 	throwforce = 10
 	throw_speed = 1
 	throw_range = 3
-	possible_item_intents = list(SHIELD_BASH_METAL, SHIELD_BLOCK, SHIELD_SMASH_METAL)	
+	possible_item_intents = list(SHIELD_BASH_METAL, SHIELD_BLOCK, SHIELD_SMASH_METAL)
 	wlength = WLENGTH_NORMAL
 	resistance_flags = null
 	flags_1 = CONDUCT_1
@@ -677,7 +677,7 @@
 	name = "bone shield"
 	desc = "If they couldn't protect their previous owners, how confident are you in these bones protecting you?"
 	icon_state = "boneshield"
-	smeltresult = null 
+	smeltresult = null
 
 /obj/item/rogueweapon/shield/iron/graggar
 	name = "vicious targe"
@@ -709,7 +709,7 @@
 	minstr = 11 //Particularly heavy to use as a melee weapon.
 	attacked_sound = list('sound/combat/parry/shield/metalshield (1).ogg','sound/combat/parry/shield/metalshield (2).ogg','sound/combat/parry/shield/metalshield (3).ogg')
 	parrysound = list('sound/combat/parry/shield/metalshield (1).ogg','sound/combat/parry/shield/metalshield (2).ogg','sound/combat/parry/shield/metalshield (3).ogg')
-	possible_item_intents = list(/datum/intent/shield/block, /datum/intent/mace/smash/shield/metal, /datum/intent/effect/daze) // No SHIELD_BASH. Able to inflict Daze due to its weight. 
+	possible_item_intents = list(/datum/intent/shield/block, /datum/intent/mace/smash/shield/metal, /datum/intent/effect/daze) // No SHIELD_BASH. Able to inflict Daze due to its weight.
 	max_integrity = 260
 	anvilrepair = /datum/skill/craft/weaponsmithing
 
@@ -731,7 +731,7 @@
 	max_integrity = 360 //Highest integrity and passive projectile-blocking chance of most non-unique shields.
 	possible_item_intents = list(/datum/intent/shield/block, /datum/intent/mace/smash/shield/metal/great, /datum/intent/effect/daze) // No SHIELD_BASH. Able to inflict Daze due to its weight.
 	force = 28
-	coverage = 75 
+	coverage = 75
 	wdefense = 10
 	minstr = 12 //Requires a natural +STR modifier or statpack to double as a melee weapon, for its given class. Note that it has a heavier charge time and active stamina drain, too, as.. well, it's quite heavy.
 

--- a/code/modules/roguetown/roguejobs/blacksmith/recipe_lookup.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/recipe_lookup.dm
@@ -1,31 +1,27 @@
 GLOBAL_LIST_EMPTY(anvil_recipe_smelt_cache)
 
 /proc/build_anvil_recipe_smelt_cache()
-	for(var/recipe_path in subtypesof(/datum/anvil_recipe))
-		var/datum/anvil_recipe/R = recipe_path
-		if(initial(R.abstract_type) == recipe_path)
+	for(var/datum/anvil_recipe/recipe as anything in GLOB.anvil_recipes)
+		if(!recipe.created_item)
 			continue
-		var/created = initial(R.created_item)
-		if(!created)
+		if(GLOB.anvil_recipe_smelt_cache[recipe.created_item])
 			continue
-		if(GLOB.anvil_recipe_smelt_cache[created])
+		if(recipe.createditem_num > 1)
 			continue
-		var/datum/anvil_recipe/instance = new recipe_path
 		var/list/products = list()
-		if(ispath(instance.req_bar, /obj/item/ingot))
-			products |= instance.req_bar
-		for(var/path in instance.additional_items)
+		if(ispath(recipe.req_bar, /obj/item/ingot))
+			products |= recipe.req_bar
+		for(var/path in recipe.additional_items)
 			if(ispath(path, /obj/item/ingot))
 				products |= path
-		qdel(instance)
 		if(length(products))
-			GLOB.anvil_recipe_smelt_cache[created] = products
+			GLOB.anvil_recipe_smelt_cache[recipe.created_item] = products
 
 /obj/item/proc/get_smelt_products()
 	if(!smeltable)
 		return null
 	if(smeltresult)
 		return list(smeltresult)
-	if(!length(GLOB.anvil_recipe_smelt_cache))
+	if(length(GLOB.anvil_recipes) && !length(GLOB.anvil_recipe_smelt_cache))
 		build_anvil_recipe_smelt_cache()
 	return GLOB.anvil_recipe_smelt_cache[type]

--- a/code/modules/roguetown/roguejobs/blacksmith/recipe_lookup.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/recipe_lookup.dm
@@ -1,0 +1,29 @@
+GLOBAL_LIST_EMPTY(anvil_recipe_smelt_cache)
+
+/proc/build_anvil_recipe_smelt_cache()
+	for(var/recipe_path in subtypesof(/datum/anvil_recipe))
+		var/datum/anvil_recipe/R = recipe_path
+		if(initial(R.abstract_type) == recipe_path)
+			continue
+		var/created = initial(R.created_item)
+		if(!created)
+			continue
+		if(GLOB.anvil_recipe_smelt_cache[created])
+			continue
+		var/datum/anvil_recipe/instance = new recipe_path
+		var/list/products = list()
+		if(ispath(instance.req_bar, /obj/item/ingot))
+			products |= instance.req_bar
+		for(var/path in instance.additional_items)
+			if(ispath(path, /obj/item/ingot))
+				products |= path
+		qdel(instance)
+		if(length(products))
+			GLOB.anvil_recipe_smelt_cache[created] = products
+
+/obj/item/proc/get_smelt_products()
+	if(smeltresult)
+		return list(smeltresult)
+	if(!length(GLOB.anvil_recipe_smelt_cache))
+		build_anvil_recipe_smelt_cache()
+	return GLOB.anvil_recipe_smelt_cache[type]

--- a/code/modules/roguetown/roguejobs/blacksmith/recipe_lookup.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/recipe_lookup.dm
@@ -22,6 +22,8 @@ GLOBAL_LIST_EMPTY(anvil_recipe_smelt_cache)
 			GLOB.anvil_recipe_smelt_cache[created] = products
 
 /obj/item/proc/get_smelt_products()
+	if(!smeltable)
+		return null
 	if(smeltresult)
 		return list(smeltresult)
 	if(!length(GLOB.anvil_recipe_smelt_cache))

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -4,7 +4,7 @@
 	// This might need a small rework, smeltresult is a fallback for all items when they dont have a recipe, so you can still make them re-smelt things even if they dont have a recipe.
 	// But smeltable is also needed for items that have a recipe but you dont want it to be re-smelted, its a stop gap since the proc checks for smetlabe -> smeltresult -> recipe.
 	// This means that somebody will need to personally set unsmeltable items as smeltable = false, and i dont have the gameplay knowledge to know whats what right now.
-	var/smeltable
+	var/smeltable = TRUE
 	var/smelt_bar_num = 1 //variable for tracking how many bars things smelt back into for multi-bar items
 // MULTIBAR SMELTING WAS DISABLED FOR BALANCE REASONS
 // DO NOT RE-ENABLE IT UNTIL FURTHER NOTICE

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -129,7 +129,7 @@
 		if(!.) //False/null if using the item as fuel. If true, we want to try smelt it so go onto next segment.
 			return
 
-	if(attacking_item.smeltresult)
+	if(length(attacking_item.get_smelt_products()))
 		add_item(attacking_item, user) // Adds the item to the smelter's contained_items list, if it can be smelted.
 		return
 
@@ -147,7 +147,7 @@
 
 	if(istype(held, /obj/item))
 		var/obj/item/I = held
-		if(I.smeltresult)
+		if(length(I.get_smelt_products()))
 			add_item(I, user)
 			return
 
@@ -231,16 +231,13 @@
 
 /obj/machinery/light/rogue/smelter/proc/handle_smelting()
 	for(var/obj/item/item as anything in contained_items)
-		if(item.smeltresult)
-			// disabled for now, balance reasons
-			// while(item.smelt_bar_num)
-			// 	item.smelt_bar_num--
-			// 	var/obj/item/result = new item.smeltresult(src, contained_items[item])
-			// 	contained_items += result
-			// contained_items -= item
-			var/obj/item/result = new item.smeltresult(src, contained_items[item])
+		var/list/products = item.get_smelt_products()
+		if(length(products))
+			var/quality = contained_items[item]
 			contained_items -= item
-			contained_items += result
+			for(var/product_path in products)
+				var/obj/item/result = new product_path(src, quality)
+				contained_items += result
 			qdel(item)
 	playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 	visible_message(span_notice("\The [src] finished smelting."))
@@ -323,10 +320,13 @@
 			contained_items += result
 	else
 		for(var/obj/item/item in contained_items)
-			if(item.smeltresult)
-				var/obj/item/result = new item.smeltresult(src, contained_items[item])
+			var/list/products = item.get_smelt_products()
+			if(length(products))
+				var/quality = contained_items[item]
 				contained_items -= item
-				contained_items += result
+				for(var/product_path in products)
+					var/obj/item/result = new product_path(src, quality)
+					contained_items += result
 				qdel(item)
 
 	playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
@@ -376,10 +376,13 @@
 			contained_items += result
 	else
 		for(var/obj/item/item in contained_items)
-			if(item.smeltresult)
-				var/obj/item/result = new item.smeltresult(src, contained_items[item])
+			var/list/products = item.get_smelt_products()
+			if(length(products))
+				var/quality = contained_items[item]
 				contained_items -= item
-				contained_items += result
+				for(var/product_path in products)
+					var/obj/item/result = new product_path(src, quality)
+					contained_items += result
 				qdel(item)
 
 	playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -1,6 +1,10 @@
 
 /obj/item
 	var/smeltresult
+	// This might need a small rework, smeltresult is a fallback for all items when they dont have a recipe, so you can still make them re-smelt things even if they dont have a recipe.
+	// But smeltable is also needed for items that have a recipe but you dont want it to be re-smelted, its a stop gap since the proc checks for smetlabe -> smeltresult -> recipe.
+	// This means that somebody will need to personally set unsmeltable items as smeltable = false, and i dont have the gameplay knowledge to know whats what right now.
+	var/smeltable
 	var/smelt_bar_num = 1 //variable for tracking how many bars things smelt back into for multi-bar items
 // MULTIBAR SMELTING WAS DISABLED FOR BALANCE REASONS
 // DO NOT RE-ENABLE IT UNTIL FURTHER NOTICE

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2812,6 +2812,7 @@
 #include "code\modules\roguetown\roguejobs\blacksmith\forgeables.dm"
 #include "code\modules\roguetown\roguejobs\blacksmith\grindwheel.dm"
 #include "code\modules\roguetown\roguejobs\blacksmith\items.dm"
+#include "code\modules\roguetown\roguejobs\blacksmith\recipe_lookup.dm"
 #include "code\modules\roguetown\roguejobs\blacksmith\smelter.dm"
 #include "code\modules\roguetown\roguejobs\blacksmith\tools.dm"
 #include "code\modules\roguetown\roguejobs\blacksmith\anvil_recipes\_anvil_recipe.dm"


### PR DESCRIPTION
## About The Pull Request

This rewrites smelting code so that smelt result is no longer required. As long as the weapon you're smelting has a recipe (For example an iron shield or something) it will return ONE ingot from the original recipe. (This can be changed by editing the line that cuts it.)

In short ;
The new code checks if the item is smeltable at all.
Then it checks if the item has a smelt result (So you can make items that do not have a recipe, still drop things, for example a shield that drops from somewhere that you don't want people to craft, but are otherwise fine with it being smelted down into a smeltresult = whateveryouwant.)
Then the code will check for a recipe, meaning, if its smeltable, and there's no explicit smelt result set it will drop one ingot back from the original recipe.

This might still need some testing on the live server for some edge cases.

Should also stop issues like #7641 from appearing.

## Testing Evidence

I melted things down and they returned one bar from the original recipe.
My only concern is some things might now be smeltable that otherwise shouldnt be so i'd appreciate a thorough review on the items.
## Why It's Good For The Game

Should arguably make it easier for people to add smeltable items without bothering with too much of the code, allows for more item flexibility.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Rework smelting code, allows items to be just smelt back into its recipes without it being explicity set in smeltresult (one singular bar as per balance request in the code)
code: Adds a flag for making items non smeltable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
