### PR TITLE
reduce integrity range of light armour

### DIFF
--- a/code/__DEFINES/armor_defines.dm
+++ b/code/__DEFINES/armor_defines.dm
@@ -72,8 +72,8 @@
 #define ARMOR_INT_HELMET_BRONZE 350 //More integrity, less protection.
 #define ARMOR_INT_HELMET_STEEL 300
 #define ARMOR_INT_HELMET_IRON 225
-#define ARMOR_INT_HELMET_HARDLEATHER 250
-#define ARMOR_INT_HELMET_LEATHER 200
+#define ARMOR_INT_HELMET_HARDLEATHER 200
+#define ARMOR_INT_HELMET_LEATHER 150
 #define ARMOR_INT_HELMET_CLOTH 100
 
 // Chest / Armor Pieces
@@ -87,7 +87,7 @@
 #define ARMOR_INT_CHEST_PLATE_PSYDON 400 // You get free training, less int
 #define ARMOR_INT_CHEST_PLATE_IRON 375
 #define ARMOR_INT_CHEST_PLATE_BRIGANDINE 350
-#define ARMOR_INT_CHEST_PLATE_BRIGANDINE_WEIGHT_MODIFIER 50 //Light AC brigandine parts get -50, Heavy AC brigandine parts get +50.
+#define ARMOR_INT_CHEST_PLATE_BRIGANDINE_WEIGHT_MODIFIER 100
 #define ARMOR_INT_CHEST_PLATE_IRONLIGHT 325
 #define ARMOR_INT_CHEST_PLATE_DECREPIT 250
 #define ARMOR_INT_CHEST_PLATE_DECREPITLIGHT 200
@@ -100,11 +100,12 @@
 #define ARMOR_INT_CHEST_MEDIUM_DECREPIT 150
 
 // LIGHT
-#define ARMOR_INT_CHEST_LIGHT_MASTER 300 // High tier cloth / leather armor
-#define ARMOR_INT_CHEST_LIGHT_MEDIUM 250 // Medium tier cloth / leather armor
-#define ARMOR_INT_CHEST_LIGHT_BASE 200
-#define ARMOR_INT_CHEST_LIGHT_STEEL 180
-#define ARMOR_INT_CHEST_LIGHT_IRON 180
+#define ARMOR_INT_CHEST_LIGHT_ELITE 300 // Snowflake top-tier light armor
+#define ARMOR_INT_CHEST_LIGHT_MASTER 240 // High tier cloth / leather armor
+#define ARMOR_INT_CHEST_LIGHT_MEDIUM 200 // Medium tier cloth / leather armor
+#define ARMOR_INT_CHEST_LIGHT_BASE 160
+#define ARMOR_INT_CHEST_LIGHT_STEEL 150
+#define ARMOR_INT_CHEST_LIGHT_IRON 150
 #define ARMOR_INT_CHEST_CIVILIAN 100
 
 // LEG PIECES - Leg Armor
@@ -118,8 +119,8 @@
 #define ARMOR_INT_LEG_BRIGANDINE 250
 #define ARMOR_INT_LEG_IRON_CHAIN 225
 #define ARMOR_INT_LEG_DECREPIT_CHAIN 150
-#define ARMOR_INT_LEG_HARDLEATHER 250
-#define ARMOR_INT_LEG_LEATHER 200
+#define ARMOR_INT_LEG_HARDLEATHER 200
+#define ARMOR_INT_LEG_LEATHER 150
 #define ARMOR_INT_LEG_CLOTH 10
 
 // SIDE PIECES - Non-Chest armor
@@ -128,8 +129,8 @@
 #define ARMOR_INT_SIDE_BRONZE 250 // Integrity for bronze pieces
 #define ARMOR_INT_SIDE_STEEL 300 // Integrity for steel pieces
 #define ARMOR_INT_SIDE_IRON 225 // Integrity for iron pieces
-#define ARMOR_INT_SIDE_HARDLEATHER 250 // Integrity for hardened leather pieces
-#define ARMOR_INT_SIDE_LEATHER 200 // Integrity for leather / copper pieces
+#define ARMOR_INT_SIDE_HARDLEATHER 200
+#define ARMOR_INT_SIDE_LEATHER 150 // Integrity for leather / copper pieces
 #define ARMOR_INT_SIDE_DECREPIT 150 // Integrity for decrepit pieces
 #define ARMOR_INT_SIDE_CLOTH 100 // Integrity for cloth / aesthetic oriented pieces
 #define ARMOR_INT_SIDE_GOLDPLUS 10 // Integrity for royal variants of golden / cermemonial pieces

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -198,6 +198,7 @@
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/werewolf_skin
 	slot_flags = null
+	blocking_behavior = null
 	name = "verewolf's skin"
 	desc = "an impenetrable hide of dendor's fury"
 	icon_state = null

--- a/code/modules/clothing/rogueclothes/armor/gronn.dm
+++ b/code/modules/clothing/rogueclothes/armor/gronn.dm
@@ -35,7 +35,7 @@
 	max_integrity = ARMOR_INT_LEG_HARDLEATHER
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
-	
+
 /obj/item/clothing/gloves/roguetown/angle/gronn
 	name = "gronnic fur-lined leather gloves"
 	desc = "Thick, padded gloves made for the harshest of climates and the wildest of beasts encountered in the untamed north."
@@ -55,7 +55,7 @@
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
 	unarmed_bonus = 6
-	max_integrity = 250
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
 	color = "#ffffff"
 
 /obj/item/clothing/head/roguetown/helmet/leather/shaman_hood
@@ -159,7 +159,7 @@
 			update_icon()
 		qdel(I)
 	. = ..()
-	
+
 
 /obj/item/clothing/head/roguetown/helmet/leather/shaman_hood/AdjustClothes(mob/user)
 	if(loc == user)

--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -17,6 +17,7 @@
 	blocksound = SOFTUNDERHIT
 	armor = ARMOR_PADDED
 	unenchantable = TRUE
+	blocking_behavior = BLOCKSHIRT | BLOCKARMOR // Skins block layering real armor (armor_class > NONE); plain shirts still layer. Arbalist/berserker override below.
 
 	var/repairmsg_end = "My skin has become taut with newfound vigor!"
 	var/repairmsg_continue = "My armour mends some of its abuse.."
@@ -122,14 +123,14 @@
 	name = "bouhoi bujeog tattoos"
 	desc = "A mystic style of tattoos adopted by the Ruma Clan, emulating a practice performed by warrior monks of the Xinyi Dynasty. They are your way of identifying fellow clan members, a sign of companionship and secretive brotherhood. These are styled into the shape of clouds, created by a mystical ink which shifts and moves in ripples like a pond to harden where your skin is struck. Its movement causes you to shudder, and meditation restores its strength."
 	armor = ARMOR_PLATE //Great defence, while it lasts.
-	max_integrity = ARMOR_INT_CHEST_PLATE_BRIGANDINE //1.17x integrity (350) vs baseline skin armor (300).
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //Our value: 200 (was PLATE_BRIGANDINE 350).
 	//Perk of being a mercenary kinda-powerclass, and dealing with the Honorbound restrictions (no metal armor, no gambesons).
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/mistwalker
 	name = "seon-mul tattoos"
 	desc = "The flowing clouds of the Ruma are but fleeting shadow across the plains, pale imitation of Xinyi's spiritual alchemy. Imperfect, impotent. Their legend is one writ in avarice and hate.</br></br>Recount yours in love."
 	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER + 150 //1.5x integrity (450) vs baseline leather skin armor (300).
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //Our value: 300 (was LIGHT_MASTER+150).
 	//Perk of being a wretch powerclass, and dealing with the Honorbound restrictions (no metal armor, no gambesons).
 
 
@@ -222,8 +223,9 @@
 /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/confessor
 	name = "arbalist's skin"
 	desc = "Taut lyke the bow I draw."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //0.8x integrity (200) vs baseline padded skin armor (250).
+	max_integrity = ARMOR_INT_CHEST_CIVILIAN //Our value: 100 (was LIGHT_BASE).
 	//Tax for being shirt slot.
+	blocking_behavior = null // Exception: may be layered under real armor (the confessor wears it with a cuirass).
 
 /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/disciple
 	name = "enduring skin"
@@ -233,7 +235,7 @@
 	</br>To give into despair and hopelessness, however, is to rob all meaning from His sacrifice. \
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER + 100 //1.6x integrity (400) vs baseline padded skin armor (250).
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //Our value: 300 (was LIGHT_MASTER+100).
 	//Perk of being a psy-templar powerclass.
 
 
@@ -305,7 +307,7 @@
 /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk
 	name = "tough skin"
 	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //0.8x integrity (200) vs baseline padded skin armor (250).
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //Our value: 200 (was LIGHT_BASE).
 	//Tax for being an advent with utility miracles.
 
 /*
@@ -381,7 +383,7 @@
 /obj/item/clothing/suit/roguetown/armor/manual/resting/padded/bailiff
 	name = "scar-marred skin"
 	desc = "Bearing scars of countless whips leaves a gnarly visage. Now it's your time to inflict the same fate upon others."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //1.2x integrity (300) vs baseline padded skin armor (250).
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //Our value: 200 (was LIGHT_MASTER).
 	//Perk of being a MAA kinda-powerclass. Basically just a heavy gambeson.
 
 //LEATHER
@@ -398,9 +400,9 @@
 /obj/item/clothing/suit/roguetown/armor/manual/resting/leather/berzerker
 	name = "unstoppable skin"
 	desc = "I've endured enough. The onslaught has lost its meaning."
-	blocking_behavior = SAMEWEAR
+	blocking_behavior = BLOCKSHIRT | BLOCKARMOR | SAMEWEAR // Unlayerable with outside armor, but pairs with the unstoppable chest.
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER + 150 //1.5x integrity (450) vs baseline leather skin armor (300).
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //Our value: 300 (was LIGHT_MASTER+150).
 	//Perk of being a wretch powerclass.
 
 //MAILLE
@@ -408,7 +410,7 @@
 	name = "resting skin armor"
 	desc = "This should not spawn naturally. If you see this ingame, something went wrong."
 	armor = ARMOR_MAILLE
-	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON
+	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //Our value: 160 (was LIGHT_IRON 150).
 
 /obj/item/clothing/suit/roguetown/armor/manual/resting/maille/berzerkerchest
 	name = "unstoppable chest"
@@ -417,6 +419,6 @@
 	armor = ARMOR_MAILLE
 	resistance_flags = FLAMMABLE
 	blocksound = SOFTHIT
-	blocking_behavior = SAMEWEAR
+	blocking_behavior = BLOCKSHIRT | BLOCKARMOR | SAMEWEAR // Unlayerable with outside armor, but pairs with the unstoppable skin.
 	body_parts_covered = COVERAGE_VEST
 	body_parts_inherent = COVERAGE_VEST

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -162,6 +162,7 @@
 	icon_state = "artificerplate"
 	item_state = "artificerplate"
 	armor_class = ARMOR_CLASS_LIGHT // Artificer made gilbronze.
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE
 	var/powered = FALSE
 	var/mode = 1
 	var/active_item = FALSE //Prevents issues like dragon ring giving negative str instead
@@ -986,7 +987,7 @@
 	icon_state = "inqcoat"
 	item_state = "inqcoat"
 	sleevetype = "shirt"
-	max_integrity = 300
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE
 	anvilrepair = /datum/skill/craft/armorsmithing
 	equip_delay_self = 4 SECONDS
 	armor_class = ARMOR_CLASS_LIGHT

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -148,7 +148,7 @@
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/proc/setup_auto_repair()
 	repair_time = (max_integrity / auto_repair_mode_base) * auto_repair_mode_time
-	
+
 	// Ensure relative mode is on to respect the new calculated repair_time
 	relative_repair_mode = TRUE
 	auto_repair_mode_triggered = TRUE
@@ -170,6 +170,7 @@
 	armor_class = ARMOR_CLASS_LIGHT
 	blocksound = SOFTUNDERHIT
 	armor = ARMOR_PADDED
+	blocking_behavior = BLOCKSHIRT | BLOCKARMOR
 
 	repairmsg_begin = "My skin begins to slowly mend its abuse.."
 	repairmsg_continue = "My skin mends some of its abuse.."
@@ -188,7 +189,7 @@
 
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple
-	name = "enduring skin" //Unused now, just here for inheritance (primarily the tithebound).
+	name = "enduring skin" //Now only a parent for the Lirvan tithebound; the jobs use the manual sewable version.
 	desc = "It's far more than just an oath. \
 	</br>Aeon, Psydon, Adonai. Entropy, Humenity, Divinity; a trinity known to all, yet forgotten to tyme. \
 	</br>A corpse. I am living on a fucking corpse. He is the world, and the world is rotting away. \
@@ -196,7 +197,7 @@
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
 	armor = ARMOR_PADDED
-	max_integrity = 400
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE
 	repair_time = 20 SECONDS
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/iconoclast
@@ -208,7 +209,7 @@
 	Oh no, not me, I never lost control.</br> \
 	You're face to face, with the man who sold the world."
 	armor = ARMOR_DRAGONSKIN
-	max_integrity = 450
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE
 	repair_time = 20 SECONDS
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats
@@ -223,7 +224,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
 	//allowed_race = NON_DWARVEN_RACE_TYPES
-	max_integrity = 350
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
 
 	repairmsg_begin = "The tattoos begin to slowly mend their abuse..."
 	repairmsg_continue = "The tattoos mend some of their abuse..."
@@ -237,5 +238,4 @@
 	name = "seon-mul tattoos"
 	desc = "The flowing clouds of the Ruma are but fleeting shadow across the plains, pale imitation of Xinyi's spiritual alchemy. Imperfect, impotent. Their legend is one writ in avarice and hate.</br></br>Recount yours in love."
 	armor = ARMOR_LEATHER
-	max_integrity = 450
-
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE

--- a/code/modules/clothing/rogueclothes/gloves/angle.dm
+++ b/code/modules/clothing/rogueclothes/gloves/angle.dm
@@ -47,7 +47,7 @@
 	desc = "A pair of hardened leather gloves used by fencers who aren't exactly convinced of losing a finger to a particularly strong feder cut. The inside is padded for extra durability."
 	icon_state = "freigloves"
 	item_state = "freigloves"
-	max_integrity = ARMOR_INT_SIDE_HARDLEATHER + 50
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
 	color = null
 
 /obj/item/clothing/gloves/roguetown/angle/freifechter/loadout

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -216,7 +216,7 @@
 	blocksound = SOFTHIT
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
-	max_integrity = 200
+	max_integrity = 150
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
 	flags_inv = HIDEFACE|HIDESNOUT|HIDEHAIR|HIDEEARS
 	body_parts_covered = FACE|HEAD
@@ -821,7 +821,7 @@
 	blocksound = SOFTHIT
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
-	max_integrity = 200
+	max_integrity = 150
 	armor = ARMOR_PADDED
 	adjustable = CAN_CADJUST
 	sewrepair = TRUE
@@ -838,7 +838,7 @@
 	blocksound = SOFTHIT
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
-	max_integrity = 250 //slightly more durable than the padded mask
+	max_integrity = 180
 	armor = ARMOR_LEATHER
 	adjustable = CAN_CADJUST
 	sewrepair = TRUE

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/lirvan.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/lirvan.dm
@@ -125,6 +125,7 @@ third; SUNSET, little neat ability. it may be buggy. don't quote me on that. it 
 	repair_time = 30 SECONDS
 	armor = ARMOR_PLATE
 	body_parts_covered = COVERAGE_ALL_BUT_HANDFEET | HANDS | FEET | COVERAGE_HEAD //all but eyes/nose, seems fair.
+	blocking_behavior = null
 
 
 #define LIRVAN_BLING_FILTER "lirvan_titheaura"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -704,6 +704,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				if(istype(H.cloak, I.type))
 					return FALSE
 			if(H.wear_shirt)
+				var/obj/item/clothing/incoming_armor = I
+				if((H.wear_shirt.blocking_behavior & BLOCKARMOR) && istype(incoming_armor) && (incoming_armor.armor_class != ARMOR_CLASS_NONE) && !((I.blocking_behavior & SAMEWEAR) && (H.wear_shirt.blocking_behavior & SAMEWEAR)))
+					return FALSE
+				if((I.blocking_behavior & BLOCKSHIRT) && (H.wear_shirt.armor_class != ARMOR_CLASS_NONE) && !((I.blocking_behavior & SAMEWEAR) && (H.wear_shirt.blocking_behavior & SAMEWEAR)))
+					return FALSE
 				if(H.wear_shirt.blocking_behavior & BULKYBLOCKS)
 					return FALSE
 				if(istype(H.wear_shirt, I.type))
@@ -796,6 +801,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				if(H.wear_armor)
 					return FALSE
 			if(H.wear_armor)
+				var/obj/item/clothing/incoming_shirt = I
+				if((H.wear_armor.blocking_behavior & BLOCKSHIRT) && istype(incoming_shirt) && (incoming_shirt.armor_class != ARMOR_CLASS_NONE) && !((I.blocking_behavior & SAMEWEAR) && (H.wear_armor.blocking_behavior & SAMEWEAR)))
+					return FALSE
+				if((I.blocking_behavior & BLOCKARMOR) && (H.wear_armor.armor_class != ARMOR_CLASS_NONE) && !((I.blocking_behavior & SAMEWEAR) && (H.wear_armor.blocking_behavior & SAMEWEAR)))
+					return FALSE
 				if(istype(H.wear_armor, I.type))
 					if(!(I.blocking_behavior & SAMEWEAR))
 						return FALSE


### PR DESCRIPTION
## About The Pull Request

as it says on the tin. light body armour range is now 150-240 integ. helmet is 100-200. any side armament is 100-200, and chausses are unchanged.

## Testing Evidence

just numbers. in game balance testing.

## Why It's Good For The Game

light armour being categorically equivalent or higher integrity lends to part of the issue of light armour feeling very overclassed. penning them isn't a factor since lbrig/leather/skin tend to have 2-3 pip of cut/slash, stab/piercing, blunt (at 4!) resistance. and even through penetration does it feel weak (though there's a new PR to address that).

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Reduce integrity range of light armour.
balance: most skin armour is now manual instead of regenerating.
balance: most skin armour is mutually exclusive to other armour in shirt/armour slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
