### PR TITLE
Hit by a Truck Driven by FreeStylalt and Reborn as an Azure Peak Coder And Then I Viewed the Total Profiler and I Had a Heart Attack Isekai Adventure (Optimization Followup Pack 1)

### DIFF
--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -162,6 +162,9 @@
 "ev" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/manor)
+"eW" = (
+/turf/open/water,
+/area/rogue/outdoors)
 "fb" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -338,6 +341,9 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors)
+"lk" = (
+/turf/open/water/ocean/deep,
+/area/rogue/outdoors)
 "lm" = (
 /obj/item/roguemachine/mastermail,
 /turf/closed/wall/mineral/rogue/decostone/cand,
@@ -1228,6 +1234,9 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors)
+"GO" = (
+/turf/open/water/swamp/deep,
+/area/rogue/outdoors)
 "Hb" = (
 /obj/structure/roguemachine/goldface,
 /turf/open/floor/rogue/blocks/newstone/alt,
@@ -1665,6 +1674,9 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors)
+"Vz" = (
+/turf/open/water/river/flow/north,
+/area/rogue/outdoors)
 "VD" = (
 /obj/structure/fluff/customsign{
 	desc = "COURIER QUEST"
@@ -3179,9 +3191,9 @@ rT
 sR
 IC
 rT
-rT
-rT
-rT
+eW
+eW
+eW
 vq
 vq
 wX
@@ -3231,9 +3243,9 @@ rT
 Yf
 hq
 rT
-rT
-rT
-rT
+lk
+lk
+lk
 rT
 vq
 wX
@@ -3283,9 +3295,9 @@ rT
 YU
 XN
 rT
-rT
-rT
-rT
+GO
+GO
+GO
 rT
 vq
 wX
@@ -3335,9 +3347,9 @@ rT
 rT
 BU
 rT
-rT
-rT
-rT
+Vz
+Vz
+Vz
 rT
 vq
 hh

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1021,13 +1021,6 @@ GLOBAL_VAR_INIT(pixel_diff_time, 1)
 	icon = 'icons/effects/effects.dmi'
 	duration = 3
 
-/atom/movable/proc/do_warning()
-	var/image/I
-	I = image('icons/effects/effects.dmi', src, "mobwarning", src.layer + 0.1)
-	I.pixel_y = 16
-	flick_overlay(I, GLOB.clients, 5)
-
-
 /atom/movable/vv_get_dropdown()
 	. = ..()
 	. += "<option value='?_src_=holder;[HrefToken()];adminplayerobservefollow=[REF(src)]'>Follow</option>"
@@ -1184,12 +1177,12 @@ GLOBAL_VAR_INIT(pixel_diff_time, 1)
 		to_x = -32
 	if(!direction)
 		to_y = 16
-	flick_overlay(I, GLOB.clients, 6)
+	var/atom/movable/flick_visual/pickup = T.flick_overlay_view(I, 6)
 	var/matrix/M = new
 	M.Turn(pick(-30, 30))
-	animate(I, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = M, easing = CUBIC_EASING)
+	animate(pickup, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = M, easing = CUBIC_EASING)
 	sleep(1)
-	animate(I, alpha = 0, transform = matrix(), time = 1)
+	animate(pickup, alpha = 0, transform = matrix(), time = 1)
 
 /atom/movable/Exited(atom/movable/gone, atom/newLoc)
 	. = ..()

--- a/code/game/objects/items/storage/new_storage/tetris.dm
+++ b/code/game/objects/items/storage/new_storage/tetris.dm
@@ -120,9 +120,6 @@
 
 				stored_item.mouse_opacity = MOUSE_OPACITY_OPAQUE
 				bound_underlay = get_bound_underlay(used_gridwidth, used_gridheight)
-				if(!bound_underlay)
-					bound_underlay = generate_bound_underlay(used_gridwidth, used_gridheight)
-					underlay_appearances_by_size["[used_gridwidth]x[used_gridheight]"] = bound_underlay
 				stored_item.underlays += bound_underlay
 				screen_loc = LAZYACCESSASSOC(master.item_to_grid_coordinates, stored_item, 1)
 				screen_loc = master.grid_coordinates_to_screen_loc(screen_loc)
@@ -146,9 +143,6 @@
 				var/used_gridwidth = stored_item.grid_width
 				var/used_gridheight = stored_item.grid_height
 				bound_underlay = get_bound_underlay(used_gridwidth, used_gridheight)
-				if(!bound_underlay)
-					bound_underlay = generate_bound_underlay(used_gridwidth, used_gridheight)
-					underlay_appearances_by_size["[used_gridwidth]x[used_gridheight]"] = bound_underlay
 				stored_item.underlays += bound_underlay
 				screen_loc = LAZYACCESSASSOC(master.item_to_grid_coordinates, stored_item, 1)
 				screen_loc = master.grid_coordinates_to_screen_loc(screen_loc)
@@ -536,8 +530,13 @@
 			if(existing_item && (!dragged_item || (existing_item != dragged_item)))
 				return FALSE
 	return TRUE
-/datum/component/storage/proc/get_bound_underlay(grid_width = world.icon_size, grid_height = world.icon_size, enchanted)
-	return LAZYACCESS(underlay_appearances_by_size, "[grid_width]x[grid_height]_[enchanted]")
+/datum/component/storage/proc/get_bound_underlay(grid_width = world.icon_size, grid_height = world.icon_size, enchanted = FALSE)
+	var/underlay_key = "[grid_width]x[grid_height]_[enchanted]"
+	var/mutable_appearance/bound_underlay = underlay_appearances_by_size[underlay_key]
+	if(!bound_underlay)
+		bound_underlay = generate_bound_underlay(grid_width, grid_height, enchanted)
+		underlay_appearances_by_size[underlay_key] = bound_underlay
+	return bound_underlay
 
 /**
  * Generates and caches an underlay for the given width and height.

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -107,7 +107,7 @@
 	I.pixel_y = 6
 	I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	I.appearance_flags = RESET_COLOR
-	flick_overlay(I, GLOB.clients, 6)
+	flick_overlay_view(I, A, 6)
 
 /proc/ping_sound_through_walls(turf/T)
 	new /obj/effect/temp_visual/soundping(T)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -88,14 +88,16 @@
 
 	. = ..()
 
-	AddComponent(/datum/component/arousal)
-
-
 	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(clean_blood))
 	AddComponent(/datum/component/personal_crafting)
 	AddComponent(/datum/component/footstep, footstep_type, 1, 2)
 	GLOB.human_list += src
 	unarmed_special = new /datum/special_intent/upper_cut()
+
+/mob/living/carbon/human/Login()
+	. = ..()
+	if(!GetComponent(/datum/component/arousal))
+		AddComponent(/datum/component/arousal)
 
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
 	var/obj/item/bodypart/affecting

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -74,6 +74,12 @@
 	var/obj/item/cloak = null
 	var/obj/item/clothing/wear_shirt = null
 
+	var/cached_worn_ac = ARMOR_CLASS_NONE
+	var/cached_head_ac = ARMOR_CLASS_NONE
+	var/cached_hands_ac = ARMOR_CLASS_NONE
+	var/cached_body_ac = ARMOR_CLASS_NONE
+	var/worn_ac_dirty = TRUE
+
 	var/special_voice = "" // For changing our voice. Used by a symptom.
 
 	var/name_override //For temporary visible name changes

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -8,6 +8,7 @@
 				.[id] = data
 
 /mob/living/carbon/human/update_equipment_speed_mods()
+	worn_ac_dirty = TRUE
 	. = ..()
 	update_move_intent_slowdown()
 
@@ -20,11 +21,9 @@
 /mob/living/carbon/human/proc/get_ac_speed()
 	if(HAS_TRAIT(src, TRAIT_ARMOR_NOSPDCAP))
 		return 0
-	var/highest_class = ARMOR_CLASS_NONE
-	for(var/obj/item/clothing/C in list(wear_armor, wear_shirt, wear_pants, head))
-		if(C.armor_class > highest_class)
-			highest_class = C.armor_class
-	switch(highest_class)
+	if(worn_ac_dirty)
+		update_worn_ac_cache()
+	switch(max(cached_body_ac, cached_head_ac))
 		if(ARMOR_CLASS_LIGHT)
 			return AC_LIGHT_SPDCAP
 		if(ARMOR_CLASS_MEDIUM)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -351,6 +351,8 @@
 		if(!QDELETED(src))
 			update_inv_mouth()
 
+	worn_ac_dirty = TRUE
+
 	// Armor class warning — must run after slot vars are nulled so check_armor_skill() sees the correct state
 	if(!QDELETED(src) && istype(I, /obj/item/clothing))
 		var/obj/item/clothing/C = I

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -370,7 +370,7 @@
 		if(C.armor_class > cached_body_ac)
 			cached_body_ac = C.armor_class
 	cached_worn_ac = cached_body_ac
-	for(var/obj/item/clothing/C in list(wear_wrists, gloves, shoes, wear_neck, wear_mask, wear_ring))
+	for(var/obj/item/clothing/C in list(wear_wrists, gloves, shoes, wear_neck, wear_mask, wear_ring, cloak))
 		if(C.armor_class > cached_worn_ac)
 			cached_worn_ac = C.armor_class
 	if(istype(head, /obj/item/clothing))

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -344,35 +344,42 @@
 
 /// Returns the highest AC worn, or held in hands.
 /mob/living/carbon/human/proc/highest_ac_worn(check_hands, check_helmet = TRUE)
-	var/list/slots = list(wear_armor, wear_pants, wear_wrists, wear_shirt, gloves, head, shoes, wear_neck, wear_mask, wear_ring)
-	if(!check_helmet)
-		slots.Remove(head)
-	for(var/slot in slots)
-		if(isnull(slot) || !istype(slot, /obj/item/clothing))
-			slots.Remove(slot)
+	if(worn_ac_dirty)
+		update_worn_ac_cache()
+#if defined(TESTING) || defined(UNIT_TESTS)
+	else
+		var/frozen_worn = cached_worn_ac
+		var/frozen_head = cached_head_ac
+		var/frozen_hands = cached_hands_ac
+		var/frozen_body = cached_body_ac
+		update_worn_ac_cache()
+		if(frozen_worn != cached_worn_ac || frozen_head != cached_head_ac || frozen_hands != cached_hands_ac || frozen_body != cached_body_ac)
+			stack_trace("Stale worn AC cache on [src]: worn [frozen_worn]->[cached_worn_ac] head [frozen_head]->[cached_head_ac] hands [frozen_hands]->[cached_hands_ac] body [frozen_body]->[cached_body_ac]")
+#endif
+	. = cached_worn_ac
+	if(check_helmet && cached_head_ac > .)
+		. = cached_head_ac
+	if(check_hands && cached_hands_ac > .)
+		. = cached_hands_ac
 
-	
-	var/highest_ac = ARMOR_CLASS_NONE
-
-	for(var/obj/item/clothing/C in slots)
-		if(C.armor_class)
-			if(C.armor_class > highest_ac)
-				highest_ac = C.armor_class
-				if(highest_ac == ARMOR_CLASS_HEAVY)
-					return highest_ac
-	if(check_hands)
-		var/mainh = get_active_held_item()
-		var/offh = get_inactive_held_item()
-		if(mainh && istype(mainh, /obj/item/clothing))
-			var/obj/item/clothing/CMH = mainh
-			if(CMH.armor_class > highest_ac)
-				highest_ac = CMH.armor_class 
-		if(offh && istype(offh, /obj/item/clothing))
-			var/obj/item/clothing/COH = offh
-			if(COH.armor_class > highest_ac)
-				highest_ac = COH.armor_class 
-	
-	return highest_ac
+/mob/living/carbon/human/proc/update_worn_ac_cache()
+	cached_body_ac = ARMOR_CLASS_NONE
+	cached_head_ac = ARMOR_CLASS_NONE
+	cached_hands_ac = ARMOR_CLASS_NONE
+	for(var/obj/item/clothing/C in list(wear_armor, wear_shirt, wear_pants))
+		if(C.armor_class > cached_body_ac)
+			cached_body_ac = C.armor_class
+	cached_worn_ac = cached_body_ac
+	for(var/obj/item/clothing/C in list(wear_wrists, gloves, shoes, wear_neck, wear_mask, wear_ring))
+		if(C.armor_class > cached_worn_ac)
+			cached_worn_ac = C.armor_class
+	if(istype(head, /obj/item/clothing))
+		var/obj/item/clothing/C = head
+		cached_head_ac = C.armor_class || ARMOR_CLASS_NONE
+	for(var/obj/item/clothing/C in held_items)
+		if(C.armor_class > cached_hands_ac)
+			cached_hands_ac = C.armor_class
+	worn_ac_dirty = FALSE
 
 /mob/living/carbon/human/proc/process_tempo_attack(mob/living/carbon/attacker)
 	if(iscarbon(attacker) && attacker != src && attacker.mind)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -747,42 +747,13 @@
 	return TRUE
 
 /mob/living/carbon/human/check_armor_skill()
-	if(istype(src.wear_armor, /obj/item/clothing))
-		var/obj/item/clothing/CL = src.wear_armor
-		if(CL.armor_class == ARMOR_CLASS_HEAVY)
-			if(!HAS_TRAIT(src, TRAIT_HEAVYARMOR))
-				return FALSE
-		if(CL.armor_class == ARMOR_CLASS_MEDIUM)
-			if(!HAS_TRAIT(src, TRAIT_HEAVYARMOR))
-				if(!HAS_TRAIT(src, TRAIT_MEDIUMARMOR))
-					return FALSE
-	if(istype(src.wear_shirt, /obj/item/clothing))
-		var/obj/item/clothing/CL = src.wear_shirt
-		if(CL.armor_class == ARMOR_CLASS_HEAVY)
-			if(!HAS_TRAIT(src, TRAIT_HEAVYARMOR))
-				return FALSE
-		if(CL.armor_class == ARMOR_CLASS_MEDIUM)
-			if(!HAS_TRAIT(src, TRAIT_HEAVYARMOR))
-				if(!HAS_TRAIT(src, TRAIT_MEDIUMARMOR))
-					return FALSE
-	if(istype(src.wear_pants, /obj/item/clothing))
-		var/obj/item/clothing/CL = src.wear_pants
-		if(CL.armor_class == ARMOR_CLASS_HEAVY)
-			if(!HAS_TRAIT(src, TRAIT_HEAVYARMOR))
-				return FALSE
-		if(CL.armor_class == ARMOR_CLASS_MEDIUM)
-			if(!HAS_TRAIT(src, TRAIT_HEAVYARMOR))
-				if(!HAS_TRAIT(src, TRAIT_MEDIUMARMOR))
-					return FALSE
-	if(istype(src.head, /obj/item/clothing))
-		var/obj/item/clothing/CL = src.head
-		if(CL.armor_class == ARMOR_CLASS_HEAVY)
-			if(!HAS_TRAIT(src, TRAIT_HEAVYARMOR))
-				return FALSE
-		if(CL.armor_class == ARMOR_CLASS_MEDIUM)
-			if(!HAS_TRAIT(src, TRAIT_HEAVYARMOR))
-				if(!HAS_TRAIT(src, TRAIT_MEDIUMARMOR))
-					return FALSE
+	if(worn_ac_dirty)
+		update_worn_ac_cache()
+	var/ac = max(cached_body_ac, cached_head_ac)
+	if(ac == ARMOR_CLASS_HEAVY && !HAS_TRAIT(src, TRAIT_HEAVYARMOR))
+		return FALSE
+	if(ac == ARMOR_CLASS_MEDIUM && !HAS_TRAIT(src, TRAIT_HEAVYARMOR) && !HAS_TRAIT(src, TRAIT_MEDIUMARMOR))
+		return FALSE
 	return TRUE
 
 /mob/living/proc/check_dodge_skill(check_trait = TRUE)

--- a/code/modules/sexcon/components/arousal.dm
+++ b/code/modules/sexcon/components/arousal.dm
@@ -42,18 +42,25 @@
 
 /datum/component/arousal/process(dt)
 	handle_charge(dt * 1)
-	if(!can_lose_arousal())
-		return
-	adjust_arousal(parent, dt * -1)
+	if(can_lose_arousal())
+		adjust_arousal(parent, dt * -1)
+	if(arousal <= 0 && charge >= SEX_MAX_CHARGE)
+		return PROCESS_KILL
 
 /// Checks if our parent has a client and adjusts processing.
 /datum/component/arousal/proc/check_processing()
 	SIGNAL_HANDLER
 	var/mob/parent_mob = parent
 	if(parent_mob.client)
-		START_PROCESSING(SSobj, src)
+		wake_processing()
 	else
 		STOP_PROCESSING(SSobj, src)
+
+/// Starts processing only when there is something to process, arousal to decay or charge to regain.
+/datum/component/arousal/proc/wake_processing()
+	var/mob/parent_mob = parent
+	if(parent_mob.client && (arousal > 0 || charge < SEX_MAX_CHARGE))
+		START_PROCESSING(SSobj, src)
 
 /datum/component/arousal/proc/can_lose_arousal()
 	if(last_arousal_increase_time + AROUSAL_TIME_TO_UNHORNY > world.time)
@@ -69,7 +76,11 @@
 		clamp_max = THRILLSEEKER_THRESHOLD
 		if(forced)
 			clamp_max = 50
-	arousal = clamp(amount, 0, clamp_max)
+	var/new_arousal = clamp(amount, 0, clamp_max)
+	if(!new_arousal && !arousal)
+		return arousal
+	arousal = new_arousal
+	wake_processing()
 	update_arousal_effects()
 	try_ejaculate()
 	SEND_SIGNAL(parent, COMSIG_SEX_AROUSAL_CHANGED)
@@ -101,6 +112,7 @@
 	if(limit)
 		clamp_max = limit
 	arousal = clamp(amount, 0, clamp_max)
+	wake_processing()
 	update_arousal_effects()
 	SEND_SIGNAL(parent, COMSIG_SEX_AROUSAL_CHANGED)
 	return arousal
@@ -228,6 +240,7 @@
 	SEND_SIGNAL(climaxer, COMSIG_SEX_CLIMAX)
 
 	charge = max(0, charge - CHARGE_FOR_CLIMAX)
+	wake_processing()
 
 	var/intensity
 	if(action)
@@ -284,6 +297,7 @@
 /datum/component/arousal/proc/set_charge(amount)
 	var/empty = (charge < CHARGE_FOR_CLIMAX)
 	charge = clamp(amount, 0, SEX_MAX_CHARGE)
+	wake_processing()
 	var/after_empty = (charge < CHARGE_FOR_CLIMAX)
 	if(empty && !after_empty)
 		to_chat(parent, span_notice("I feel like I'm not so spent anymore"))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -73,6 +73,7 @@
 #include "species_whitelists.dm"
 #include "timer_sanity.dm"
 #include "unit_test.dm"
+#include "worn_ac_cache.dm"
 // END_INCLUDE
 
 #ifdef REFERENCE_TRACKING_DEBUG //Don't try and parse this file if ref tracking isn't turned on. IE: don't parse ref tracking please mr linter

--- a/code/modules/unit_tests/worn_ac_cache.dm
+++ b/code/modules/unit_tests/worn_ac_cache.dm
@@ -1,0 +1,43 @@
+/datum/unit_test/worn_ac_cache/Run()
+	var/mob/living/carbon/human/H = allocate(/mob/living/carbon/human)
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(), ARMOR_CLASS_NONE, "Naked human should have no AC")
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(check_hands = TRUE), ARMOR_CLASS_NONE, "Naked human should have no AC in hands")
+
+	var/obj/item/clothing/body_armor = allocate(/obj/item/clothing/head/roguetown/helmet)
+	body_armor.armor_class = ARMOR_CLASS_HEAVY
+	H.equip_to_slot(body_armor, SLOT_ARMOR, TRUE)
+	TEST_ASSERT_EQUAL(H.wear_armor, body_armor, "Armor did not reach the armor slot")
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(), ARMOR_CLASS_HEAVY, "Worn heavy armor not counted")
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(FALSE, FALSE), ARMOR_CLASS_HEAVY, "check_helmet = FALSE should still count body armor")
+	TEST_ASSERT(!H.check_armor_skill(), "Untrained human should fail check_armor_skill in heavy armor")
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	TEST_ASSERT(H.check_armor_skill(), "Heavy-trained human should pass check_armor_skill in heavy armor")
+
+	var/obj/item/clothing/helmet = allocate(/obj/item/clothing/head/roguetown/helmet)
+	helmet.armor_class = ARMOR_CLASS_MEDIUM
+	H.equip_to_slot(helmet, SLOT_HEAD, TRUE)
+	TEST_ASSERT_EQUAL(H.head, helmet, "Helmet did not reach the head slot")
+	H.dropItemToGround(body_armor, TRUE)
+	TEST_ASSERT_NULL(H.wear_armor, "Armor slot should be empty after drop")
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(), ARMOR_CLASS_MEDIUM, "Worn helmet not counted after armor drop")
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(FALSE, FALSE), ARMOR_CLASS_NONE, "check_helmet = FALSE should exclude the helmet")
+
+	var/obj/item/clothing/held = allocate(/obj/item/clothing/head/roguetown/helmet)
+	held.armor_class = ARMOR_CLASS_HEAVY
+	H.put_in_hands(held, forced = TRUE)
+	TEST_ASSERT(H.is_holding(held), "Held clothing did not reach the hands")
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(check_hands = TRUE), ARMOR_CLASS_HEAVY, "Held clothing not counted with check_hands")
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(), ARMOR_CLASS_MEDIUM, "Held clothing should not count without check_hands")
+	H.dropItemToGround(held, TRUE)
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(check_hands = TRUE), ARMOR_CLASS_MEDIUM, "Hands should not count after drop")
+
+	qdel(helmet)
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(), ARMOR_CLASS_NONE, "Deleted worn helmet should not count")
+
+	var/obj/item/clothing/second_armor = allocate(/obj/item/clothing/head/roguetown/helmet)
+	second_armor.armor_class = ARMOR_CLASS_MEDIUM
+	H.equip_to_slot(second_armor, SLOT_SHIRT, TRUE)
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(), ARMOR_CLASS_MEDIUM, "Worn shirt armor not counted")
+	H.transferItemToLoc(second_armor, run_loc_floor_bottom_left, TRUE)
+	TEST_ASSERT_NULL(H.wear_shirt, "Shirt slot should be empty after transfer")
+	TEST_ASSERT_EQUAL(H.highest_ac_worn(), ARMOR_CLASS_NONE, "Transferred armor should not count")


### PR DESCRIPTION
## About The Pull Request
My eyes saw red when I saw the highest_ac_worn() took out 92 out of 3200 cpu time live and isn't cached. The Fuck. 

Series of optimizations for stupid shit that should not have been taking up so much CPU time: 
- Cache the highest AC worn on the body instead of recomputing it aggressively, with water's get_stamina_drain() aggressively driving the hundreds of thousands of calls and recalculation costing us precious CPU
- We ported Vanderlin's tetris wrong and busted the cache of the item underlay for no reasons making it extremely expensive, this took up approximately 66s on live. This should be fixed.
- Our flick overlays from sound and pickup animations were sent to **every clients on server**, completely ignoring the flick_overlay_view() helper which sends it to people in view??? This has been fixed.
- The arousal system was taking up 66s despite us knowing that less than 10 person on the server ERP at any given time. Hello. It now stop processing unless it is being changed which should massively reduce the CPU time it is taking. The component are also no longer given to every NPCs.

There were two more tweaks / fixes I did not put in here: 
- Spell action icon was taking an unnecessarily high amount of CPU to rebuild icons when unneeded, this has been moved into the mage 3 PR to avoid self conflict
- get_stamina_drain() on water was costing 37 self cpu, on top of the approximately 93 downstream with highest_ac_worn(). My initial pass with my AI broke it, therefore I've decided to not tackle this proc, for now. It is still extremely expensive for a trivial proc and therefore worth investigating and "micro" optimizing (it is not micro opt if it is 1%).

Also modified roguetest to add some water tiles for testing purpose.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="317" height="366" alt="dreamseeker_BpeBOiSv1A" src="https://github.com/user-attachments/assets/49445910-74a9-44cc-bad2-104b88f4a066" />
<img width="1446" height="737" alt="dreamseeker_NOjzMyn8w3" src="https://github.com/user-attachments/assets/67e447a9-0661-4dfc-9a5f-5e0b57593be2" />
<img width="475" height="650" alt="dreamseeker_hjLGLY30SX" src="https://github.com/user-attachments/assets/779b3a24-c176-4cb1-9c39-ef105cecf188" />
<img width="1050" height="934" alt="dreamseeker_Ohxm0Jdpa8" src="https://github.com/user-attachments/assets/0ac6b313-0e2e-4f72-9726-d9959e9daa23" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Self-evident why we shouldn't be busting 200+ second of CPU on these stupid shit.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Optimized calculation of the heaviest armor worn on body. Report any oddities with swimming stamina drain, jumping and / or speed cap. etc. 
add: Optimized item underlay, report any oddity with your tetris inventory.
add: Optimized flick overlays used in pickup animations and emote overlays to not send to the entire server. Report any oddities. 
add: Optimized the arousal system to no longer process when unneeded. Report any oddities.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
