### PR TITLE
Fixes runtime I added with leechtick checks, leechticks now can't attach to simplemobs

### DIFF
--- a/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_tick.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_tick.dm
@@ -64,7 +64,15 @@
 		return FALSE
 
 	var/obj/item/bodypart/chest/target_chest = target.get_bodypart(BODY_ZONE_CHEST)
-	if(target_chest.skeletonized)
+
+	//Simplemobs won't have a chest to read
+	if(target_chest == null)
+		target.visible_message(
+			span_warning("[src] is uninterested in this creature."),
+			span_notice("[src] refuses to attach to your simple form.")
+		)
+		return FALSE
+	else if(target_chest.skeletonized)
 		target.visible_message(
 			span_warning("[src] refuses to latch onto a skeleton!"),
 			span_notice("[src] refuses to attach to you, on account of being boney.")


### PR DESCRIPTION
## About The Pull Request

Catches a null I didn't consider and makes it so leechticks can't attach to simplemobs (anything with a null BODY_ZONE_CHEST)

## Testing Evidence

<img width="280" height="94" alt="image" src="https://github.com/user-attachments/assets/c519a53b-503b-436c-87e7-6d7d3911584f" />
Tested on a deadite, a skeleton carbon, a human, and a cabbit.

## Why It's Good For The Game

Leechticks are cool and good but harvesting lux from literally any creature seems unintended to me.

## Changelog

:cl:
fix: Fixes leechtick runtime I added, prevents leechticks from attaching to simplemobs, skeletons, and deadites
/:cl:

