### PR TITLE
Yea - re-tunes decomposing debuff

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -35,15 +35,15 @@
 
 /datum/component/rot/process()
 
-	var/amt2add = 10 // 1 Second. Base increment. 
+	var/amt2add = 10 // 1 Second. Base increment.
 	var/current_time = world.time
-    
+
 	// time elapsed since the last rot/process
 	var/elapsed_time = last_process ? (current_time - last_process) : 0
 	last_process = current_time
 
 	// Add amount based on the time elapsed. This is used to calculate when to wake/decompose
-	amount += (elapsed_time / 10) * amt2add 
+	amount += (elapsed_time / 10) * amt2add
 
 	return
 
@@ -105,14 +105,14 @@
 					B.rotted = TRUE
 					findonerotten = TRUE
 					shouldupdate = TRUE
-					C.apply_status_effect(/datum/status_effect/debuff/rotted_zombie)	//-8 con to rotting zombie corpse.
+					C.apply_status_effect(/datum/status_effect/debuff/rotted_zombie)	//-3 con, -8 int to rotting zombie corpse.
 			else
 				if(amount > CORPSE_SKELETONIZE_TIME)
 					if(!is_zombie)
 						B.skeletonize()
 						if(C.dna && C.dna.species)
 							C.dna.species.species_traits |= NOBLOOD
-						C.apply_status_effect(/datum/status_effect/debuff/rotted_zombie)	//-8 con to rotting zombie corpse - duplicate as a failsafe.
+						C.apply_status_effect(/datum/status_effect/debuff/rotted_zombie)	//-3 con, -8 int to rotting zombie corpse - duplicate as a failsafe.
 						shouldupdate = TRUE
 				else
 					findonerotten = TRUE

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -525,9 +525,9 @@
 	icon_state = "revived_rot"
 
 /datum/status_effect/debuff/rotted_zombie
-	id = "rotted_zombie" //Replaces the flat-stat change, this should ONLY apply to zombies who have been dead for some time. Makes them easier to kill.
+	id = "rotted_zombie" //Replaces the flat-stat change, this should ONLY apply to zombies, makes them easier to kill
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/rotted_zombie
-	effectedstats = list(STATKEY_CON = -8) //No duration = infinate in time - this is removed on de-rot miricle OR de-rot surgery. Won't be applied unless you've been a zombie for ~20 min.
+	effectedstats = list(STATKEY_CON = -3, STATKEY_INT = -8) //No duration = infinate in time - this is removed on de-rot miricle OR de-rot surgery. Won't be applied unless you're rotting long enough to zombify.
 	examine_text = "<font color='#2c8b00'>SUBJECTPRONOUN's flesh bears the unmistakable signs of unnatural decay. An ill omen whispers that this corpse may yet walk again.</font>"
 
 /atom/movable/screen/alert/status_effect/debuff/rotted_zombie


### PR DESCRIPTION
## About The Pull Request

Seeing as my prior zombification debuff caused HUGE issues where it was trying to dynamically shift your stats and this debuff is absolutely nuking zombies to : 2 con or less because zombies were keeping this debuff.

I don't want to axe it from zombies since they're meant to be weaker than living in exchange for all of their traits and so. But they're not a major antag so they don't need anything impressive.

*the debuff was applying on-rot* which was causing problems.

Re-tunes the debuff for decomposing:

-3 con
-8 int

from

-8 con

that's it, there's no dynamic buff shifting because it was breaking people I think, w/ their statlines getting fucked up.

enough to put you at that sovlful near 1 int. always fientable, but enough to still be a moderate threat as most classes.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Its a few codeline changes

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Zombies aren't meant to be an overwhelming threat but it speaks volumes if you can skullcrack one instantly by throwing a rock at their head, when they turned w/ antag-grade stats without even hurting them.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: returned rotted corpse debuff -3 con, -8 int. this should make deadites less of an instaloss bait and still reasonably weak to account for their self-healing capacity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
