### PR TITLE
Gives Daybreak A Fantastically Larptastic Blunt Intent + Touches up on the Blunt Whip description to fix it's improper inheritance.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -73,14 +73,21 @@
 
 //Bludgeon = Sidegrade of the Crack that functions like a ranged mace. Unique to the Nagaika, or the Steppsman's whip.
 /datum/intent/whip/crack/blunt
-	name = "bludgeon"
-	blade_class = BCLASS_BLUNT
-	penfactor = PEN_NONE
-	recovery = 6
-	reach = 2			//Less range than a normal whip by 1 compared to crack.
-	icon_state = "instrike"
-	item_d_type = "blunt"
-	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
+    name = "bludgeon"
+    desc = "Wind up and deliver a powerful strike with the reinforced tip of your whip, shortening your reach but increasing the power. </br>Strikes deliver powerful blunt damage, lacking any cutting power but increasing damage against integrity."
+    blade_class = BCLASS_BLUNT
+    penfactor = PEN_NONE
+    recovery = 6
+    reach = 2            //Less range than a normal whip by 1 compared to crack.
+    icon_state = "instrike"
+    item_d_type = "blunt"
+    intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
+/datum/intent/flail/smash/ranged/psywhip
+    name = "Meteor Strike"
+    desc = "Swing the weight of your whip around your body, using the angular momentum to deliver a devastating strike, propelling your enemy back and savaging them at the same time."
+    chargedrain = 0 //The charge time is indicative of a warmup, not a hold.
+    chargedloop = /datum/looping_sound/flailswing
+    keep_looping = FALSE
 
 //Punish = Non-lethal sorta damage.
 /datum/intent/whip/punish
@@ -156,7 +163,7 @@
 	icon_state = "psywhip"
 	is_silver = TRUE
 	force = 25
-	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish)
+	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish, /datum/intent/flail/smash/ranged/psywhip)
 	minstr = 11
 	wdefense = 0
 	anvilrepair = /datum/skill/craft/weaponsmithing


### PR DESCRIPTION
## About The Pull Request

As the title says, this gives the Inquisitor's 1 of 1 whip a blunt intent to match the description and sprite, as well as provides some more options for mainlining the weapon - and touches up on the description for blunt whip strikes used on other weapons, since they were previously (incorrectly!) inheriting the description from Crack. 

## Testing Evidence
<img width="1829" height="782" alt="image" src="https://github.com/user-attachments/assets/91798323-75b2-4e31-b2d3-2ec016a63100" />

<img width="1894" height="848" alt="image" src="https://github.com/user-attachments/assets/e1bc7cc1-dd4b-4fe8-9312-2c3f15756896" />

<img width="468" height="200" alt="image" src="https://github.com/user-attachments/assets/1a8d498a-523f-453f-96c6-68ba4b988a5c" />


## Why It's Good For The Game

This isn't some scathing massive balance change because I think Daybreak needs it, I'm literally just doing it because by all means flavor wise it SHOULD have a blunt intent and it's really not even that strong. Something Something, Trevor Belmont. Otherwise, the blunt description fix for other whips is cool!

## Changelog

:cl:
balance: blunt intent added to daybreak
fix: whip blunt strike description
/:cl:
