### PR TITLE
Restore the Credit Icons subsystem with a 6 seconds timer, and other TG ports / fixes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -390,6 +390,7 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define DUMMY_HUMAN_SLOT_PREFERENCES "dummy_preference_preview"
 #define DUMMY_HUMAN_SLOT_ADMIN "admintools"
 #define DUMMY_HUMAN_SLOT_MANIFEST "dummy_manifest_generation"
+#define DUMMY_HUMAN_SLOT_CREDITS "dummy_credits_generation"
 
 #define PR_ANNOUNCEMENTS_PER_ROUND 5 //The number of unique PR announcements allowed per round
 									//This makes sure that a single person can only spam 3 reopens and 3 closes before being ignored

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -767,9 +767,8 @@ world
 	var/render_icon = curicon
 
 	if (render_icon)
-		var/curstates = icon_states(curicon)
-		if(!(curstate in curstates))
-			if ("" in curstates)
+		if(!icon_exists(curicon, curstate))
+			if(icon_exists(curicon, ""))
 				curstate = ""
 			else
 				render_icon = FALSE
@@ -1411,6 +1410,43 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 		var/icon/my_icon = icon(icon_path)
 		GLOB.icon_dimensions[icon_path] = list("width" = my_icon.Width(), "height" = my_icon.Height())
 	return GLOB.icon_dimensions[icon_path]
+
+/// Checks whether a given icon state exists in a given icon file. If `file` and `state` both exist,
+/// this will return `TRUE` - otherwise, it will return `FALSE`.
+///
+/// If you want a stack trace to be output when the given state/file doesn't exist, use
+/// `/proc/icon_exists_or_scream()`.
+/proc/icon_exists(file, state)
+	if(isnull(file) || isnull(state))
+		return FALSE //This is common enough that it shouldn't panic, imo.
+
+	if(isnull(GLOB.icon_states_cache_lookup[file]))
+		compile_icon_states_cache(file)
+	return !isnull(GLOB.icon_states_cache_lookup[file][state])
+
+
+/// Functions the same as `/proc/icon_exists()`, but with the addition of a stack trace if the
+/// specified file or state doesn't exist.
+///
+/// Stack traces will only be output once for each file.
+/proc/icon_exists_or_scream(file, state)
+	if(icon_exists(file, state))
+		return TRUE
+
+	var/static/list/screams = list()
+	if(!isnull(screams[file]))
+		screams[file] = TRUE
+		stack_trace("State [state] in file [file] does not exist.")
+
+	return FALSE
+
+
+/proc/compile_icon_states_cache(file)
+	GLOB.icon_states_cache[file] = list()
+	GLOB.icon_states_cache_lookup[file] = list()
+	for(var/istate in icon_states(file))
+		GLOB.icon_states_cache[file] += istate
+		GLOB.icon_states_cache_lookup[file][istate] = TRUE
 
 /proc/ma2html(mutable_appearance/appearance, mob/viewer, extra_classes = "")
 	if(isatom(appearance))

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1076,7 +1076,8 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		body.update_inv_back()
 		body.update_inv_head()
 
-		humanoid_icon_cache[icon_id] = out_icon
+		if(icon_id)
+			humanoid_icon_cache[icon_id] = out_icon
 		dummy_key? unset_busy_human_dummy(dummy_key) : qdel(body)
 		return out_icon
 	else

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -118,12 +118,6 @@
 	var/atom/movable/screen/splash/credits/S = new(src, FALSE)
 	S.Fade(FALSE,FALSE)
 	RollCredits()
-	if(GLOB.credits_icons.len)
-		for(var/i=0, i<=GLOB.credits_icons.len, i++)
-			var/atom/movable/screen/P = new()
-			P.layer = SPLASHSCREEN_LAYER+1
-			P.appearance = GLOB.credits_icons
-			screen += P
 
 /datum/controller/subsystem/ticker/proc/declare_completion()
 	set waitfor = FALSE

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1214,29 +1214,6 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 	pixel_x = initialpixelx
 	pixel_y = initialpixely
 
-///Checks if the given iconstate exists in the given file, caching the result. Setting scream to TRUE will print a stack trace ONCE.
-/proc/icon_exists(file, state, scream)
-	var/static/list/icon_states_cache = list()
-	if(icon_states_cache[file]?[state])
-		return TRUE
-
-	if(icon_states_cache[file]?[state] == FALSE)
-		return FALSE
-
-	var/list/states = icon_states(file)
-
-	if(!icon_states_cache[file])
-		icon_states_cache[file] = list()
-
-	if(state in states)
-		icon_states_cache[file][state] = TRUE
-		return TRUE
-	else
-		icon_states_cache[file][state] = FALSE
-		if(scream)
-			stack_trace("Icon Lookup for state: [state] in file [file] failed.")
-		return FALSE
-
 /proc/weightclass2text(w_class)
 	switch(w_class)
 		if(WEIGHT_CLASS_TINY)

--- a/code/_globalvars/lists/icons.dm
+++ b/code/_globalvars/lists/icons.dm
@@ -1,2 +1,6 @@
 /// Cache of the width and height of icon files, to avoid repeating the same expensive operation
 GLOBAL_LIST_EMPTY(icon_dimensions)
+/// Cache of the states of icon files
+GLOBAL_LIST_EMPTY(icon_states_cache)
+/// Cache of the states of icon files, stored associatively with TRUE for lookup
+GLOBAL_LIST_EMPTY(icon_states_cache_lookup)

--- a/code/_onclick/hud/credits.dm
+++ b/code/_onclick/hud/credits.dm
@@ -65,10 +65,12 @@
 	icon = I
 	parent = P
 	var/voicecolor = "dc0174"
-	var/credited_title = GLOB.credits_icons[credited]["title"]
-	if(GLOB.credits_icons[credited])
-		if(GLOB.credits_icons[credited]["vc"])
-			voicecolor=GLOB.credits_icons[credited]["vc"]
+	var/credited_title
+	var/list/credit_data = GLOB.credits_icons[credited]
+	if(credit_data)
+		credited_title = credit_data["title"]
+		if(credit_data["vc"])
+			voicecolor = credit_data["vc"]
 	icon_state = credited
 	maptext = {"<span style='vertical-align:top; text-align:center;
 				color: #[voicecolor]; font-size: 100%;

--- a/code/controllers/subsystem/rogue/crediticons.dm
+++ b/code/controllers/subsystem/rogue/crediticons.dm
@@ -32,12 +32,8 @@ SUBSYSTEM_DEF(crediticons)
 	if(!target || !istype(target) || !target.mind || !target.client)
 		return null
 
+
 	var/credit_name = "[target.real_name]"
-	if(target.mind.assigned_role)
-		// We don't have their job refactor yet
-		var/datum/job/job = target.mind.assigned_role
-		if(job)
-			credit_name = "[credit_name]\nthe [job]"
 
 	if(!GLOB.credits_icons[credit_name]?["icon"])
 		return null

--- a/code/controllers/subsystem/rogue/crediticons.dm
+++ b/code/controllers/subsystem/rogue/crediticons.dm
@@ -1,12 +1,11 @@
 
 SUBSYSTEM_DEF(crediticons)
 	name = "crediticons"
-	wait = 20
+	wait = 6 SECONDS
 	flags = SS_NO_INIT
 	priority = 1
 	var/list/processing = list()
 	var/list/currentrun = list()
-	can_fire = FALSE
 
 /datum/controller/subsystem/crediticons/fire(resumed = 0)
 	if (!resumed)
@@ -23,7 +22,7 @@ SUBSYSTEM_DEF(crediticons)
 			if (MC_TICK_CHECK)
 				return
 			continue
-		thing.add_credit()
+		thing.add_credit(processing[thing])
 		STOP_PROCESSING(SScrediticons, thing)
 		if (MC_TICK_CHECK)
 			return

--- a/code/controllers/subsystem/rogue/crediticons.dm
+++ b/code/controllers/subsystem/rogue/crediticons.dm
@@ -23,7 +23,6 @@ SUBSYSTEM_DEF(crediticons)
 			continue
 		actor.add_credit(processing[queued_ckey])
 		processing -= queued_ckey
-		return
 
 /datum/controller/subsystem/crediticons/proc/get_credit_icon(mob/living/carbon/human/target, crop_to_upper_half = FALSE)
 	if(!target || !istype(target) || !target.mind || !target.client)

--- a/code/controllers/subsystem/rogue/crediticons.dm
+++ b/code/controllers/subsystem/rogue/crediticons.dm
@@ -1,8 +1,7 @@
-
 SUBSYSTEM_DEF(crediticons)
 	name = "crediticons"
 	wait = 6 SECONDS
-	flags = SS_NO_INIT
+	flags = SS_NO_INIT | SS_BACKGROUND
 	priority = 1
 	var/list/processing = list()
 	var/list/currentrun = list()
@@ -15,17 +14,16 @@ SUBSYSTEM_DEF(crediticons)
 	var/list/currentrun = src.currentrun
 
 	while (currentrun.len)
-		var/mob/living/carbon/human/thing = currentrun[currentrun.len]
+		var/queued_ckey = currentrun[currentrun.len]
 		currentrun.len--
-		if (!thing || QDELETED(thing))
-			processing -= thing
+		var/mob/living/carbon/human/actor = GLOB.directory[queued_ckey]?.mob
+		if(!istype(actor) || QDELETED(actor))
 			if (MC_TICK_CHECK)
 				return
 			continue
-		thing.add_credit(processing[thing])
-		STOP_PROCESSING(SScrediticons, thing)
-		if (MC_TICK_CHECK)
-			return
+		actor.add_credit(processing[queued_ckey])
+		processing -= queued_ckey
+		return
 
 /datum/controller/subsystem/crediticons/proc/get_credit_icon(mob/living/carbon/human/target, crop_to_upper_half = FALSE)
 	if(!target || !istype(target) || !target.mind || !target.client)

--- a/code/controllers/subsystem/rogue/crediticons.dm
+++ b/code/controllers/subsystem/rogue/crediticons.dm
@@ -23,6 +23,7 @@ SUBSYSTEM_DEF(crediticons)
 			continue
 		actor.add_credit(processing[queued_ckey])
 		processing -= queued_ckey
+		return
 
 /datum/controller/subsystem/crediticons/proc/get_credit_icon(mob/living/carbon/human/target, crop_to_upper_half = FALSE)
 	if(!target || !istype(target) || !target.mind || !target.client)

--- a/code/controllers/subsystem/rogue/crediticons.dm
+++ b/code/controllers/subsystem/rogue/crediticons.dm
@@ -16,7 +16,8 @@ SUBSYSTEM_DEF(crediticons)
 	while (currentrun.len)
 		var/queued_ckey = currentrun[currentrun.len]
 		currentrun.len--
-		var/mob/living/carbon/human/actor = GLOB.directory[queued_ckey]?.mob
+		var/client/queued_client = GLOB.directory[queued_ckey]
+		var/mob/living/carbon/human/actor = queued_client?.mob
 		if(!istype(actor) || QDELETED(actor))
 			if (MC_TICK_CHECK)
 				return

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -351,7 +351,6 @@
 	var/datum/job/J = SSjob.GetJob(mind.assigned_role)
 	var/used_title = get_role_title()
 
-	GLOB.credits_icons[thename] = list()
 	var/client/C = client
 	var/datum/preferences/P = C.prefs
 	var/icon/I
@@ -363,6 +362,7 @@
 		var/icon/female_s = icon("icon"='icons/mob/clothing/under/masking_helpers.dmi', "icon_state"="credits")
 		I.Blend(female_s, ICON_MULTIPLY)
 		I.Scale(96,96)
+		GLOB.credits_icons[thename] = list()
 		GLOB.credits_icons[thename]["title"] = used_title
 		GLOB.credits_icons[thename]["icon"] = I
 		GLOB.credits_icons[thename]["vc"] = voice_color
@@ -529,7 +529,7 @@
 /proc/should_wear_masc_clothes(mob/living/carbon/human/H)
 	if(!H.mind)
 		return (H.pronouns == HE_HIM || H.pronouns == THEY_THEM || H.pronouns == IT_ITS)
-	else 
+	else
 		return (H.clothes_pref == CLOTHES_M)
 
 /proc/should_wear_femme_clothes(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -292,8 +292,8 @@
 			SStreasury.noble_incomes[H] = noble_income
 			SStreasury.grant_estate_income(H, noble_income, TRUE)
 
-	if(show_in_credits && isnull(SScrediticons.processing[H]))
-		SScrediticons.processing[H] = FALSE
+	if(show_in_credits && H.ckey && isnull(SScrediticons.processing[H.ckey]))
+		SScrediticons.processing[H.ckey] = FALSE
 
 	if(cmode_music)
 		H.cmode_music = cmode_music

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -292,8 +292,8 @@
 			SStreasury.noble_incomes[H] = noble_income
 			SStreasury.grant_estate_income(H, noble_income, TRUE)
 
-	if(show_in_credits)
-		SScrediticons.processing += H
+	if(show_in_credits && isnull(SScrediticons.processing[H]))
+		SScrediticons.processing[H] = FALSE
 
 	if(cmode_music)
 		H.cmode_music = cmode_music
@@ -355,9 +355,9 @@
 	var/datum/preferences/P = C.prefs
 	var/icon/I
 	if(generate_for_adv_class)
-		I = get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_MANIFEST, list(SOUTH), human_gear_override = src)
+		I = get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_CREDITS, list(SOUTH), human_gear_override = src)
 	else if (P)
-		I = get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_MANIFEST, list(SOUTH))
+		I = get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_CREDITS, list(SOUTH))
 	if(I)
 		var/icon/female_s = icon("icon"='icons/mob/clothing/under/masking_helpers.dmi', "icon_state"="credits")
 		I.Blend(female_s, ICON_MULTIPLY)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -161,7 +161,8 @@
 		apply_character_post_equipment(H)
 
 /datum/advclass/proc/post_equip(mob/living/carbon/human/H)
-	SScrediticons.processing[H] = TRUE
+	if(H.ckey)
+		SScrediticons.processing[H.ckey] = TRUE
 	if(cmode_music)
 		H.cmode_music = cmode_music
 	if(class_tempo_faction)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -161,7 +161,7 @@
 		apply_character_post_equipment(H)
 
 /datum/advclass/proc/post_equip(mob/living/carbon/human/H)
-	addtimer(CALLBACK(H,TYPE_PROC_REF(/mob/living/carbon/human, add_credit), TRUE), 20)
+	SScrediticons.processing[H] = TRUE
 	if(cmode_music)
 		H.cmode_music = cmode_music
 	if(class_tempo_faction)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -56,8 +56,6 @@ GLOBAL_VAR_INIT(mobids, 1)
 	for(var/datum/action/A in actions)
 		A.Remove(src)
 	actions = null
-	SScrediticons.processing -= src
-	SScrediticons.currentrun -= src
 	SStreasury.remove_person(src) // Call me overly cautious I dunno when they giving dogs bank account
 	if(skills && skills.current == src)
 		var/datum/skill_holder/my_skill = skills


### PR DESCRIPTION
## About The Pull Request
- Ported TGstation's icon_exists and icon_exists_or_scream proc. A port of it was included in the Major Optimization Pass: Azure Edition but I accidentally mangled it while reverting that PR. Specific PR credit can be: https://github.com/tgstation/tgstation/pull/89547
- Fixes a bunch of issues related to the credit icons subsystem
- Reenabled the credit icons subsystem to spread out credit icons load throughout the first 16 minutes of the round, instead of firing it in 2 seconds lagspike right at roundstart, lagging the server hard. I ported this optimization from Scarlet but in truth this turns out to be a mistake and restoring it let us throttle its burden on the server instead of slamming it at once. May or may not help alleviate possible roundstart crash.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="353" height="348" alt="dreamseeker_keL07hD7gm" src="https://github.com/user-attachments/assets/bb504e1f-1ffb-4750-9135-cb62d3a467ea" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Should help with roundstart lag and possibly a small amount of latejoin induced lag.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Ported TGstation's icon_exists and icon_exists_or_scream proc. A port of it was included in the Major Optimization Pass: Azure Edition but I accidentally mangled it while reverting that PR. Specific PR credit can be: https://github.com/tgstation/tgstation/pull/89547
add: Fixes a bunch of issues related to the credit icons subsystem
add: Reenabled the credit icons subsystem to spread out credit icons load throughout the first 16 minutes of the round, instead of firing it in 2 seconds lagspike right at roundstart, lagging the server hard. I ported this optimization from Scarlet but in truth this turns out to be a mistake and restoring it let us throttle its burden on the server instead of slamming it at once. May or may not help alleviate possible roundstart crash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
