### PR TITLE
IS THIS TRVE?! - my dumbass put the amulet on the ID slot overriden by a ring

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/Iconoclast.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/Iconoclast.dm
@@ -37,7 +37,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
-	id = /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios //IS THIS TRVE? WE NEED TO USE MIRACLES SIRE.
+	neck = /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios //IS THIS TRVE? WE NEED TO USE MIRACLES SIRE.
 	backpack_contents = list(
 					/obj/item/needle/thorn = 1,
 					/obj/item/natural/cloth = 1,


### PR DESCRIPTION
## About The Pull Request

Icono amulet spawns on neck

***'Look upon myne works, thee mighty and despair'***
*I accidentally forgot to account for the ring first time "fixing" this.*

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

id -> neck

that's the change, I woe if this breaks because nothing adds anything to your neck on-spawn. you gotta buy neck armor.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

the miracle class should be able to miracle probably

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: moves icono amulet to neck cause the ring replaces it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
