### PR TITLE
[Werewolf] Werewolf armorjak & repulse howl spell fixes

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -210,6 +210,7 @@
 #define BELOW_HEAD	(CHEST | GROIN | VITALS | ARMS | HANDS | LEGS | FEET)
 #define BELOW_CHEST	(GROIN | VITALS | LEGS | FEET) //for water
 #define FULL_BODY	(FULL_HEAD | NECK | BELOW_HEAD)
+#define FULL_BODY_NO_CHEST	(GROIN | VITALS | LEGS | FEET | ARMS | HANDS | FULL_HEAD | NECK)
 
 //defines for the index of hands
 #define LEFT_HANDS 1

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -15,11 +15,11 @@
 	var/list/inherent_traits = list(
 		TRAIT_IGNORESLOWDOWN,
 		TRAIT_IGNOREDAMAGESLOWDOWN,
-		TRAIT_NOPAIN, 
-		TRAIT_NOPAINSTUN, 
-		TRAIT_CRITICAL_RESISTANCE, 
-		TRAIT_NOFALLDAMAGE1, 
-		TRAIT_KNEESTINGER_IMMUNITY, 
+		TRAIT_NOPAIN,
+		TRAIT_NOPAINSTUN,
+		TRAIT_CRITICAL_RESISTANCE,
+		TRAIT_NOFALLDAMAGE1,
+		TRAIT_KNEESTINGER_IMMUNITY,
 		TRAIT_SHOCKIMMUNE,
 		TRAIT_SILVER_WEAK,
 		TRAIT_STRENGTH_UNCAPPED,
@@ -94,7 +94,7 @@
 	owner.special_role = name
 	if(increase_votepwr)
 		forge_werewolf_objectives()
-	
+
 	wolfname = "[pick(GLOB.wolf_prefixes)] [pick(GLOB.wolf_suffixes)]"
 	return ..()
 
@@ -128,7 +128,7 @@
 	return ..()
 
 /datum/antagonist/werewolf/lesser/greet()
-	// DO NOT call parent. 
+	// DO NOT call parent.
 	// lesser verevolfs should always be created by alpha bites, which have their own way of informing the user
 	// they are a werewolf. despite this, i still want to provide a new audio cue in the form of [THE CRY].
 	// remove it if it's obstructive. thx.
@@ -200,16 +200,24 @@
 	name = "verewolf's skin"
 	desc = "an impenetrable hide of dendor's fury"
 	icon_state = null
-	body_parts_covered = FULL_BODY
-	body_parts_inherent = FULL_BODY
+	body_parts_covered = CHEST
+	body_parts_inherent = CHEST
 	armor = ARMOR_WWOLF
 	blocksound = SOFTHIT
 	blade_dulling = DULLING_BASHCHOP
 	sewrepair = FALSE
-	max_integrity = 550
+	max_integrity = 750
 	item_flags = DROPDEL
-	repair_time = 15 SECONDS
+	repair_time = 20 SECONDS
 	interrupt_damount = 35
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/werewolf_skin/extremities
+	max_integrity = 550
+	slot_flags = ITEM_SLOT_ARMOR
+	repair_time = 20 SECONDS
+	body_parts_covered = FULL_BODY_NO_CHEST
+	body_parts_inherent = FULL_BODY_NO_CHEST
+	name = "verewolf's thin skin"
 
 /datum/intent/simple/werewolf
 	name = "claw"

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
@@ -99,7 +99,7 @@
 				log_runtime(msg)
 			user.temporarilyRemoveItemFromInventory(I = current_item, force = TRUE)
 			qdel(current_item)
-		extended_claw_record[hand_index] = FALSE		
+		extended_claw_record[hand_index] = FALSE
 	return TRUE
 
 /obj/effect/proc_holder/spell/self/claws/proc/clear_claw_entry(datum/source)
@@ -113,10 +113,11 @@
 	name = "Terrifying Howl"
 	desc = "Let loose a howl of dread, repelling anyone around you."
 	button_icon_state = "howl"
-	cooldown_time = 6 MINUTES
+	cooldown_time = 2 MINUTES
 	charge_required = FALSE
 	showsparkles = FALSE
 	invocations = null
 	invocation_type = INVOCATION_NONE
+	spell_flags = SPELL_IGNORE_SPELLBLOCK
 	sound = 'sound/vo/mobs/wwolf/roar.ogg'
 	spell_requirements = NONE

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -188,7 +188,7 @@
 	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/howl)
 	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/claws)
 	W.RemoveSpell(new /obj/effect/proc_holder/spell/targeted/woundlick)
-	W.RemoveSpell(new /datum/action/cooldown/spell/repulse/werewolf)
+	W.mind.RemoveSpell(new /datum/action/cooldown/spell/repulse/werewolf)
 	W.regenerate_icons()
 
 	to_chat(W, span_userdanger("I return to my facade."))

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -27,7 +27,7 @@
 			transformed = TRUE // Mark as transformed
 
 		else if (world.time >= transforming + 25 SECONDS) // Stage 2
-			
+
 			if(H.show_redflash())
 				H.flash_fullscreen("redflash3")
 			H.emote("agony", forced = TRUE)
@@ -103,6 +103,8 @@
 							'sound/music/cmode/antag/combat_dying_world_instrumental.ogg' = 3) // 1/4 is good odds for 1/round tho
 	W.cmode_music = pickweight(dying_world)
 	W.skin_armor = new /obj/item/clothing/suit/roguetown/armor/regenerating/skin/werewolf_skin(W)
+	// Equip without checking if we can equip, since it is forced.
+	W.wear_armor = new /obj/item/clothing/suit/roguetown/armor/regenerating/skin/werewolf_skin/extremities(W)
 	playsound(W.loc, pick('sound/combat/gib (1).ogg','sound/combat/gib (2).ogg'), 200, FALSE, 3)
 	W.spawn_gibs(FALSE)
 	src.forceMove(W)
@@ -127,7 +129,7 @@
 	ADD_TRAIT(src, TRAIT_NOBREATH, TRAIT_SOURCE_WEREWOLF)
 	ADD_TRAIT(src, TRAIT_DEATHLESS, TRAIT_SOURCE_WEREWOLF)
 	ADD_TRAIT(src, TRAIT_NOPAIN, TRAIT_SOURCE_WEREWOLF)
-	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_SOURCE_WEREWOLF)	
+	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_SOURCE_WEREWOLF)
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_SOURCE_WEREWOLF)
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_SOURCE_WEREWOLF)
 	ADD_TRAIT(src, TRAIT_PACIFISM, TRAIT_SOURCE_WEREWOLF)
@@ -146,7 +148,7 @@
 	W.AddSpell(new /obj/effect/proc_holder/spell/self/howl)
 	W.AddSpell(new /obj/effect/proc_holder/spell/self/claws)
 	W.AddSpell(new /obj/effect/proc_holder/spell/targeted/woundlick)
-	W.AddSpell(new /datum/action/cooldown/spell/repulse/werewolf)
+	W.mind.AddSpell(new /datum/action/cooldown/spell/repulse/werewolf)
 	invisibility = oldinv
 
 /mob/living/carbon/human/proc/werewolf_untransform(dead,gibbed)


### PR DESCRIPTION
## About The Pull Request
Requested by Witty.
- Splits WW armor into two layers.
- Thick skin (750 int, up from 550. Covers JUST the chest)
- Thin skin (550 int, covers every other area but chest)
- Makes sure terrifying howl (repulse howl) is given to WW's again, and made castable.
- Repulse howl cd buffed from 6 mins down to 2 mins, which was the original duration when it was added.
- WW armor repair time reduced from 15 seconds to 20 seconds to compensate for the higher int.

## Testing Evidence
<img width="873" height="772" alt="image" src="https://github.com/user-attachments/assets/1a77180e-0254-43f7-8087-0f002c5da9da" />

## Why It's Good For The Game
Requested by witty.

Werewolves are in a pretty sorry spot. This should make it harder to quickly dispatch them with bleeds by targeting chest and then targeting every limbs once, and re-enables the anti dorpel repel howl they used to have, but got lost in the spell/action update.

## Changelog

:cl:
balance: Werewolf skin split into two layers, one covering just chest, the other covering the rest except chest.
fix: Terrifying howl (repel howl) re-enabled for werewolf.
balance: Werewolf terrifying howl cooldown reduced from 6 minutes to the original 2 minutes.
balance: Core werewolf armor integrity increased from 550 to 750.
balance: Werewolf armor repair time increased from 15 to 20 seconds.
/:cl:
