### PR TITLE
[Bugfix] fixes needles not updating icons correctly

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -34,6 +34,8 @@
 	grid_width = 32
 	grid_height = 32
 	//dropshrink = 0.75
+	// we store the overlay to avoid needless icon updates.
+	var/mutable_appearance/thread_overlay
 
 /obj/item/needle/examine()
 	. = ..()
@@ -55,22 +57,17 @@
 
 /obj/item/needle/Initialize()
 	. = ..()
-	update_icon()
-
-/obj/item/needle/update_overlays()
-	. = ..()
-	if(stringamt <= 0)
-		return
-	. += "[icon_state]string"
-
+	thread_overlay = mutable_appearance(icon, "[icon_state]string")
+	if(stringamt > 0)
+		add_overlay(thread_overlay)
 
 /obj/item/needle/use(used)
 	if(infinite)
 		return TRUE
-	stringamt = stringamt - used
-	update_icon()
-//	if(stringamt <= 0)
-//		qdel(src)
+	var/old_amt = stringamt
+	stringamt = max(0, stringamt - used)
+	if(old_amt > 0 && stringamt <= 0)
+		cut_overlay(thread_overlay)
 
 /obj/item/needle/attack(mob/living/M, mob/user)
 	sew(M, user)
@@ -86,9 +83,11 @@
 	return 6 SECONDS - user.get_skill_level(/datum/skill/craft/sewing)
 
 /obj/item/needle/proc/rethread()
+	var/old_amt = stringamt
 	var/gained = min(FIBER_THREAD_USES, (maxstring - stringamt))
 	stringamt += gained
-	update_icon()
+	if(old_amt <= 0 && stringamt > 0)
+		add_overlay(thread_overlay)
 	return gained
 
 /obj/item/needle/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
## About The Pull Request
Fixes needle icons not updating to look emptied when emptied of thread.
Optimized needle code not to update overlays needlessly. (it was readding the overlay on each use and icon update?)

## Testing Evidence
<img width="1590" height="817" alt="image" src="https://github.com/user-attachments/assets/cc41f67c-f133-479f-b4e8-7f6f196b63c4" />

## Why It's Good For The Game
fix good

## Changelog
:cl:
fix: needles now update their icon immediately when emptied of thread.
/:cl:
