### PR TITLE
loadout prefs bug fix

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -54,6 +54,7 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 			character.mind.special_items["[LI.name][TRIUMPH_STASH_SUFFIX]"] = LI.path
 		else
 			character.mind.special_items[LI.name] = LI.path
+		character.mind.special_items_metadata[LI.name] = player.prefs.gear_list[item_name]
 	var/datum/job/assigned_job = SSjob.GetJob(character.mind?.assigned_role)
 	if(assigned_job)
 		assigned_job.clamp_stats(character)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -108,6 +108,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	var/list/learned_recipes
 
 	var/list/special_items = list()
+	var/list/special_items_metadata = list()
 
 	var/list/areas_entered = list()
 
@@ -1418,7 +1419,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 							I.special_item = TRUE
 							I.smeltresult = /obj/item/ash
 							I.salvage_result = /obj/item/ash
-						var/list/metadata = user.client?.prefs?.gear_list?[base_name]
+						var/list/metadata = user.mind.special_items_metadata[base_name]
 						if(islist(metadata))
 							if(metadata["color"])
 								I.add_atom_colour(metadata["color"], FIXED_COLOUR_PRIORITY)


### PR DESCRIPTION
## About The Pull Request
there was a bug where swapping character slots in game preferences after spawning would make your custom loadout items not have their names, descs, colors, etc

## Testing Evidence
gave loadout items some quick names n descs for this, swapped charslots between taking the two out. nothing changed, because we're no longer checking prefs midround, just caching the loadout setup at roundstart  
<img width="508" height="572" alt="image" src="https://github.com/user-attachments/assets/b9d7b4d3-09b2-4ed3-9d72-b4b4f07b48a4" />

## Why It's Good For The Game
bugfix good

:cl:
fix: Changing character slots in game preferences midround will no longer cause loadout items to lose their custom metadata (name, desc, color, etc) when retrieved from stash.
/:cl:
