### PR TITLE
MAA & Heraldic Tabard Tweaks - Small loadout adjustments and consistency improvements

### DIFF
--- a/code/__HELPERS/cloaksetup.dm
+++ b/code/__HELPERS/cloaksetup.dm
@@ -9,35 +9,37 @@
 			name_index = "knight's"
 			allowed_cloaks = list(
 			"Jupon" = 			/obj/item/clothing/cloak/tabard/stabard/surcoat/guard,
-			"Knight tabard" = 	/obj/item/clothing/cloak/tabard/retinue,
-			"Short tabard" = 	/obj/item/clothing/cloak/tabard/stabard/guard,
+			"Surcoat" = 	/obj/item/clothing/cloak/tabard/stabard/guard,
+			"Hood" = 		/obj/item/clothing/cloak/tabard/stabard/guardhood,
+			"Tabard" = 	/obj/item/clothing/cloak/tabard/retinue,
 			"Cape" = 			/obj/item/clothing/cloak/cape/guard,
-			"Guard hood" = 		/obj/item/clothing/cloak/tabard/stabard/guardhood)
+			)
 		if("Squire")
 			name_index = "squire's"
 			allowed_cloaks = list(
 			"Jupon" = 			/obj/item/clothing/cloak/tabard/stabard/surcoat/guard,
+			"Surcoat" = 	/obj/item/clothing/cloak/tabard/stabard/guard,
+			"Hood" = 		/obj/item/clothing/cloak/tabard/stabard/guardhood,
+			"Tabard" =		/obj/item/clothing/cloak/tabard/retinue,
 			"Cape" = 			/obj/item/clothing/cloak/cape/guard,
-			"Long tabard" =		/obj/item/clothing/cloak/tabard/retinue,
-			"Short tabard" = 	/obj/item/clothing/cloak/tabard/stabard/guard,
-			"Guard hood" = 		/obj/item/clothing/cloak/tabard/stabard/guardhood)
+			)
 		if("Man at Arms")
 			name_index = "man-at-arms"
 			allowed_cloaks = list(
 			"Jupon" = 			/obj/item/clothing/cloak/tabard/stabard/surcoat/guard,
-			"Tabard" = 			/obj/item/clothing/cloak/tabard/stabard/guard,
-			"Guard hood" = 		/obj/item/clothing/cloak/tabard/stabard/guardhood
+			"Surcoat" = 			/obj/item/clothing/cloak/tabard/stabard/guard,
+			"Hood" = 		/obj/item/clothing/cloak/tabard/stabard/guardhood,
 			)
 		if("Sergeant")
 			name_index = "sergeant"
 			allowed_cloaks = list(
 			"Jupon" = 			/obj/item/clothing/cloak/tabard/stabard/surcoat/guard,
-			"Tabard" = 			/obj/item/clothing/cloak/tabard/stabard/guard,
+			"Surcoat" = 			/obj/item/clothing/cloak/tabard/stabard/guard,
+			"Hood" = 		/obj/item/clothing/cloak/tabard/stabard/guardhood,
 			"Cape" = 			/obj/item/clothing/cloak/cape/guard,
-			"Guard hood" = 		/obj/item/clothing/cloak/tabard/stabard/guardhood
 			)
 
-	var/choive_key = input(src, "Choose your cloak", "IDENTIFY YOURSELF") as anything in allowed_cloaks
+	var/choive_key = input(src, "Choose your cloak.", "IDENTIFY YOURSELF") as anything in allowed_cloaks
 	var/typepath = allowed_cloaks[choive_key]
 	var/obj/item/clothing/cloak/cloak_choice = new typepath(src)
 	var/list/namesplit = splittext(src.real_name, " ")

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -693,8 +693,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/detailed/tabards.dmi'
 
 /obj/item/clothing/cloak/tabard/stabard/guard
-	name = "guard tabard"
-	desc = "A tabard with the lord's heraldic colors."
+	desc = "An outer garment with the lord's heraldic colors."
 	color = CLOTHING_AZURE
 	detail_tag = "_quad"
 	detail_color = CLOTHING_WHITE
@@ -800,7 +799,7 @@
 	body_parts_covered = CHEST
 
 /obj/item/clothing/cloak/tabard/stabard/surcoat/guard
-	desc = "A surcoat with the lord's heraldic colors."
+	desc = "A jupon with the lord's heraldic colors."
 	color = CLOTHING_AZURE
 	detail_tag = "_quad"
 	detail_color = CLOTHING_WHITE
@@ -1515,7 +1514,7 @@
 //Short hoods for guards
 
 /obj/item/clothing/cloak/tabard/stabard/guardhood
-	name = "guard hood"
+	name = "hood"
 	desc = "A hood with the lord's heraldic colors."
 	color = CLOTHING_AZURE
 	detail_tag = "_spl"

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
@@ -44,7 +44,6 @@
 /datum/outfit/job/roguetown/manorguard
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	saiga_shoes = /obj/item/clothing/shoes/roguetown/horseshoes
-	beltl = /obj/item/rogueweapon/mace/cudgel
 	belt = /obj/item/storage/belt/rogue/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/scomstone/bad/garrison
@@ -85,10 +84,10 @@
 
 /datum/outfit/job/roguetown/manorguard/footsman/pre_equip(mob/living/carbon/human/H)
 	..()
-
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
+	beltl = /obj/item/rogueweapon/mace/cudgel
 
 	H.adjust_blindness(-3)
 	if(H.mind)
@@ -172,7 +171,7 @@
 		STATKEY_WIL = 1
 	)
 	subclass_skills = list(
-		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE, 		// Still have a cugel.
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE, 		// Still can have a cudgel.
 		/datum/skill/combat/crossbows = SKILL_LEVEL_MASTER,		//Only effects draw and reload time.
 		/datum/skill/combat/bows = SKILL_LEVEL_MASTER,			//Only effects draw times.
 		/datum/skill/combat/slings = SKILL_LEVEL_MASTER,
@@ -210,7 +209,7 @@
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			if("Sling")
 				beltr = /obj/item/quiver/sling/iron
-				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling // Both are belt slots and it's not worth setting where the cugel goes for everyone else, sad.
+				l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling // Both are belt slots and it's not worth setting where the cudgel goes for everyone else, sad.
 
 		switch(armor_choice)
 			if("Leather Armor") //OG more or less RT guardsman archer
@@ -218,21 +217,39 @@
 				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy
 				wrists = /obj/item/clothing/wrists/roguetown/bracers
 				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+				beltl = /obj/item/rogueweapon/scabbard/sheath
 				H.adjust_skillrank(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+				var/sidearm = list(
+					"Dagger" = /obj/item/rogueweapon/huntingknife/idagger/steel/special,
+					"Messer" = /obj/item/rogueweapon/huntingknife/combat/messser,
+				)
+				var/sidearm_choice = input(H, "Choose your sidearm.", "TAKE UP ARMS") as anything in sidearm
+				r_hand = sidearm[sidearm_choice]
 			if("Brigandine Armor") //New MAA skirmisher
-				head = /obj/item/clothing/head/roguetown/helmet/kettle
 				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
 				pants = /obj/item/clothing/under/roguetown/brigandinelegs
+				beltl = /obj/item/rogueweapon/scabbard
+				r_hand = /obj/item/rogueweapon/sword/short
 				H.adjust_skillrank(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+				var/helmets = list(
+				"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+				"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+				"Bascinet Helmet"	= /obj/item/clothing/head/roguetown/helmet/bascinet,
+				"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+				"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+				"Skull Cap"			= /obj/item/clothing/head/roguetown/helmet/skullcap,
+				"None"
+				)
+				var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+				if(helmchoice != "None")
+					head = helmets[helmchoice]
 
 		backpack_contents = list(
-			/obj/item/rogueweapon/huntingknife/combat/messser = 1,
 			/obj/item/rope/chain = 1,
 			/obj/item/storage/keyring/manatarms = 1,
-			/obj/item/rogueweapon/scabbard/sheath = 1,
 			/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
 			)
 		add_verb(H, /mob/proc/haltyell)
@@ -263,7 +280,7 @@
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE, 		// Still have a cugel.
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE, 		// Still have a cudgel.
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT,	//Not case anymore so let's put them on par with Bailiff.
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
@@ -288,6 +305,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	pants = /obj/item/clothing/under/roguetown/chainlegs
+	beltl = /obj/item/rogueweapon/mace/cudgel
 
 	H.adjust_blindness(-3)
 	if(H.mind)
@@ -349,10 +367,11 @@
 		STATKEY_INT = -1//Old dungeoneer statspread more or less
 	)
 	subclass_skills = list(
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE, // Still can have a cudgel.
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT,//Primary way they are meant to dispose of ppl
 		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT, //hilarious
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/swords = SKILL_LEVEL_NOVICE, //You are not actually meant to use this in combat.
+		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE, //You are not actually meant to use this in combat.
 		/datum/skill/combat/slings = SKILL_LEVEL_JOURNEYMAN,//Funny
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,//Enough for majority of surgeries without grinding.
@@ -377,6 +396,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	beltl = /obj/item/rogueweapon/mace/cudgel
 	beltr = /obj/item/rogueweapon/whip/antique
 	backl = /obj/item/rogueweapon/sword/long/exe/cloth
 
@@ -412,7 +432,7 @@
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT, // SWING THAT THING.
-		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN, 
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN, // On par with Footman, but journeyman.
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
@@ -437,6 +457,7 @@
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 	r_hand = /obj/item/rogueweapon/spear/keep_standard
+	beltl = /obj/item/rogueweapon/mace/cudgel
 	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
@@ -371,7 +371,6 @@
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT,//Primary way they are meant to dispose of ppl
 		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT, //hilarious
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE, //You are not actually meant to use this in combat.
 		/datum/skill/combat/slings = SKILL_LEVEL_JOURNEYMAN,//Funny
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,//Enough for majority of surgeries without grinding.


### PR DESCRIPTION
## About The Pull Request
- Skirmisher no longer starts with a cudgel. Instead, they receive an appropriate scabbard depending on their chosen sidearm (dagger or sword).
- Skirmishers who choose Leather Armor may now select either a Dagger or a Messer as their sidearm.
- Skirmishers who choose Brigandine Armor now always receive a Steel Shortsword, giving the heavier armor option a more defined identity.
- Skirmishers choosing Brigandine Armor now get access to the same selection of helmets as any other Man-At-Arms class."
- Cudgel has been redistributed to every other Man-at-Arms class, leaving Skirmisher as the sole exception.
- Bailiff now has Apprentice Maces instead of swords, allowing them to properly use the cudgel they spawn with.
- Standardized the names of heraldic tabards and cleaned up their selection menu. Tabards that share the same sprite now share the same name, making the menu more consistent and less confusing.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled and tested.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Makes the Skirmisher loadout more coherent by pairing weapons with the correct scabbards and giving each armor choice a clearer equipment identity.
- Ensures the cudgel is issued to classes that are actually intended to use it.
- Improves the heraldic tabard menu by eliminating duplicate entries with different names for identical sprites, making cosmetic selection more intuitive.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Skirmishers now receive an appropriate scabbard instead of a cudgel.
balance: Leather Armor Skirmishers may choose between a Dagger and a Messer, while Brigandine Armor Skirmishers now receive a Steel Shortsword.
balance: Bailiffs now have Apprentice Maces instead of Novice Swords.
balance: Redistributed the cudgel to all other Man-at-Arms classes.
qol: Skirmishers wearing Brigandine Armor now get access to helmet selection, just like any other Man-at-Arms class.
qol: Standardized heraldic tabard names and cleaned up the selection menu for consistency.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
