### PR TITLE
stakes no longer qdel heads when destroyed

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1572,7 +1572,7 @@
 /obj/structure/fluff/headstake/Destroy()
 	victim?.forceMove(drop_location())
 	victim = null
-	return ..
+	return
 
 /obj/structure/bars/passage/shutter/bookcase
 	name = "Empty Bookcase"

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1532,7 +1532,6 @@
 	var/obj/item/grown/log/tree/stake/stake
 	var/obj/item/bodypart/head/victim
 
-
 /obj/structure/fluff/headstake/CheckParts(list/parts_list)
 	..()
 	victim = locate(/obj/item/bodypart/head) in parts_list

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1330,54 +1330,54 @@
 					var/mob/living/carbon/human/thebride
 					for(var/mob/M in viewers(src, 7))
 						// You cannot marry an animal, a corpse, a brainless mob, or someone who is already married.
-						if(!ishuman(M)) 
+						if(!ishuman(M))
 							continue
 						var/mob/living/carbon/human/C = M
 
 						if(C.stat == DEAD || !C.client || C.marriedto)
 							continue
-						
+
 						if(C.real_name == A.bitten_names[1])
 							thegroom = C
 						if(C.real_name == A.bitten_names[2])
 							thebride = C
-					
+
 					if(!thegroom || !thebride)
 						to_chat(user, span_warn("nonexistent"))
 						return
-					
+
 					// Astounding update: marriage now requires consent (it didn't before)
 					var/groom_confirm = input(thegroom, "Do you want to marry [thebride]?") as null|anything in list("Yes", "No")
 					if(groom_confirm != "Yes")
 						to_chat(user, span_warning("The groom has declined the marriage!"))
 						return ..()
-					
+
 					var/bride_confirm = input(thebride, "Do you want to marry [thegroom]?") as null|anything in list("Yes", "No")
 					if(bride_confirm != "Yes")
 						to_chat(user, span_warning("The bride has declined the marriage!"))
 						return ..()
-					
+
 					// Horrible terrible last name necromancy (sometimes works)
 					var/groom_index = findtext(thegroom.real_name, " ")
 					var/bride_index = findtext(thebride.real_name, " ")
 					var/bride_firstname = bride_index ? copytext(thebride.real_name, 1, bride_index) : thebride.real_name
-					
+
 					// Get groom's surname
 					var/groom_surname = copytext(thegroom.real_name, groom_index + 1)
 					if(!groom_index)
 						groom_surname = null
 					else if(findtext(thegroom.real_name, " of ") || findtext(thegroom.real_name, " the "))
 						groom_surname = null
-					
+
 					var/final_bride_name
 					// Ask bride if she wants to take the groom's surname
 					if(groom_surname != null)
 						var/bride_surname_choice = input(thebride, "Do you want to take [thegroom]'s surname? (Your new name will be [bride_firstname] [groom_surname])") as null|anything in list("Yes", "No")
 						final_bride_name = (bride_surname_choice == "Yes") ? (bride_firstname + " " + groom_surname) : thebride.real_name
-					
+
 					// Apply the changes
 					thebride.change_name(final_bride_name)
-			
+
 					thegroom.marriedto = thebride.real_name
 					thebride.marriedto = thegroom.real_name
 
@@ -1570,6 +1570,11 @@
 	stake = null
 	qdel(src)
 
+/obj/structure/fluff/headstake/Destroy()
+	victim?.forceMove(drop_location())
+	victim = null
+	return ..
+
 /obj/structure/bars/passage/shutter/bookcase
 	name = "Empty Bookcase"
 	desc = "Refuge for few, an irrelevance to most."
@@ -1588,7 +1593,7 @@
 		set_opacity(TRUE)
 
 // This is from the Druid Grove remap ages back. Turning it into a proper subtype for faster init. or whatever reason ur supposed
-// to do it. 
+// to do it.
 /obj/effect/wisp/prestidigitation/willowwisp
 	name = "Will-o'-the-wisp"
 	desc = "A small, fiery ball of light made up of mystical energy."

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1569,10 +1569,12 @@
 	stake = null
 	qdel(src)
 
-/obj/structure/fluff/headstake/Destroy()
-	victim?.forceMove(drop_location())
+/obj/structure/fluff/headstake/deconstruct()
+	victim.forceMove(drop_location())
 	victim = null
-	return
+	stake.forceMove(drop_location())
+	stake = null
+	qdel(src)
 
 /obj/structure/bars/passage/shutter/bookcase
 	name = "Empty Bookcase"


### PR DESCRIPTION
## About The Pull Request

stakes should no longer qdel heads when destroyed

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

head dropped

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

see title
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: stakes no longer qdel heads when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
