### PR TITLE
Fix Triumphs Loss on virtue item name collision - no save loss edition.

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -561,6 +561,9 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define TRIUMPH_CAT_MISC "MISC!"
 #define TRIUMPH_CAT_ACTIVE_DATUMS "ACTIVE"
 
+// Suffix for a triumph entry so that it doesn't overlap
+#define TRIUMPH_STASH_SUFFIX " - TR"
+
 #define ARMOR_CLASS_NONE 0
 #define ARMOR_CLASS_LIGHT 1
 #define ARMOR_CLASS_MEDIUM 2

--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -49,7 +49,11 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		var/datum/loadout_item/LI = GLOB.loadout_items_by_name[item_name]
 		if(!LI)
 			continue
-		character.mind.special_items[LI.name] = LI.path
+		if(LI.triumph_cost)
+			// Tag triumph cost items so that it is charged properly
+			character.mind.special_items["[LI.name][TRIUMPH_STASH_SUFFIX]"] = LI.path
+		else
+			character.mind.special_items[LI.name] = LI.path
 	var/datum/job/assigned_job = SSjob.GetJob(character.mind?.assigned_role)
 	if(assigned_job)
 		assigned_job.clamp_stats(character)
@@ -65,11 +69,11 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		REMOVE_TRAIT(H, TRAIT_EASYDISMEMBER, null) // Doesn't care for source, they ARE getting canceled
 		REMOVE_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, null)
 		to_chat(H, span_warning("My limbs are too frail and my body too tough... the contradiction leaves me unable to resist critical wounds."))
-		
+
 	var/datum/advclass/advclass = H.get_advclass_datum()
 	if(advclass?.tempo_capable && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Towner") // (Easier to filter these out than apply the bool to every subclass)
 		if(!H.mind.has_antag_datum(/datum/antagonist/skeleton) && !H.mind.has_antag_datum(/datum/antagonist/lich) && !H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/vampire/lord))
-			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)		
+			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	return TRUE
 
 /proc/apply_voicepacks(mob/living/carbon/human/character, client/player)
@@ -154,7 +158,7 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 	var/bonus = player.prefs.race_bonus
 	if(!(bonus in character.dna.species.custom_selection))
 		return
-	var/full_bonus 
+	var/full_bonus
 	full_bonus = character.dna.species.custom_selection[bonus]
 	if(!full_bonus)
 		return

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1396,7 +1396,12 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 			if(item)
 				if(user.Adjacent(host_object))
 					if(user.mind.special_items[item])
-						var/datum/loadout_item/LI = GLOB.loadout_items_by_name[item]
+						// Don't charge for non-triumph derived item of the same name
+						var/base_name = item
+						var/datum/loadout_item/LI
+						if(copytext(item, -length(TRIUMPH_STASH_SUFFIX)) == TRIUMPH_STASH_SUFFIX)
+							base_name = copytext(item, 1, length(item) - length(TRIUMPH_STASH_SUFFIX) + 1)
+							LI = GLOB.loadout_items_by_name[base_name]
 						if(LI?.triumph_cost)
 							var/discounted_cost = max(0, LI.triumph_cost - user.mind.triumph_discount_remaining)
 							if(discounted_cost > 0 && user.get_triumphs() < discounted_cost)
@@ -1413,7 +1418,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 							I.special_item = TRUE
 							I.smeltresult = /obj/item/ash
 							I.salvage_result = /obj/item/ash
-						var/list/metadata = user.client?.prefs?.gear_list?[item]
+						var/list/metadata = user.client?.prefs?.gear_list?[base_name]
 						if(islist(metadata))
 							if(metadata["color"])
 								I.add_atom_colour(metadata["color"], FIXED_COLOUR_PRIORITY)


### PR DESCRIPTION
## About The Pull Request
Basically do the same thing as Orbis's idea in https://github.com/Azure-Peak/Azure-Peak/pull/8228 but without any chance of overriding or losing the save. 

- Items sourced from triumphs is now suffixed with - TR 
- Now they check for these suffix BEFORE charging you triumphs 
- This means for example, Ladylike Shortcloak (triumph) will not collide with nobility virtue and lose you triumphs.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="242" height="62" alt="dreamseeker_kTXM1GMPRO" src="https://github.com/user-attachments/assets/0596cace-4fb8-4868-9a48-ca8dc1b1335b" />
<img width="374" height="194" alt="dreamseeker_FiZrM0Najj" src="https://github.com/user-attachments/assets/be0d491e-9252-4d05-b3df-83ff13978052" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fixes a bug w/o messing up all loadout selection

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Items sourced from triumphs is now suffixed with - TR in your stash. It is checked to avoid name collision. This means nobility virtue's ladylike shortcloak don't charge you for withdrawing it while triumphs one will. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
