### PR TITLE
[Econ Tweak] adjusts fortitude potions quantities in standing orders

### DIFF
--- a/code/modules/roguetown/roguestock/standing_order.dm
+++ b/code/modules/roguetown/roguestock/standing_order.dm
@@ -592,13 +592,11 @@ GLOBAL_LIST_EMPTY(standing_order_pool)
 	// overwrite the larger primary qty when the same id was picked twice.
 	var/list/medicinal_pool = list(
 		TRADE_GOOD_HEALTH_POTION,
-		TRADE_GOOD_STAM_POTION,
 		TRADE_GOOD_ANTIDOTE_POTION,
 	)
 	var/list/premium_pool = list(
 		TRADE_GOOD_STRONG_HEALTH_POTION,
 		TRADE_GOOD_STRONG_MANA_POTION,
-		TRADE_GOOD_STRONG_STAM_POTION,
 		TRADE_GOOD_STRONG_ANTIDOTE_POTION,
 		TRADE_GOOD_MANA_POTION,
 	)
@@ -624,7 +622,7 @@ GLOBAL_LIST_EMPTY(standing_order_pool)
 
 // ============================================================================
 // demand_alchemical_warband - elite buff-potion order for adventurers, the conclave,
-// and chosen retinues. Stat-buff potions plus a backbone of strong-* support potions.
+// and chosen retinues. Stat-buff potions and stamina potions plus a backbone of strong-* support potions.
 // ============================================================================
 /datum/standing_order/demand_alchemical_warband
 	roll_weight = 1
@@ -639,11 +637,12 @@ GLOBAL_LIST_EMPTY(standing_order_pool)
 		TRADE_GOOD_PERCEPTION_POTION,
 		TRADE_GOOD_INTELLIGENCE_POTION,
 		TRADE_GOOD_SPEED_POTION,
+		TRADE_GOOD_STAM_POTION,
+		TRADE_GOOD_STRONG_STAM_POTION,
 	)
 	var/list/support_pool = list(
 		TRADE_GOOD_STRONG_HEALTH_POTION,
 		TRADE_GOOD_STRONG_MANA_POTION,
-		TRADE_GOOD_STRONG_STAM_POTION,
 		TRADE_GOOD_STRONG_ANTIDOTE_POTION,
 	)
 


### PR DESCRIPTION
## About The Pull Request
Moves stamina and strong stamina (now fortitude and strong fortitude) from the general medicinal pool and into the stat buff potion pool.

No price/value changes were made.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Confirmed to spawn in appropriate standing orders only
<img width="791" height="195" alt="image" src="https://github.com/user-attachments/assets/6c77e3be-4c57-41d4-bae3-d9d9189ff76f" />
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The change from 90 dram production to 30 dram production means that to fill an order for these, you’d be spending 3x as long as any other potion in the category because you need to brew it once for every potion instead of once per 3 potions. So moving it to the category of other 30 dram per craft potions evens out the labor ask.

also I pitched it to Ansari and he said it’s aight
<img width="828" height="238" alt="IMG_8582" src="https://github.com/user-attachments/assets/8d664df9-7186-4cb4-9a0a-13538b12e792" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: moved stamina potions to the alchemical warband standing order pool and removed from medical pool due to 90->30 dram production change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
