### PR TITLE
fixes odd sprite issues with altgrips

### DIFF
--- a/code/game/objects/inhands_rogue.dm
+++ b/code/game/objects/inhands_rogue.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(has_behind_cache, list()) // cheaty hack to avoid repeated list
 	if(HAS_BLOOD_DNA(src))
 		used_index += "_b"
 	var/static/list/onmob_sprites = list()
-	var/cache_key = "[type]|[tag]|[behind]|[mirrored]|[used_index]|[get_onmob_overlay_signature()]"
+	var/cache_key = "[type]|[icon]|[tag]|[current_alt_grip?.type]|[behind]|[mirrored]|[used_index]|[get_onmob_overlay_signature()]"
 	var/icon/onmob = onmob_sprites[cache_key]
 	if(!onmob || force_reupdate_inhand)
 		onmob = fcopy_rsc(generateonmob(tag, prop, behind, mirrored))
@@ -62,7 +62,7 @@ GLOBAL_LIST_INIT(has_behind_cache, list()) // cheaty hack to avoid repeated list
 ///Mob ref is only needed for their dir to know how to rotate it and for the throw proc.
 /obj/item/proc/get_deflected(mob/deflector)
 	var/turnangle = (prob(50) ? 270 : 90)
-	if(prob(10))	
+	if(prob(10))
 		turnangle = 0 //Right back at thee
 	var/turndir = turn(deflector.dir, turnangle)
 	var/dist = rand(1, 6)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -330,9 +330,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 					B.remove()
 					B.generate_appearance()
 					B.apply()
-				refresh_detail_overlay()
 				if (obj_broken)
 					update_damaged_state()
+			if(override_state)
+				icon_state = "[override_state][gripsprite ? "1" : ""]"
+			refresh_detail_overlay()
 			return
 		if(wielded)
 			if(gripsprite)
@@ -1543,8 +1545,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(user.get_active_held_item() == src)
 		user.update_a_intents()
 	user.changeNext_move(CLICK_CD_RAPID)
-	if(override_state)
-		apply_override_state(override_state)
 	return TRUE
 
 /obj/item/proc/altgrip(mob/living/carbon/user)

--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -294,12 +294,6 @@
 	update_wdefense_dynamic()
 	return TRUE
 
-/obj/item/proc/apply_override_state(state)
-	if(!state)
-		return
-	icon_state = state
-	item_state = state
-
 /obj/item/proc/clear_altgrip_state()
 	if(current_alt_grip)
 		current_alt_grip.remove_from(src)


### PR DESCRIPTION
## About The Pull Request

as it says on the tin. this was due to weird icon state keying n then getting to update the icon of the alt grips/morphing elixirs improperly before update_inv_* procs

## Testing Evidence

yes

## Why It's Good For The Game

idunno

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: altgripped swordes having mismatched icons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
