### PR TITLE
Revert "fix leechticks attaching to deadites and skeletons"

### DIFF
--- a/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_tick.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_tick.dm
@@ -56,21 +56,6 @@
 	if(!SSchimeric_tech.get_node_status("CORPSE_TICKS") && target.stat == DEAD)
 		return FALSE
 
-	if(HAS_TRAIT(target, TRAIT_DEADITE))
-		target.visible_message(
-			span_warning("[src] refuses to latch onto an undead thing!"),
-			span_notice("[src] refuses to attach to you, on account of being a deadite.")
-		)
-		return FALSE
-
-	var/obj/item/bodypart/chest/target_chest = target.get_bodypart(BODY_ZONE_CHEST)
-	if(target_chest.skeletonized)
-		target.visible_message(
-			span_warning("[src] refuses to latch onto a skeleton!"),
-			span_notice("[src] refuses to attach to you, on account of being boney.")
-		)
-		return FALSE
-
 	if(target.has_status_effect(/datum/status_effect/debuff/devitalised))
 		return FALSE
 
@@ -286,7 +271,7 @@
 /datum/status_effect/debuff/leech_schizophrenia/on_creation(mob/living/new_owner, ...)
 	. = ..()
 
-	duration = rand(14 MINUTES, 28 MINUTES)
+	duration = rand(14 MINUTES, 28 MINUTES) 
 	current_cooldown = world.time + message_cooldown
 	return .
 


### PR DESCRIPTION
Reverts Azure-Peak/Azure-Peak#8251

Leechticks are refusing to attach as of the latest round, confirmed on checksum just before the merge.
<img width="1102" height="778" alt="image" src="https://github.com/user-attachments/assets/8d7ec7ff-7388-447f-83c0-70c349223334" />
<img width="850" height="581" alt="image" src="https://github.com/user-attachments/assets/d04fbe78-faad-460c-ba9c-947d4ef49ad0" />

confirmed to runtime when trying to attach to a cabbit due to an incorrect cast in the code.