### PR TITLE
book binding descriptors + icon typo fix

### DIFF
--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -507,14 +507,14 @@
 	var/is_in_round_player_generated
 	var/list/book_icons = list(
 	"Sickly green with embossed bronze" = "book8",
-	"White with embossed obsidian" = "book7",
-	"Black with embossed quartz" = "book6",
-	"Blue with embossed ruby" = "book5",
-	"Green with embossed amethyst" = "book4",
-	"Purple with embossed emerald" = "book3",
-	"Red with embossed sapphire" = "book2",
-	"Brown with embossed gold" = "book1",
-	"Brown without embossed material" = "basic_book")
+	"Red with embossed toper" = "book7",
+	"Purple with embossed obsidian" = "book6",
+	"Brown with embossed obsidian" = "book5",
+	"Yellow without embossed material" = "book4",
+	"Blue without embossed material" = "book3",
+	"Red without embossed material" = "book2",
+	"Black without embossed material" = "book",
+	"Green without embossed material" = "basic_book")
 	name = "unknown title"
 	desc = "Penned by an unknown author."
 	icon_state = "basic_book_0"


### PR DESCRIPTION
## About The Pull Request
Makes the descriptions of book cover options when binding a book actually match what they are. Also fixes a typo that caused one of them to produce invalid iconstates.

## Testing Evidence
text changes

## Why It's Good For The Game
Functional

## Changelog

:cl:
fix: Book-binding now correctly describes the cover image options
/:cl:
