### PR TITLE
Update whip.dm - reduces MINSTR of bronze whip from 9 < 6

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -136,7 +136,7 @@
 	desc = "A heavy whip, corded from thick leather and adorned with a razor-sharp bronzehead. In ancient tymes, this shepherd's weapon once repelled the gnashing teeth of bloodthirsty nitebeasts: now, it seperates limb-from-trunk with thunderous claps. </br>Holding this whip imbues you with determination.. and a rather odd hankering for turkey dinners."
 	icon_state = "bronzewhip"
 	force = 21
-	minstr = 11
+	minstr = 6
 	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish)
 	smeltresult = /obj/item/ingot/bronze
 


### PR DESCRIPTION
## About The Pull Request

The minimum strength requirement for the bronze-tipped whip is now set to 6 _(like other first-generation whips.)_

## Testing Evidence

Yeah.

## Why It's Good For The Game

Bronze whips, while capable of dismemberment, are still essentially on par with regular whips. I originally cranked up the strength values because I was worried that they'd be overpowered - but, thankfully, my fears were unfounded.

## Changelog

:cl:
balance: Bronze-tipped whips now have a minimum strength value of 6, instead of 9.
/:cl: