### PR TITLE
Minor Pen Tweaks

### DIFF
--- a/code/__DEFINES/armor_defines.dm
+++ b/code/__DEFINES/armor_defines.dm
@@ -44,7 +44,8 @@
 #define ARMOR_DBLOCK_TYPES list("slash", "stab", "piercing")
 
 // Penetration passthrough fractions
-#define PEN_PASSTHROUGH_RATIO	0.1		// How much damage will go through per pen point (+ per relevant stat above 10). 0.1 = 10%
+#define PEN_PASSTHROUGH_MINIMUM 0.4
+#define PEN_PASSTHROUGH_RATIO	0.05		// How much damage will go through per pen point (+ per relevant stat above 10). 0.1 = 10%
 #define PEN_PASSTHROUGH_PROJ_EQUAL 0.2
 #define PEN_PASSTHROUGH_PROJ_MORE 0.8
 #define PEN_PASSTHROUGH_CAP	8			// How many "dots" maximum (pen vs armor, + 1 dot per relevant stat above 10)
@@ -150,7 +151,7 @@
 #define ARMOR_PADDED_BAD list("blunt" = DR_MEDIUM, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE)
 
 // LIGHT ARMOR - Split into two sidegrades: PADDED VS LEATHER
-// PADDED: Best Blunt protection, Bodkin immune. But Axe CHOP (MEDIUM) and most thrusts (LIGHT) get through. 
+// PADDED: Best Blunt protection, Bodkin immune. But Axe CHOP (MEDIUM) and most thrusts (LIGHT) get through.
 // LEATHER: Decent Blunt DR. Axe CHOP (MEDIUM), sword thrust (MEDIUM) and bodkin (HEAVY) get through. Better vs stab than padded, worse vs piercing.
 #define ARMOR_PADDED list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_BSTEEL, "fire" = DR_LIGHT)
 #define ARMOR_LEATHER_NPC list("blunt" = DR_HEAVY, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM)
@@ -169,7 +170,7 @@
 // MAILLE — Chainmail. Medium: Plate level protection but weak vs Bodkin (100% through)
 #define ARMOR_MAILLE list("blunt" = DR_MEDIUM, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE)
 
-// PLATE — Cuirass, plate. All plate-tier items; differentiated by integrity, not rating. Spear (PEN_HEAVY) gets 20% through stab. Bodkin goes through 100% - MEDIUM rating. Weak vs Blunt. 
+// PLATE — Cuirass, plate. All plate-tier items; differentiated by integrity, not rating. Spear (PEN_HEAVY) gets 20% through stab. Bodkin goes through 100% - MEDIUM rating. Weak vs Blunt.
 #define ARMOR_PLATE list("blunt" = DR_LIGHT, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_NONE)
 
 // BSTEEL — Blacksteel, antagonist. DBLOCK_BSTEEL (4).
@@ -177,7 +178,7 @@
 #define ARMOR_PLATE_BSTEEL list("blunt" = DR_MEDIUM, "slash" = DBLOCK_BSTEEL, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_BSTEEL, "fire" = DR_LIGHT)
 
 //Antag / Special / Unique armor defines
-// If you DO NOT have a VERY VERY good design reasons for why your armor should varies 
+// If you DO NOT have a VERY VERY good design reasons for why your armor should varies
 // Please do not add it and use an existing one, so to prevent armor bloat and keep armor
 // reasonable and intuitive.
 #define ARMOR_REGENERATING_BROKEN list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1867,8 +1867,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		H.balloon_alert(H, "[bodyzone2readablezone(selzone)]...")
 
 	var/pen_info_check = get_pen_info(H, user, H.get_best_worn_armor(def_zone, int.item_d_type), def_zone, int.item_d_type, int.penfactor, I)
-	if(I.sharpness)
-		if(I.blade_int)
 	var/armor_block = H.run_armor_check(selzone, I.d_type, "", "",pen, damage = Iforce, blade_dulling=bladec, intdamfactor = used_intfactor, used_weapon = I, pen_info = pen_info_check)
 
 	var/nodmg = FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1867,6 +1867,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		H.balloon_alert(H, "[bodyzone2readablezone(selzone)]...")
 
 	var/pen_info_check = get_pen_info(H, user, H.get_best_worn_armor(def_zone, int.item_d_type), def_zone, int.item_d_type, int.penfactor, I)
+	if(I.sharpness)
+		if(I.blade_int)
 	var/armor_block = H.run_armor_check(selzone, I.d_type, "", "",pen, damage = Iforce, blade_dulling=bladec, intdamfactor = used_intfactor, used_weapon = I, pen_info = pen_info_check)
 
 	var/nodmg = FALSE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -40,7 +40,7 @@
 							if(I.sharpness)
 								if((I.blade_int / I.max_blade_int) <= SHARPNESS_TIER2_THRESHOLD) // Our sharpness is 'chunked' (<20%), so we do not pen at all.
 									pen_info = 0
-						if(peninfo)
+						if(pen_info)
 							blocked = block_damage * (1 - (PEN_PASSTHROUGH_MINIMUM + (pen_info * PEN_PASSTHROUGH_RATIO)))
 					if(penetrated_text)
 						to_chat(src, span_danger("[penetrated_text]"))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -35,7 +35,13 @@
 			if(armor_tier > 0)
 				if(armor_penetration >= armor_tier)
 					if(pen_info)
-						blocked = block_damage * (1 - (pen_info * PEN_PASSTHROUGH_RATIO)) 
+						if(used_weapon)
+							var/obj/item/I = used_weapon
+							if(I.sharpness)
+								if((I.blade_int / I.max_blade_int) <= SHARPNESS_TIER2_THRESHOLD) // Our sharpness is 'chunked' (<20%), so we do not pen at all.
+									pen_info = 0
+						if(peninfo)
+							blocked = block_damage * (1 - (PEN_PASSTHROUGH_MINIMUM + (pen_info * PEN_PASSTHROUGH_RATIO)))
 					if(penetrated_text)
 						to_chat(src, span_danger("[penetrated_text]"))
 				else
@@ -73,21 +79,17 @@
 		update_sneak_invis(reset = TRUE)
 	return blocked
 
-#define SHARPNESS_PENALTY_RATIO_ONE 0.7
-#define SHARPNESS_PENALTY_RATIO_TWO 0.6
-#define SHARPNESS_PENALTY_RATIO_THREE 0.5
-#define SHARPNESS_PENALTY_RATIO_FOUR 0.4
 
 /proc/get_pen_info(mob/living/carbon/human/target, mob/living/attacker, obj/item/clothing/used_armor, def_zone, d_type, armor_pen, obj/item/I)
 	if(!target || !def_zone || !d_type || !armor_pen || !ishuman(target))
 		return 1
-	var/pen_total = armor_pen
+	var/pen_total = (armor_pen * 2)
 	var/protection
 	if(!used_armor)
 		used_armor = target.get_best_worn_armor(def_zone, d_type)
 	if(used_armor)
 		protection = used_armor.armor.getRating(d_type)
-	pen_total -= protection
+	pen_total -= (protection * 2)
 	var/balance_bonus = 0
 	var/sharpness_bonus = 0
 	var/damfactor_bonus = 0
@@ -101,22 +103,9 @@
 
 			if(dullness_ratio > SHARPNESS_TIER1_THRESHOLD)	// We are above 80% sharpness, so we go along as planned and get a small bonus.
 				sharpness_bonus += 1
-				use_bonus = TRUE
-			else if(dullness_ratio < SHARPNESS_TIER2_THRESHOLD + 0.1)	// We are below sharpness threshold where we use damfactors & STR for damage, so we won't use it for pen either.
+			if(dullness_ratio <= SHARPNESS_TIER1_FLOOR)
 				use_bonus = FALSE
-				if(damfactor_bonus > 0)
-					damfactor_bonus = 0
-			else	// We are inbetween, so we'll apply a penalty.
-				if(dullness_ratio < SHARPNESS_PENALTY_RATIO_ONE)
-					if(damfactor_bonus > 0)
-						damfactor_bonus = max(damfactor_bonus - 1, 0) // -1 from damfactor
-				if(dullness_ratio <= SHARPNESS_PENALTY_RATIO_TWO)
-					sharpness_bonus -= 1	//-1 from the total
-				if(dullness_ratio <= SHARPNESS_PENALTY_RATIO_THREE)
-					if(damfactor_bonus > 0)
-						damfactor_bonus = max(damfactor_bonus - 1, 0) // -2 from damfactor
-				if(dullness_ratio <= SHARPNESS_PENALTY_RATIO_FOUR)
-					sharpness_bonus -= 1	//-2 from the total
+				damfactor_bonus = 0
 
 		if(use_bonus)
 			switch(I.wbalance)
@@ -124,28 +113,25 @@
 					balance_bonus = (attacker.STASTR - 10) + 2
 				if(WBALANCE_NORMAL)
 					balance_bonus = (attacker.STASTR - 10)
-				if(WBALANCE_SWIFT)
-					balance_bonus = (attacker.STASPD - 10)
+				if(WBALANCE_SWIFT)	// We use either SPD or STR, whichever's higher.
+					balance_bonus = max((attacker.STASPD - 10), (attacker.STASTR - 10))
+			if(I.wbalance != WBALANCE_HEAVY)
+				balance_bonus = min(balance_bonus, 4)
 
 	else
 		balance_bonus = (attacker.STASTR - 10)	// Unarmed, probably.
 	// If our negative sharpness malus is equal or greater than the balance bonus, we neutralize them both.
 	// This is to prevent edge cases where losing sharpness would -increase- our pen damage.
 	// Fundamentally, we shouldn't be penalized via sharpness beyond what we would've gained from our stats.
-	if(abs(balance_bonus) <= abs(sharpness_bonus) && sharpness_bonus <= 0 && balance_bonus >= 0)	
+	if(abs(balance_bonus) <= abs(sharpness_bonus) && sharpness_bonus <= 0 && balance_bonus >= 0)
 		balance_bonus = 0
 		sharpness_bonus = 0
 	pen_total += balance_bonus
 	pen_total += sharpness_bonus
-	// This proc's usage is meant to presume we're in the part of the 
+	// This proc's usage is meant to presume we're in the part of the
 	// proc pipeline that is already penning, so we give it at least a 1.
 	pen_total = clamp(pen_total, 1, 8)
 	return pen_total
-
-#undef SHARPNESS_PENALTY_RATIO_ONE
-#undef SHARPNESS_PENALTY_RATIO_TWO
-#undef SHARPNESS_PENALTY_RATIO_THREE
-#undef SHARPNESS_PENALTY_RATIO_FOUR
 
 /mob/living/proc/getarmor(def_zone, type, damage, armor_penetration, blade_dulling, intdamfactor, used_weapon)
 	return 0
@@ -428,9 +414,9 @@
 	if(user == src)
 		instant = TRUE
 
-	if(HAS_TRAIT(user, TRAIT_NOSTRUGGLE))	
+	if(HAS_TRAIT(user, TRAIT_NOSTRUGGLE))
 		instant = TRUE
-		
+
 	if(surrendering)
 		combat_modifier = 2
 
@@ -541,7 +527,7 @@
 	return list(/datum/intent/grab/move)
 
 /mob/living/proc/send_grabbed_message(mob/living/carbon/user)
-	if(HAS_TRAIT(user, TRAIT_NOTIGHTGRABMESSAGE))	
+	if(HAS_TRAIT(user, TRAIT_NOTIGHTGRABMESSAGE))
 		return
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		visible_message(span_danger("[user] firmly grips [src]!"),
@@ -653,7 +639,7 @@
 			span_danger("[src] was shocked by \the [source]!"), \
 			span_danger("I feel a powerful shock coursing through my body!"), \
 			span_hear("I hear a heavy electrical crack.")
-		)	
+		)
 	playsound(get_turf(src), pick('sound/misc/elec (1).ogg', 'sound/misc/elec (2).ogg', 'sound/misc/elec (3).ogg'), 100, FALSE)
 	return shock_damage
 
@@ -710,4 +696,4 @@
 			do_item_attack_animation(A, visual_effect_icon, used_item, animation_type, used_intent)
 	setMovetype(movement_type & ~FLOATING) // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
 
-	
+

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -90,6 +90,9 @@
 	if(used_armor)
 		protection = used_armor.armor.getRating(d_type)
 	pen_total -= (protection * 2)
+
+	if(armor_pen == protection)
+		pen_total = 1	// If we match, we still get a little extra.
 	var/balance_bonus = 0
 	var/sharpness_bonus = 0
 	var/damfactor_bonus = 0


### PR DESCRIPTION
## About The Pull Request
- Damage to the body done from penetration now starts at 40%, up to 80%. Used to start at 10%.
- Swift weapons now scale either off of STR or SPD, whichever is higher for pen purposes
- Scaling from either SPD or STR is now capped at 14 for purposes of pen, though negative scaling has no cap.
- Overpenning (and penning in general) is now a bit more meaningful and comes with extra 10-20% damage, meaning stuff like spears and light-armor penetrative stab 2 intents are likely to start at 50% rather than 40%, even if the user doesn't have any favorable stats.
   - This carries over into the wounds and their bleedrates as well, though those were not changed directly
- Simplifies some of the calculations in the backend, mostly by removing overreliance on sharpness
- Bladed weapons at under 20% sharpness (chunked) can't pen anymore
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
it's all nubmers
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Penning should now be more oomphy no matter what weapon is being used
- Monostacked stats no longer as impactful, if anyone suffered some Hacks from 18 STR chads
- Anyone can use daggers now without it feeling too odd

Frankly all of this should've been baked into the pen requiem PR itself, this has just been a case of me cleaning up my own negligence from months ago. Combat tweaking will do terrible things to a man's soul.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Penetrative damage now scales more harshly when dealing direct body damage.
balance: Swift-balanced weapons now use either STR or SPD, whichever is higher for pen purposes.
balance: Stat-scaling for pen damage purposes is now capped at 14.
balance: Sharpness-based weapons that are under 20% sharpness ("chunked") can no longer penetrate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
