### PR TITLE
[TM for a day or two] THE MANTRAPPENING: RMB ARMING & RUSTIFICATION

### DIFF
--- a/_maps/dungeon_generator/room/AcidMageTower.dmm
+++ b/_maps/dungeon_generator/room/AcidMageTower.dmm
@@ -1263,7 +1263,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors/magic)
 "TW" = (
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/tomb/indoors/magic)
 "Ue" = (

--- a/_maps/dungeon_generator/room/TownRuins.dmm
+++ b/_maps/dungeon_generator/room/TownRuins.dmm
@@ -2351,7 +2351,7 @@
 /area/rogue/under/tomb/indoors)
 "Xj" = (
 /obj/structure/mineral_door/wood/violet,
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/under/tomb/indoors)
 "Xu" = (

--- a/_maps/dungeon_generator/room/hctomb1.dmm
+++ b/_maps/dungeon_generator/room/hctomb1.dmm
@@ -98,7 +98,7 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/tomb/indoors)
 "fE" = (
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb)
 "fQ" = (
@@ -184,7 +184,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "jq" = (
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/cave)
 "jx" = (
@@ -235,7 +235,7 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/tomb/indoors)
 "mE" = (
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/tomb/cave)
 "mX" = (

--- a/_maps/dungeon_generator/room/hctomb2.dmm
+++ b/_maps/dungeon_generator/room/hctomb2.dmm
@@ -65,7 +65,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/tomb/cave)
 "eL" = (
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/tomb/cave)
 "fm" = (
@@ -466,7 +466,7 @@
 /area/rogue/under/tomb)
 "MV" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/tomb/cave)
 "MX" = (
@@ -495,7 +495,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/tomb)
 "Pt" = (
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/cave)
 "PD" = (

--- a/_maps/dungeon_generator/room/queensretreat.dmm
+++ b/_maps/dungeon_generator/room/queensretreat.dmm
@@ -912,7 +912,7 @@
 	name = "Bedroom"
 	},
 /obj/effect/mapping_helpers/access/locker,
-/obj/effect/spawner/roguemap/beartrap,
+/obj/effect/spawner/roguemap/beartrap/camo,
 /turf/open/floor/carpet/red,
 /area/rogue/under/tomb/indoors/royal)
 "NK" = (

--- a/code/game/objects/effects/spawners/roguemapgen.dm
+++ b/code/game/objects/effects/spawners/roguemapgen.dm
@@ -67,7 +67,7 @@
 	icon_state = "beartrap"
 	name = "beartrap"
 	probby = 50
-	spawned = list(/obj/item/restraints/legcuffs/beartrap/armed/camouflage)
+	spawned = list(/obj/item/restraints/legcuffs/beartrap/armed/camouflage/rusty)
 
 // Potions n shit
 

--- a/code/game/objects/effects/spawners/roguemapgen.dm
+++ b/code/game/objects/effects/spawners/roguemapgen.dm
@@ -67,6 +67,12 @@
 	icon_state = "beartrap"
 	name = "beartrap"
 	probby = 50
+	spawned = list(/obj/item/restraints/legcuffs/beartrap/armed/rusty)
+
+/obj/effect/spawner/roguemap/beartrap/camo
+	icon_state = "beartrap"
+	name = "camo beartrap"
+	probby = 50
 	spawned = list(/obj/item/restraints/legcuffs/beartrap/armed/camouflage/rusty)
 
 // Potions n shit

--- a/code/game/objects/effects/spawners/roguemapgen.dm
+++ b/code/game/objects/effects/spawners/roguemapgen.dm
@@ -70,7 +70,7 @@
 	spawned = list(/obj/item/restraints/legcuffs/beartrap/armed/rusty)
 
 /obj/effect/spawner/roguemap/beartrap/camo
-	icon_state = "beartrap"
+	icon_state = "beartrap" //todo: make camo icon
 	name = "camo beartrap"
 	probby = 50
 	spawned = list(/obj/item/restraints/legcuffs/beartrap/armed/camouflage/rusty)

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -102,12 +102,22 @@
 	grid_width = 256
 	grid_height = 256
 
+
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage
 	w_class = WEIGHT_CLASS_BULKY
 	armed = TRUE
 	alpha = 80
 	grid_width = 256
 	grid_height = 256
+
+// realistically, both of theses hould be rusty by default but im just subtyping them for now.
+/obj/item/restraints/legcuffs/beartrap/armed/rusty
+	name = "rusty mantrap"
+	rusty = TRUE
+
+/obj/item/restraints/legcuffs/beartrap/armed/camouflage/rusty
+	name = "rusty mantrap"
+	rusty = TRUE
 
 /obj/item/restraints/legcuffs/beartrap/Initialize()
 	. = ..()

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -250,7 +250,19 @@
 			visible_message(span_warning(msg))
 			close_trap()
 
+// hardens against carts
+/obj/item/restraints/legcuffs/beartrap/forceMove(atom/destination)
+	if(armed)
+		visible_message(span_warning("[src] suddenly snaps shut!"))
+		close_trap()
+	. = ..()
 
+// hardens against repel and fetch
+/obj/item/restraints/legcuffs/beartrap/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback)
+	if(armed)
+		visible_message(span_warning("[src] suddenly snaps shut!"))
+		close_trap()
+	. = ..()
 
 /obj/item/restraints/legcuffs/beartrap/dropped(mob/living/carbon/human/user)
 	..()

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -149,6 +149,7 @@
 		var/dur = 5 SECONDS
 		// dur lowers by str score
 		dur = (dur - str)
+		visible_message(span_warning("[H] begins arming [src]!"))
 		if(do_after(user, dur, TRUE, src, TRUE, null, TRUE))
 			if(prob(50 + str*2)) // for a max of ~86% in common situations
 				// GRIEF PROT
@@ -163,7 +164,7 @@
 					return
 				// everything went well. arm it.
 				arm_trap(H)
-				to_chat(H, span_warning("You arm the [src.name]!"))
+				visible_message(span_boldwarning("[H] arms [src]!"), null) // aahh big bold and scary
 				// logging
 				log_combat(H, src, "armed a mantrap")
 			else

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -179,30 +179,6 @@
 	if(play_sound)
 		playsound(src.loc, 'sound/items/garroteshut.ogg', 70, TRUE, -3)
 
-
-/*
-// DEPRECATED, OLD CODE. LEFT IN FOR POSTERITY IN CASE ANYONE ELSE TOUCHES THESE.
-/obj/item/restraints/legcuffs/beartrap/attack_self(mob/user)
-	..()
-	if(ishuman(user) && !user.stat && !user.restrained())
-		var/mob/living/L = user
-		if(do_after(user, 50 - (L.STASTR*2), target = user))
-			if(prob(50))
-				armed = !armed
-				if(armed)
-					w_class = WEIGHT_CLASS_BULKY
-					grid_width = 256
-					grid_height = 256
-				else
-					w_class = WEIGHT_CLASS_NORMAL
-					grid_width = 64
-					grid_height = 64
-				update_icon()
-				to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
-			else
-				user.visible_message(span_warning("You couldn't get the shoddy [src.name] [armed ? "shut close!" : "to open up!"]"))
-*/
-
 /obj/item/restraints/legcuffs/beartrap/proc/close_trap(play_sound = TRUE)
 	armed = FALSE
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -132,6 +132,56 @@
 	playsound(loc, 'sound/blank.ogg', 50, TRUE, -1)
 	return (BRUTELOSS)
 
+/obj/item/restraints/legcuffs/beartrap/attack_right(mob/user)
+	. = ..()
+	if(ishuman(user) && !user.stat && !user.restrained())
+		var/mob/living/carbon/human/H = user
+		if(armed)
+			to_chat(H, span_danger("[src] is already armed!"))
+			return
+		// no stacking
+		for(var/obj/item/restraints/legcuffs/beartrap/B in src.loc)
+			if(B.armed)
+				to_chat(H, span_warning("There is already an armed [src.name] here!"))
+				return
+		// init vars
+		var/str = H.STASTR
+		var/dur = 5 SECONDS
+		// dur lowers by str score
+		dur = (dur - str)
+		if(do_after(user, dur, TRUE, src, TRUE, null, TRUE))
+			if(prob(50 + str*2)) // for a max of ~86% in common situations
+				// GRIEF PROT
+				for(var/obj/structure/fluff/traveltile/TT in range(1, src))
+					log_combat(H, src, "attempted to arm [src] near travel tiles")
+					return
+				// PRE-MAPPED THINGS CAN BE RUSTY.
+				if(rusty)
+					visible_message(span_warning("[src] VIOLENTLY shuts, breaking its own pressure plate!"))
+					playsound(src.loc, 'sound/items/beartrap2.ogg', 100, TRUE, -1)
+					qdel(src)
+					return
+				// everything went well. arm it.
+				arm_trap(H)
+				to_chat(H, span_warning("You arm the [src.name]!"))
+				// logging
+				log_combat(H, src, "armed a mantrap")
+			else
+				to_chat(H, span_warning("You couldn't get the shoddy [src.name] to open up!"))
+
+/obj/item/restraints/legcuffs/beartrap/proc/arm_trap(play_sound = TRUE)
+	armed = TRUE
+	w_class = WEIGHT_CLASS_BULKY
+	grid_width = 256
+	grid_height = 256
+	update_icon()
+	// tentative. if it works keep it, if not, toss it. idgaf. i want u 2 feel like traper dead by daylight.
+	if(play_sound)
+		playsound(src.loc, 'sound/items/garroteshut.ogg', 70, TRUE, -3)
+
+
+/*
+// DEPRECATED, OLD CODE. LEFT IN FOR POSTERITY IN CASE ANYONE ELSE TOUCHES THESE.
 /obj/item/restraints/legcuffs/beartrap/attack_self(mob/user)
 	..()
 	if(ishuman(user) && !user.stat && !user.restrained())
@@ -151,6 +201,7 @@
 				to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
 			else
 				user.visible_message(span_warning("You couldn't get the shoddy [src.name] [armed ? "shut close!" : "to open up!"]"))
+*/
 
 /obj/item/restraints/legcuffs/beartrap/proc/close_trap(play_sound = TRUE)
 	armed = FALSE
@@ -221,8 +272,8 @@
 				I.take_damage(50, BRUTE, "stab")
 			visible_message(span_warning(msg))
 			close_trap()
-		
-	
+
+
 
 /obj/item/restraints/legcuffs/beartrap/dropped(mob/living/carbon/human/user)
 	..()

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -136,6 +136,9 @@
 	. = ..()
 	if(ishuman(user) && !user.stat && !user.restrained())
 		var/mob/living/carbon/human/H = user
+		if(!isturf(loc))
+			to_chat(H, span_warning("I should place this on the ground before arming it..."))
+			return
 		if(armed)
 			to_chat(H, span_danger("[src] is already armed!"))
 			return

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -136,7 +136,7 @@
 	. = ..()
 	if(ishuman(user) && !user.stat && !user.restrained())
 		var/mob/living/carbon/human/H = user
-		if(!isturf(loc))
+		if(!isturf(loc)) // comment so this compiles on git
 			to_chat(H, span_warning("I should place this on the ground before arming it..."))
 			return
 		if(armed)

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -31,7 +31,7 @@
 
 /obj/item/restraints/legcuffs/beartrap/get_mechanics_examine(mob/user)
 	. = ..()
-	. += span_info("Activate in your hand to prime it. Depending on its age, this might take multiple attempts to successfully prepare.")
+	. += span_info("Place the trap on the ground and right-click it to arm it. A higher strength decreases the arming time while increasing the arming chance. Rusty traps will break upon re-arming.")
 	. += span_info("Beartraps can be safely disarmed by either left-clicking them with a open hand, or - at the cost of some durability - left-clicking them with a weapon.")
 
 /obj/item/restraints/legcuffs/beartrap/attack_hand(mob/user)

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -20,7 +20,7 @@
 	throw_range = 1
 	icon_state = "beartrap"
 	desc = "A crude and rusty spring trap, used to snare interlopers, or prey on a hunt. Looks almost like falling apart."
-	var/rusty = TRUE // Is it an old trap? Will most likely be destroyed if not handled right
+	var/rusty = FALSE // Is it an old trap? Will most likely be destroyed if not handled right
 	var/armed = FALSE // Is it armed?
 	var/trap_damage = 90 // How much brute damage the trap will do to its victim
 	var/used_time = 12 SECONDS // How many seconds it takes to disarm the trap


### PR DESCRIPTION
## About The Pull Request
- mantraps are now used by placing them down (dropping) and rmb'ing to arm.
- previous attackself functionality has been commented out
- arming mantraps is now a PROB check after a doafter, both of which scale off of strength.
- "rusty" var mantraps (which i will deal with, mapping wise, as i go through the tomb later, in addition to dun world. ideally, most pre-placed traps will be rusty) will fail & qdel on arming.
- mantraps cannot be stacked on top of each other by players. at least, not by arming them on top of each other. there's prolly sum bullshit w/ spells or something. idfk.
- new helper proc so admins can remotely call arm_trap as required. coders might find it useful, too.

**MAINTAINER:** please check over the LOGS and ensure they were done properly. i have not used log_combat before.

**REVIEWERS:** please consider if there is any way to still pick up placed, armed traps. i am FAIRLY CERTAIN you cant, but it might not be impossible. i did not anchor them as the original arming proc did not.

**GOING FORWARDS:** if this pr is merged, i will be doing additional work to change tomb of alotheos as well as dun world guaranteed mantrap spawners into my newly defined rusty mantrap helper thingamajig. you know it has a chance to spawn them. awesome  cool
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/21086e9c-d0ca-4fcb-96d8-7449c0058b20


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
i don't expect this PR to be popular with particular fraglords or stonehead-era players. i, however, do not really think that mantraps should be able to just like. be armed. in a backpack. and then dropped. idfk its just kinda dumb to me. we had a bug report with a deadite arming them and droppign them on the road on people who followed them & frankly even if it wasn't a deadite i'd still be going "Ughjh Ok Man"

i am willing to compromise on certain details like the rusty traps having a lesser prob instead of qdel'ing, or similar. i'd just like to open this up as a conversation For the People:tm:. we can maybe have placed traps have MMB functionality & allow them to be hidden (lowered alpha) with trapmaking skill, too.

if this pr is merged, mantraps will become less of a "drop mid combat on a guy chasing you" and more of a siege engineer placing them mid-battle (and being at risk doing so) or using them as proper pre-done area denial, whatever. 

TL;DR: i am not fond of the backpack mantrap strat. this turns them into actual placed... traps. instead of just shit u toss on da road. also rusty needed to be implemented. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:BALANCE JACKSON
balance: mantraps are now armed by placing and RMB'ing. you can now larp as trapper from dbd
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
