### PR TITLE
add frameworks for manual resting and emoting skin armour repairs + shifts skin armour

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -241,6 +241,8 @@
 #define COMSIG_MOB_DEATH "mob_death"							//from base of mob/death(): (gibbed)
 #define COMSIG_MOB_TRY_BARK "try_bark"
 #define COMSIG_MOB_TRY_EMOTE "try_emote"
+#define COMSIG_MOB_EMOTED "mob_emoted"							//from /mob/proc/emote() when a keyed emote is intentionally invoked
+#define COMSIG_MOB_MEDITATED "mob_meditated"						//from /datum/emote/living/meditate/run_emote() when a meditation focus completes uninterrupted: ()
 #define COMSIG_MOB_MODIFY_AGGRO_LINES "comsig_mob_modify_aggro_lines"
 #define COMSIG_MOB_MODIFY_DEATH_LINES "comsig_mob_modify_death_lines"
 
@@ -256,7 +258,7 @@
 	#define COMPONENT_BLOCK_MAGIC 1
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"				//from base of mob/create_mob_hud(): ()
 #define COMSIG_MOB_ATTACK_HAND "mob_attack_hand"				//from base of
-#define COMSIG_MOB_ATTACK_BITE "mob_attack_bite"				
+#define COMSIG_MOB_ATTACK_BITE "mob_attack_bite"
 #define COMSIG_MOB_ATTACKED_BY_HAND	"mob_attacked_by_hand"		//from base of datum/species/proc/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style)
 #define COMSIG_MOB_ATTACKED_BY_BITE	"mob_attacked_by_bite"		//from base of /datum/intent/bite/on_mmb(atom/target, mob/living/user, params): (mob/living/user)
 	#define COMPONENT_HAND_NO_ATTACK 1

--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -20,9 +20,17 @@
 
 	var/repairmsg_end = "My skin has become taut with newfound vigor!"
 	var/repairmsg_continue = "My armour mends some of its abuse.."
+	/// Shown when a repair is attempted while the skin is already at full integrity.
+	var/repairmsg_full = "My skin isn't wounded."
+	/// Fraction of max_integrity restored per repair cycle. Overridden per repair method (resting/sewing/prayer/etc.).
+	var/repair_fraction = 0.35
+	/// Flat integrity restored per cycle. Defaults to repair_fraction * max_integrity at Initialize; set directly for a flat per-armour override.
+	var/repair_percent
 
 /obj/item/clothing/suit/roguetown/armor/manual/Initialize(mapload)
 	..()
+	if(isnull(repair_percent))
+		repair_percent = repair_fraction * max_integrity
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
 /obj/item/clothing/suit/roguetown/armor/manual/dropped(mob/living/carbon/human/user)
@@ -31,13 +39,17 @@
 		return
 	qdel(src)
 
-/obj/item/clothing/suit/roguetown/armor/manual/proc/armour_regen(var/repair_percent = 0.35 * max_integrity)
+/obj/item/clothing/suit/roguetown/armor/manual/proc/armour_regen(repair_amount = repair_percent)
     if(obj_integrity >= max_integrity)
         to_chat(loc, span_notice(repairmsg_end))
     to_chat(loc, span_notice(repairmsg_continue))
-    obj_integrity = min(obj_integrity + repair_percent, max_integrity)
+    obj_integrity = min(obj_integrity + repair_amount, max_integrity)
     if(obj_broken)
         obj_fix(full_repair = FALSE)
+
+/// TRUE while this skin is actually worn on its owner's body (armour or shirt slot), not merely held.
+/obj/item/clothing/suit/roguetown/armor/manual/proc/worn_on_body(mob/living/carbon/human/user)
+	return user?.wear_armor == src || user?.wear_shirt == src
 
 //35% repair per proc, procs taking ~10-11s for sewing, pushup set, or meditation emote. Thus ~30-33s to fullrepair.
 
@@ -50,6 +62,7 @@
 /obj/item/clothing/suit/roguetown/armor/manual/pushups
     name = "muscular skin"
     desc = "The reward for all your hard work. </br>THE INFLUENCE OF THE HAM SANDWYCH RACE IS WANING. I MUST DO PUSH-UPS, TO REMIND MY MUSCLES OF THEIR OWN STRENGTH."
+    repair_fraction = 0.40 //40% per 10-pushup set, a bit stronger per chunk due to stamina management.
 
     repairmsg_end = "My muscles sheen with vitality!"
     repairmsg_continue = "My muscles are reminded of their own strength."
@@ -64,18 +77,33 @@
 	armor = ARMOR_LEATHER
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //Identical to a glued-on hardened leather coat, with bonus arm-hand-foot coverage.
 
-/*
- * MEDITATION ARMOUR - Currently no trigger for the repair proc, thus unused and should not be used.
- */
-
 /obj/item/clothing/suit/roguetown/armor/manual/meditation
-    name = "harmonious skin"
-    desc = "Exotic skin armor that can be renewed via meditation. If you see this ingame, something went wrong."
+	name = "harmonious skin"
+	desc = "Exotic skin armor that can be renewed via meditation. If you see this ingame, something went wrong."
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/equipped(mob/user, slot, initial = FALSE)
+	. = ..()
+	if(ishuman(user) && worn_on_body(user))
+		RegisterSignal(user, COMSIG_MOB_MEDITATED, PROC_REF(on_wearer_meditated), override = TRUE)
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/dropped(mob/living/carbon/human/user)
+	if(ismob(user))
+		UnregisterSignal(user, COMSIG_MOB_MEDITATED)
+	return ..()
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/get_mechanics_examine(mob/user)
 	. = ..()
 
-	. += span_info("Repairable via meditate emotes.")
+	. += span_info("Repairable by completing a *meditate emote.")
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/proc/on_wearer_meditated(mob/living/carbon/human/user)
+	SIGNAL_HANDLER
+	if(!worn_on_body(user))
+		return
+	if(obj_integrity >= max_integrity)
+		to_chat(user, span_warning(repairmsg_full))
+		return
+	armour_regen()
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats
 	resistance_flags = FIRE_PROOF
@@ -110,6 +138,7 @@
  */
 
 /obj/item/clothing/suit/roguetown/armor/manual/sewable
+	repair_fraction = 0.20 //20% per 5s of sewing, ~25s to full.
 	var/list/repair_items[] = list(
 		/obj/item/needle = 'sound/foley/sewflesh.ogg',
 		/obj/item/needle/thorn = 'sound/foley/sewflesh.ogg',
@@ -128,12 +157,12 @@
 	if(user != loc)
 		return FALSE
 	if(obj_integrity == max_integrity)
-		to_chat(user, span_warning("My skin isn't wounded."))
+		to_chat(user, span_warning(repairmsg_full))
 		return FALSE
 	if(!repair_check(user, I))
 		return FALSE
 
-	if(!do_after(user, 10 SECONDS, target = src))
+	if(!do_after(user, 5 SECONDS, target = src))
 		return FALSE
 
 	armour_regen()
@@ -167,8 +196,6 @@
 
 	return TRUE
 
-
-
 //PADDED
 /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded
 	name = "sewable skin armor"
@@ -183,20 +210,6 @@
 		/obj/item/rogueweapon/surgery/cautery = 'sound/surgery/cautery1.ogg'
 	)
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/barbarian
-	name = "hardened skin"
-	desc = "Toughened from abuse. My mettle remains."
-
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/gladiator
-	name = "pit-hardened skin"
-	desc = "Are you not entertained?!"
-
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/bailiff
-	name = "scar-marred skin"
-	desc = "Bearing scars of countless whips leaves a gnarly visage. Now it's your time to inflict the same fate upon others."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //1.2x integrity (300) vs baseline padded skin armor (250).
-	//Perk of being a MAA kinda-powerclass. Basically just a heavy gambeson.
-
 /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/monke
 	name = "trained skin"
 	desc = "They say I've taken the first step on a path older than memory.\
@@ -205,12 +218,6 @@
 	</br>I came here because I wanted purpose, something solid to believe in.\
 	</br>They tell me doubt is natural, and that understanding comes with time.\
 	</br>For now, I will listen, learn, and try to live in a way that does not waste what was given to us."
-
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/monk
-	name = "tough skin"
-	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //0.8x integrity (200) vs baseline padded skin armor (250).
-	//Tax for being an advent with utility miracles.
 
 /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/confessor
 	name = "arbalist's skin"
@@ -230,21 +237,165 @@
 	//Perk of being a psy-templar powerclass.
 
 
+/*
+ * EMOTE ARMOUR
+ */
+
+/obj/item/clothing/suit/roguetown/armor/manual/emote
+	name = "abstract emote skin"
+	desc = "Why."
+	/// Emote required to repair. list("yawn").
+	var/list/repair_emotes = null
+	/// How long a single emote repair cycle takes (do_after).
+	var/repair_time = 10 SECONDS
+	/// Bool to keep track of cycles.
+	var/repairing = FALSE
+
+/obj/item/clothing/suit/roguetown/armor/manual/emote/equipped(mob/user, slot, initial = FALSE)
+	. = ..()
+	if(ishuman(user) && repair_emotes && worn_on_body(user))
+		RegisterSignal(user, COMSIG_MOB_EMOTED, PROC_REF(on_wearer_emoted), override = TRUE)
+
+/obj/item/clothing/suit/roguetown/armor/manual/emote/dropped(mob/living/carbon/human/user)
+	if(ismob(user))
+		UnregisterSignal(user, COMSIG_MOB_EMOTED)
+	return ..()
+
+/obj/item/clothing/suit/roguetown/armor/manual/emote/get_mechanics_examine(mob/user)
+	. = ..()
+	if(!repair_emotes)
+		return
+	var/list/emote_names = list()
+	for(var/emote_key in repair_emotes)
+		emote_names += "*[emote_key]"
+	. += span_info("Repairable by emoting: [english_list(emote_names)]. Moving or being struck interrupts the repair.")
+
+/obj/item/clothing/suit/roguetown/armor/manual/emote/proc/on_wearer_emoted(mob/living/carbon/human/user, act, intentional)
+	SIGNAL_HANDLER
+	if(!intentional)
+		return
+	if(repairing || !repair_emotes || !(act in repair_emotes))
+		return
+	INVOKE_ASYNC(src, PROC_REF(emote_repair_cycle), user, act)
+
+/obj/item/clothing/suit/roguetown/armor/manual/emote/proc/emote_repair_cycle(mob/living/carbon/human/user, act)
+	if(!worn_on_body(user))
+		return
+	if(obj_integrity >= max_integrity)
+		to_chat(user, span_warning(repairmsg_full))
+		return
+	repairing = TRUE
+	var/soundeffect = repair_emotes[act]
+	// The emote kicks off the repair; it mends cycle by cycle until full, or a cycle is interrupted (move/struck).
+	while(obj_integrity < max_integrity)
+		if(!do_after(user, repair_time, target = src))
+			break
+		if(soundeffect)
+			playsound(user, soundeffect, 100, TRUE)
+		armour_regen()
+	repairing = FALSE
+
+/*
+ * PRAYER SKIN - repaired via the *pray emote (non-psydonite monks). 35% per 10s, ~30s to full.
+ */
+
+/obj/item/clothing/suit/roguetown/armor/manual/emote/prayer
+	repair_emotes = list("pray")
+
+/obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk
+	name = "tough skin"
+	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
+	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //0.8x integrity (200) vs baseline padded skin armor (250).
+	//Tax for being an advent with utility miracles.
+
+/*
+ * REST ARMOUR
+ */
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting
+	name = "abstract resting skin"
+	desc = "How."
+	repair_fraction = 0.25 //25% per 5s of rest, ~20s to full.
+	/// How long of unbroken rest each repair cycle takes.
+	var/repair_time = 5 SECONDS
+	/// Shown once when a rest-based repair cycle begins.
+	var/repairmsg_rest_begin = "I settle in, and my skin begins to knit itself whole.."
+	/// world.time the wearer began their current uninterrupted rest on a bed, 0 when not resting.
+	var/resting_since = 0
+	/// Structures on the wearer's turf that count as a bed.
+	var/static/list/repair_rest_beds = list(/obj/structure/bed, /obj/structure/flora/roguetree/stump, /obj/item/bedsheet)
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/Initialize(mapload)
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("Repairs slowly while resting on a bed.")
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/process(delta_time)
+	var/mob/living/carbon/human/H = loc
+	if(!ishuman(H) || !worn_on_body(H) || obj_integrity >= max_integrity)
+		resting_since = 0
+		return
+	if(!H.resting || H.cmode || (H.in_combat_until > world.time) || !rest_on_valid_bed(H))
+		resting_since = 0
+		return
+	if(!resting_since)
+		resting_since = world.time
+		to_chat(H, span_notice(repairmsg_rest_begin))
+		return
+	if(world.time >= resting_since + repair_time)
+		resting_since = world.time
+		armour_regen()
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/proc/rest_on_valid_bed(mob/living/carbon/human/H)
+	var/turf/T = get_turf(H)
+	if(!T)
+		return FALSE
+	for(var/obj/O in T.contents)
+		for(var/bed_path in repair_rest_beds)
+			if(istype(O, bed_path))
+				return TRUE
+	return FALSE
+
+//PADDED
+/obj/item/clothing/suit/roguetown/armor/manual/resting/padded
+	name = "resting skin armor"
+	desc = "This should not spawn naturally. If you see this ingame, something went wrong."
+	armor = ARMOR_PADDED
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //Identical to a glued-on gambeson in armor slot, with bonus hand+foot coverage.
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/padded/barbarian
+	name = "hardened skin"
+	desc = "Toughened from abuse. My mettle remains."
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/padded/gladiator
+	name = "pit-hardened skin"
+	desc = "Are you not entertained?!"
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/padded/bailiff
+	name = "scar-marred skin"
+	desc = "Bearing scars of countless whips leaves a gnarly visage. Now it's your time to inflict the same fate upon others."
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //1.2x integrity (300) vs baseline padded skin armor (250).
+	//Perk of being a MAA kinda-powerclass. Basically just a heavy gambeson.
+
 //LEATHER
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/leather
-	name = "sewable skin armor"
+/obj/item/clothing/suit/roguetown/armor/manual/resting/leather
+	name = "resting skin armor"
 	desc = "This should not spawn naturally. If you see this ingame, something went wrong."
 	armor = ARMOR_LEATHER
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //Identical to a glued-on hardened leather coat, with bonus arm-hand-foot coverage.
-	repair_items = list(
-		/obj/item/needle = 'sound/foley/sewflesh.ogg',
-		/obj/item/needle/thorn = 'sound/foley/sewflesh.ogg',
-		/obj/item/needle/bronze = 'sound/foley/sewflesh.ogg',
-		/obj/item/needle/pestra = 'sound/foley/sewflesh.ogg',
-		/obj/item/rogueweapon/surgery/cautery = 'sound/surgery/cautery1.ogg'
-	)
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/leather/berzerker
+/obj/item/clothing/suit/roguetown/armor/manual/resting/leather/thug
+	name = "calloused skin"
+	desc = "A brawler's hide, thickened by a hard life. A spell of rest is enough to knit it whole again."
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/leather/berzerker
 	name = "unstoppable skin"
 	desc = "I've endured enough. The onslaught has lost its meaning."
 	blocking_behavior = SAMEWEAR
@@ -252,22 +403,14 @@
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER + 150 //1.5x integrity (450) vs baseline leather skin armor (300).
 	//Perk of being a wretch powerclass.
 
-
 //MAILLE
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/maille
-	name = "sewable skin armor"
+/obj/item/clothing/suit/roguetown/armor/manual/resting/maille
+	name = "resting skin armor"
 	desc = "This should not spawn naturally. If you see this ingame, something went wrong."
 	armor = ARMOR_MAILLE
 	max_integrity = ARMOR_INT_CHEST_LIGHT_IRON
-	repair_items = list(
-		/obj/item/needle = 'sound/foley/sewflesh.ogg',
-		/obj/item/needle/thorn = 'sound/foley/sewflesh.ogg',
-		/obj/item/needle/bronze = 'sound/foley/sewflesh.ogg',
-		/obj/item/needle/pestra = 'sound/foley/sewflesh.ogg',
-		/obj/item/rogueweapon/surgery/cautery = 'sound/surgery/cautery1.ogg'
-	)
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/maille/berzerkerchest
+/obj/item/clothing/suit/roguetown/armor/manual/resting/maille/berzerkerchest
 	name = "unstoppable chest"
 	desc = "The callouses could stop arrows! But only so many."
 	slot_flags = ITEM_SLOT_ARMOR

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -73,7 +73,7 @@
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
 					armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/monke // ape out, brothers. +25 durability over other monks.
 				else
-					armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/monk // 25 less than gladiator's skin.
+					armor = /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk // repaired by praying; 25 less than gladiator's skin.
 
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -641,7 +641,7 @@
 				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC) //Lite!Barbarian.
 				head = /obj/item/clothing/head/roguetown/helmet/bronzegladiator
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/cloth/gladiator
-				armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/gladiator
+				armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/padded/gladiator
 				pants = /obj/item/clothing/under/roguetown/loincloth/brown
 				shirt = /obj/item/clothing/suit/roguetown/shirt/tribalrag/gladiator
 				belt = /obj/item/storage/belt/rogue/leather/battleskirt/breechcloth/red

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -311,7 +311,7 @@
 			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 			head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm
 			gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted
-			armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/barbarian
+			armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/padded/barbarian
 		if ("Discipline - Bodybuilder") //its really not that good
 			H.adjust_skillrank_up_to(/datum/skill.combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
 			armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/barbarian

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -191,7 +191,7 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/barbarian
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/leather/thug
 	backpack_contents = list(
 				/obj/item/rogueweapon/huntingknife = 1,
 				/obj/item/recipe_book/leatherworking = 1,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -67,8 +67,8 @@
 			if("Light Armor")
 				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 			if("Bare Skin")
-				armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/maille/berzerkerchest
-				shirt = /obj/item/clothing/suit/roguetown/armor/manual/sewable/leather/berzerker
+				armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/maille/berzerkerchest
+				shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/leather/berzerker
 		var/list/main_choices = list("Unarmed Master", "Martial Expert") // Unarmed focuses on master punching and wrestling moves, Martial gives you two expert weapon skills to be flexible
 		var/category_choice = input(H, "Choose your MEANS OF VIOLENCE.", "SMASH OR SLASH!!") as anything in main_choices
 		switch(category_choice)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
@@ -81,7 +81,7 @@
 					shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced //dwarves like to blow up my patience
 			if("Enchanted Inks")
 				neck = /obj/item/clothing/neck/roguetown/coif/heavypadding/black
-				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats/mistwalker //they don't get stronger swords like ruma, let them have the +50 integ
+				armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/mistwalker //they don't get stronger swords like ruma, let them have the +50 integ
 				shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 				ADD_TRAIT(H, TRAIT_HONORBOUND, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
@@ -391,7 +391,7 @@
 	head = /obj/item/clothing/head/roguetown/menacing/executioner
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	mask = /obj/item/clothing/head/roguetown/roguehood/black
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/bailiff
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/padded/bailiff
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
@@ -38,7 +38,7 @@
 	beltl = /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
 	cloak = /obj/item/clothing/cloak/eastcloak1
-	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
 	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
@@ -90,7 +90,7 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
 	cloak = /obj/item/clothing/cloak/eastcloak1
-	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
 	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/seonjang.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/seonjang.dm
@@ -33,7 +33,7 @@
 /datum/outfit/job/roguetown/mercenary/seonjang/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("You are a Captain of the Clan, second to none. The blades and bows of the Ruma look to you for guidance - rally your warriors and lead by example!"))
-	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
 	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -73,6 +73,8 @@
 			mute_time = P.mute_time
 			if(P.run_emote(src, param, m_type, intentional, targetted, (animal ? animal : P.is_animal)))
 				break
+		if(intentional)
+			SEND_SIGNAL(src, COMSIG_MOB_EMOTED, act, intentional)
 
 	if(custom_me)
 		next_me_emote = world.time + mute_time
@@ -162,7 +164,7 @@
 		var/sound/tmp_sound = P.get_sound(src)
 		if(!istype(tmp_sound))
 			tmp_sound = sound(get_sfx(tmp_sound))
-		
+
 		if(tmp_sound)
 			tmp_sound.frequency = pitch
 			if(tmp_sound.file)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -92,18 +92,19 @@
 
 /datum/emote/living/meditate/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
+	to_chat(user, span_green("You focus inwards..."))
+	for(var/cycle in 1 to 3)
+		if(!do_after(user, 10 SECONDS))
+			return
+		SEND_SIGNAL(user, COMSIG_MOB_MEDITATED)
 	if(HAS_TRAIT(user, TRAIT_IRONMAN))
-		to_chat(user, span_green("You focus inwards..."))
-		if(do_after(user, 1 MINUTES))
-			var/mob/living/U = user
-			var/percent = U.max_energy * 0.3
-			user.add_stress(/datum/stressevent/meditation_ironman)
-			user.energy_add(percent)
-			playsound(user, 'sound/misc/machineyes.ogg', 25)
+		var/mob/living/U = user
+		var/percent = U.max_energy * 0.3
+		user.add_stress(/datum/stressevent/meditation_ironman)
+		user.energy_add(percent)
+		playsound(user, 'sound/misc/machineyes.ogg', 25)
 	else
-		to_chat(user, span_green("You focus inwards..."))
-		if(do_after(user, 1 MINUTES))
-			user.add_stress(/datum/stressevent/meditation)
+		user.add_stress(/datum/stressevent/meditation)
 
 /datum/emote/living/bow
 	key = "bow"


### PR DESCRIPTION
## About The Pull Request

as it says on the tin.

## Testing Evidence

frameworks. tested but ideally would get a better test through pushing existing skin armours to it.

## Why It's Good For The Game

probably merge after my light armour PR

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: framework for emote and rest skin repair.
balance: shifts and changes how most skin armour repair themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
