### PR TITLE
dasdasdas - morphing elixirs are now 1x2 slots in size (instead of 2x2), like a regular bottle

### DIFF
--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -5,6 +5,8 @@
 	desc = "A small container of special morphing dust, perfect to make a specific item."
 	icon = 'icons/obj/items/donor_objects.dmi'	//We default to here just to avoid tons of uneeded sprites.
 	icon_state = "enchanting_kit"
+	grid_width = 32
+	grid_height = 64
 	w_class = WEIGHT_CLASS_SMALL	//So can fit in a bag, we don't need these large. They're just used to apply to items.
 	var/list/target_items = list()
 	/// Result item we'll exchange it to. Currently /weapon/ type kits use this as an example they'll copy all the visual data from. Keep this in mind if this never gets properly refactored!


### PR DESCRIPTION
## About The Pull Request

yea

## Testing Evidence

,ghj

## Why It's Good For The Game

* Continuity with inventory space.

## Changelog

:cl:
add: Morphing elixirs now take up 1x2 inventory tiles (like a regular bottle), instead of 2x2.
/:cl:
