### PR TITLE
fixes secular barter return rates

### DIFF
--- a/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -589,6 +589,7 @@
 	button_icon = 'icons/mob/actions/antiquarianspells.dmi'
 	button_icon_state = "secularbarter"
 	sound = null
+	associated_skill = /datum/skill/misc/reading
 
 	click_to_activate = TRUE
 	cast_range = SPELL_RANGE_ADJACENT


### PR DESCRIPTION
## About The Pull Request
secular barter's associated skill was changed to Holy  in https://github.com/Azure-Peak/Azure-Peak/pull/8036. This changes it back to Reading.

I personally believe the cooldown change is too big a nerf, but that's out of scope

## Testing Evidence

<img width="348" height="383" alt="{3CE2C240-A15C-4857-8FED-9888AA79DFFC}" src="https://github.com/user-attachments/assets/7944b597-bda0-43f8-996b-50d798638754" />

## Why It's Good For The Game

fixes secular barter being useless on its intended class
## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fixes secular barter associated skill
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
