### PR TITLE
Gives the Seneschal the key to the Manor secure areas.

### DIFF
--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -262,7 +262,7 @@
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/apothecary, /obj/item/roguekey/mage, /obj/item/roguekey/university, /obj/item/roguekey/university_secure)
 
 /obj/item/storage/keyring/seneschal //Housekeeper, more of a reason to attack them too by antags
-	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/royal, /obj/item/roguekey/heir, /obj/item/roguekey/garrison)
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/royal, /obj/item/roguekey/heir, /obj/item/roguekey/garrison, /obj/item/roguekey/walls)
 
 /obj/item/storage/keyring/jester //Might infact be hilarious, might be horrid, who knows
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/university, /obj/item/roguekey/walls)


### PR DESCRIPTION
## About The Pull Request

Adds the walls key in the Seneschal keyring to give them access to the manor secure areas. They need sweeping, too.

## Testing Evidence

It changes one line, my liege.

## Why It's Good For The Game

Having the garrison key and not the wall key caused some weird edge cases due of how access is set up. This fixes that. Also potentially makes the Seneschal a more attractive robbery target.

## Changelog

Such a small change it doesn't need documentation. Save the CL for the things that matter.
