### PR TITLE
Loadout items without armor fit aesthetically

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -222,6 +222,8 @@
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
 	armor = ARMOR_CLOTHING
 	armor_class = ARMOR_CLASS_NONE
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/shirt/freifechter/shepherd
 	name = "shepherd's shirt"
@@ -284,6 +286,8 @@
 	name = "aesthetic grenzelhoftian hip-shirt"
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
 	armor = ARMOR_CLOTHING
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/raneshen
 	name = "padded desert coat"
@@ -305,6 +309,8 @@
 	armor = ARMOR_CLOTHING
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
 	armor_class = ARMOR_CLASS_NONE
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/pontifex
 	name = "pontifex's kaftan"
@@ -318,6 +324,8 @@
 	armor = ARMOR_CLOTHING
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
 	armor_class = ARMOR_CLASS_NONE
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/inq
 	name = "inquisitorial leather tunic"
@@ -342,6 +350,9 @@
 	armor_class = ARMOR_CLASS_NONE
 	armor = ARMOR_CLOTHING
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
+	grid_width = 64
+	grid_height = 64
+
 //Hand's gambeson, looks fancy
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hand

--- a/code/modules/clothing/rogueclothes/armor/leather.dm
+++ b/code/modules/clothing/rogueclothes/armor/leather.dm
@@ -300,6 +300,8 @@
 	sleevetype = null
 	sleeved = null
 	armor_class = ARMOR_CLASS_NONE
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/armor/leather/vest/sailor
 	name = "sea jacket"

--- a/code/modules/clothing/rogueclothes/armor/misc.dm
+++ b/code/modules/clothing/rogueclothes/armor/misc.dm
@@ -48,6 +48,8 @@
 	sleeved = null
 	nodismemsleeves = TRUE
 	boobed = TRUE
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/armor/workervest/Initialize()
 	color = pick("#94b4b6", "#ba8f9e", "#bd978c", "#92bd8c", "#c7c981")

--- a/code/modules/clothing/rogueclothes/armor/misc.dm
+++ b/code/modules/clothing/rogueclothes/armor/misc.dm
@@ -8,7 +8,9 @@
 	salvage_result = /obj/item/natural/hide/cured
 	sewrepair = TRUE
 	salvage_amount = 1
-	
+	grid_width = 64
+	grid_height = 64
+
 /obj/item/clothing/suit/roguetown/armor/longcoat
 	name = "longcoat"
 	desc = "A padded longcoat meant to keep you warm in the frigid winters"

--- a/code/modules/clothing/rogueclothes/armor/unique.dm
+++ b/code/modules/clothing/rogueclothes/armor/unique.dm
@@ -40,6 +40,8 @@
 	armor = ARMOR_CLOTHING
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
 	armor_class = ARMOR_CLASS_NONE
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/loadout/ComponentInitialize()
 	return
@@ -60,6 +62,8 @@
 	armor = ARMOR_CLOTHING
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
 	armor_class = ARMOR_CLASS_NONE
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/crafteast/loadout/ComponentInitialize()
 	return
@@ -80,6 +84,8 @@
 	armor = ARMOR_CLOTHING
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
 	armor_class = ARMOR_CLASS_NONE
+	grid_width = 64
+	grid_height = 64
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit/loadout/ComponentInitialize()
 	return


### PR DESCRIPTION
## About The Pull Request

Allows you to equip your loadout armor items into the aesthetic slot.

This change applies to all the recently added aesthetic cultural donor items, and does not apply to their normal armored variants. This also applies to the corset and striped tunic, both items with no armor value that for some reason could not fit in the aesthetic slot. And I have also included changes to the leather vest, and the items that spawn from it that are also purely cosmetic.

This does have the side effect of making the items "smaller" for storage purposes, as they take up a 2x2 grid rather then a 3x2 grid. But I don't think that would be an issue as these are not actual armor items.

## Testing Evidence

Tested it locally, could now equip the "armor" into the decorative slot, and could not equip the normal variants in the decorative slot. Sprites are not deformed and it all looks and functions as it should.

## Why It's Good For The Game

These items have no armor value, and thus should be equip-able in the decorative/aesthetic slot. Naturally this further enhances player expression.

## Changelog

:cl:
add: Loadout gear with no armor value can now be stored in your aesthetic slot
/:cl:

