### PR TITLE
Gives disguisable amulets proper examine highlights

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -206,3 +206,9 @@ GLOBAL_VAR_INIT(magic_appearance_detecting_image, new /image) // appearances are
 #define isappearance(thing) (!isimage(thing) && !ispath(thing) && istype(GLOB.magic_appearance_detecting_image, thing))
 #define isappearance_or_image(thing) (isimage(thing) || (!ispath(thing) && istype(GLOB.magic_appearance_detecting_image, thing)))
 #define is_ooze_wound(A) (istype(A, /datum/wound/fracture) || istype(A, /datum/wound/dislocation)) //Defines what kinds of wounds cause ooze limbs to melt.
+
+#define is_zizo_amulet(amulet_type) (amulet_type in GLOB.zizo_amulet_types)
+#define is_baotha_amulet(amulet_type) (amulet_type in typesof(/obj/item/clothing/neck/roguetown/psicross/inhumen/baotha))
+#define is_matthios_amulet(amulet_type) (amulet_type in typesof(/obj/item/clothing/neck/roguetown/psicross/inhumen/matthios))
+#define is_graggar_amulet(amulet_type) (amulet_type in typesof(/obj/item/clothing/neck/roguetown/psicross/inhumen/graggar))
+#define is_gronn_amulet(amulet_type) (amulet_type in GLOB.gronn_amulet_types)

--- a/code/_globalvars/examine_highlights.dm
+++ b/code/_globalvars/examine_highlights.dm
@@ -9,8 +9,6 @@ GLOBAL_LIST_INIT(gronn_amulet_types, get_amulet_type_list_gronn())
 	// Therefore we search for zcrosses in a very dumb way.
 	var/inhumen_cross_types = typesof(/obj/item/clothing/neck/roguetown/psicross/inhumen)
 	for(var/type in inhumen_cross_types)
-		if(is_abstract(type))
-			continue
 		var/obj/item/clothing/neck/roguetown/psicross/inhumen/cross = type
 		// This is the very dumb way.
 		// The alternative is manually making a list of all zcrosses, which will be annoying to maintain.
@@ -30,8 +28,6 @@ GLOBAL_LIST_INIT(gronn_amulet_types, get_amulet_type_list_gronn())
 	// Therefore we search for talismans in a very dumb way.
 	var/inhumen_cross_types = typesof(/obj/item/clothing/neck/roguetown/psicross)
 	for(var/type in inhumen_cross_types)
-		if(is_abstract(type))
-			continue
 		var/obj/item/clothing/neck/roguetown/psicross/inhumen/cross = type
 		// This is the very dumb way.
 		// The alternative is manually making a list of all talismans, which will be annoying to maintain.

--- a/code/_globalvars/examine_highlights.dm
+++ b/code/_globalvars/examine_highlights.dm
@@ -1,0 +1,44 @@
+// NOTE: We deliberately exclude Gronn carving amulets from the ascendant amulet lists due to the unique nature of their relationship with the Four.
+
+GLOBAL_LIST_INIT(zizo_amulet_types, get_amulet_type_list_zizo())
+GLOBAL_LIST_INIT(gronn_amulet_types, get_amulet_type_list_gronn())
+
+/proc/get_amulet_type_list_zizo()
+	. = list()
+	// Zizo amulet types are not organized underneath a central type unlike most other amulets.
+	// Therefore we search for zcrosses in a very dumb way.
+	var/inhumen_cross_types = typesof(/obj/item/clothing/neck/roguetown/psicross/inhumen)
+	for(var/type in inhumen_cross_types)
+		if(is_abstract(type))
+			continue
+		var/obj/item/clothing/neck/roguetown/psicross/inhumen/cross = type
+		// This is the very dumb way.
+		// The alternative is manually making a list of all zcrosses, which will be annoying to maintain.
+		// In a perfect world, we'd have all Zizo amulets neatly organized underneath a type that denominates it as Zizite.
+		// But this is not a perfect world...
+		var/cross_name = initial(cross.name)
+		var/list/zcross_names = list("zcross", "inverted psycross")
+		for(var/zname in zcross_names)
+			var/regex/name_search = regex("([zname])", "im")
+			if(name_search.Find(cross_name))
+				. += type
+	return .
+
+/proc/get_amulet_type_list_gronn()
+	. = list()
+	// Gronn amulet types are not organized underneath a central type unlike most other amulets.
+	// Therefore we search for talismans in a very dumb way.
+	var/inhumen_cross_types = typesof(/obj/item/clothing/neck/roguetown/psicross)
+	for(var/type in inhumen_cross_types)
+		if(is_abstract(type))
+			continue
+		var/obj/item/clothing/neck/roguetown/psicross/inhumen/cross = type
+		// This is the very dumb way.
+		// The alternative is manually making a list of all talismans, which will be annoying to maintain.
+		// In a perfect world, we'd have all Gronn amulets neatly organized underneath a type that denominates it as Gronnite.
+		// But this is not a perfect world...
+		var/cross_name = initial(cross.name)
+		var/regex/name_search = regex("(carved talisman)", "im")
+		if(name_search.Find(cross_name))
+			. += type
+	return .

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -1047,6 +1047,7 @@
 	desc = "In lyfe a smile is sharper than any blade."
 	icon_state = "xylix"
 	toggle_icon_state = FALSE
+	var/disguised_type = null
 
 /obj/item/clothing/neck/roguetown/psicross/xylix/wood
 	name = "wooden amulet of Xylix"
@@ -1075,6 +1076,26 @@
 	if(human.patron == GLOB.patronlist[/datum/patron/divine/xylix])
 		. += span_notice("This is an amulet of Xylix! By shift-right clicking it, I can alter its shape to whatever befits my whim.")
 
+
+/obj/item/clothing/neck/roguetown/psicross/xylix/get_examine_highlight_status()
+	// If the cross is not disguised, it's a regular Xylixian amulet. Not heretical, just silly.
+	if(!disguised_type)
+		return null
+
+	if(is_zizo_amulet(disguised_type))
+		return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_ZIZO_ICON)
+	if(is_graggar_amulet(disguised_type))
+		return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_GRAGGAR_ICON)
+	if(is_baotha_amulet(disguised_type))
+		return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_BAOTHA_ICON)
+	if(is_matthios_amulet(disguised_type))
+		return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_MATTHIOS_ICON)
+	if(is_gronn_amulet(disguised_type))
+		return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ODD, HERESYDESC_GRONN)
+
+	// Otherwise, we assume it isn't disguised as anything heretical.
+	return null
+
 /obj/item/clothing/neck/roguetown/psicross/xylix/ShiftRightClick(mob/user, params)
 	if(!ishuman(user))
 		return
@@ -1093,7 +1114,8 @@
 	if(!selected_cross)
 		return
 
-	var/obj/item/clothing/neck/roguetown/psicross/cross_type = choices[selected_cross]
+	disguised_type = choices[selected_cross]
+	var/obj/item/clothing/neck/roguetown/psicross/cross_type = disguised_type
 
 	name = initial(cross_type.name)
 	desc = initial(cross_type.desc)
@@ -1522,7 +1544,7 @@
 	smeltresult = /obj/item/ingot/weeping
 	sellprice = 666
 	equip_delay_self = 3 SECONDS
-	unequip_delay_self = 7 SECONDS 
+	unequip_delay_self = 7 SECONDS
 	inv_storage_delay = 3 SECONDS
 	var/active_item
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_items.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_items.dm
@@ -39,19 +39,16 @@
 		return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, "The cross's silhouette shifts. That's no psycross... What is that?!")
 	// If it is disguised, check to see if it appears like one of the heretical amulets and present it accordingly
 	else
-		switch(mimic_type)
-			// Zizo psicrosses
-			if(/obj/item/clothing/neck/roguetown/psicross/inhumen/iron, /obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy, /obj/item/clothing/neck/roguetown/psicross/inhumen/g/triumph, /obj/item/clothing/neck/roguetown/psicross/inhumen/paalloy, /obj/item/clothing/neck/roguetown/psicross/inhumen/g)
-				return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_ZIZO_ICON)
-			// Matthios psicrosses
-			if(/obj/item/clothing/neck/roguetown/psicross/inhumen/matthios)
-				return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_MATTHIOS_ICON)
-			// Graggar psicrosses
-			if(/obj/item/clothing/neck/roguetown/psicross/inhumen/graggar)
-				return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_GRAGGAR_ICON)
-			// Baotha psicrosses
-			if(/obj/item/clothing/neck/roguetown/psicross/inhumen/baotha)
-				return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_BAOTHA_ICON)
+		if(is_zizo_amulet(mimic_type))
+			return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_ZIZO_ICON)
+		if(is_graggar_amulet(mimic_type))
+			return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_GRAGGAR_ICON)
+		if(is_baotha_amulet(mimic_type))
+			return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_BAOTHA_ICON)
+		if(is_matthios_amulet(mimic_type))
+			return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_SUSPICIOUS, HERESYDESC_MATTHIOS_ICON)
+		if(is_gronn_amulet(mimic_type))
+			return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ODD, HERESYDESC_GRONN)
 		// If it isn't disguised as anything heretical, present it as the "totally innocent" amulet it pretends to be
 		return null
 
@@ -122,7 +119,7 @@
 		src.slot_flags = initial(C.slot_flags)
 		// I'm not implementing this yet for brevity.
 		src.wrist_display = initial(C.wrist_display)
-		
+
 		to_chat(user, span_notice("The strange cross shudders, mimicking the weight and presence of \a [name]."))
 
 	// Ensure the floor and in-hand sprites update

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_items.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_items.dm
@@ -119,7 +119,7 @@
 		src.slot_flags = initial(C.slot_flags)
 		// I'm not implementing this yet for brevity.
 		src.wrist_display = initial(C.wrist_display)
-
+		
 		to_chat(user, span_notice("The strange cross shudders, mimicking the weight and presence of \a [name]."))
 
 	// Ensure the floor and in-hand sprites update

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -292,6 +292,7 @@
 #include "code\__HELPERS\sorts\TimSort.dm"
 #include "code\_globalvars\bitfields.dm"
 #include "code\_globalvars\configuration.dm"
+#include "code\_globalvars\examine_highlights.dm"
 #include "code\_globalvars\food_preferences.dm"
 #include "code\_globalvars\game_modes.dm"
 #include "code\_globalvars\genetics.dm"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Hag and Xylix amulets now both correctly display themselves with the examine highlights of ascendant and Gronn amulets when disguised.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
Spawned a Xylix amulet and disguised it as various heretical amulet types.

<img width="588" height="338" alt="dreamseeker_2026-07-20_20-06-06" src="https://github.com/user-attachments/assets/4a3e632a-846f-4159-834e-d3f0e0d73beb" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Now Xylixians can better disguise themselves as Gronnites and Ascendants to better ragebait their foes.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl: Ryumi
add: Xylixian amulets now correctly show themselves as "heretical" when disguised as heretical amulet types.
fix: Hag amulets also account for Gronn amulets and more Zizite amulet types.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
