### PR TITLE
Halberds for heavy knight and mounted knight

### DIFF
--- a/code/modules/jobs/job_types/roguetown/retinue/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/knight.dm
@@ -132,6 +132,9 @@
 			if("Partizan")
 				r_hand = /obj/item/rogueweapon/spear/partizan
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Halberd")
+				r_hand = /obj/item/rogueweapon/halberd
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
 
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	pants = /obj/item/clothing/under/roguetown/chainlegs
@@ -327,7 +330,8 @@
 			"Billhook + Recurve Bow",
 			"Grand Mace + Longbow",
 			"Sabre + Recurve Bow",
-			"Lance + Kite Shield"
+			"Lance + Kite Shield",
+			"Halberd + Recurve Bow"
 		)
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
@@ -342,6 +346,11 @@
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				beltr = /obj/item/quiver/arrows
 				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			if("Halberd + Crossbow")
+				r_hand = /obj/item/rogueweapon/halberd
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				beltr = /obj/item/quiver/bolt/standard
+				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 			if("Grand Mace + Longbow")
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 				beltr = /obj/item/quiver/arrows

--- a/code/modules/jobs/job_types/roguetown/retinue/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/knight.dm
@@ -106,7 +106,7 @@
 
 	H.adjust_blindness(-3)
 	if(H.mind)
-		var/weapons = list("Claymore","Great Mace","Battle Axe","Poleaxe","Estoc","Stecher","Lucerne", "Partizan")
+		var/weapons = list("Claymore","Great Mace","Battle Axe","Poleaxe","Estoc","Halberd","Stecher","Lucerne", "Partizan")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
 		switch(weapon_choice)
@@ -331,7 +331,7 @@
 			"Grand Mace + Longbow",
 			"Sabre + Recurve Bow",
 			"Lance + Kite Shield",
-			"Halberd + Recurve Bow"
+			"Halberd + Crossbow"
 		)
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)

--- a/code/modules/jobs/job_types/roguetown/retinue/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/knight.dm
@@ -348,9 +348,9 @@
 				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			if("Halberd + Crossbow")
 				r_hand = /obj/item/rogueweapon/halberd
+				l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				beltr = /obj/item/quiver/bolt/standard
-				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 			if("Grand Mace + Longbow")
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 				beltr = /obj/item/quiver/arrows


### PR DESCRIPTION
## About The Pull Request

Gives Halberd option for Heavy Knight, and Halberd + Crossbow option for Mounted Knight


## Testing Evidence

I tested it in localhost, it worked. It's very much a linechange and not a very "priority" PR

## Why It's Good For The Game

I think more variety is good for Knights, I don't think Halberd is a "op" weapon (correct me if anything) or rare at all. 

## Changelog

:cl:
balance: adds halberd option for heavy knight and mounted knight
/:cl:
