### PR TITLE
Some varied fixes and tweaks

### DIFF
--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -25,6 +25,10 @@
 	can_hold = typecacheof(list(
 	/obj/item/rogueweapon/surgery,
 	/obj/item/needle,
+	/obj/item/rogueweapon/huntingknife/stoneknife,
+	/obj/item/reagent_containers/glass/bottle/rogue/beer,
+	/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab,
+	/obj/item/reagent_containers/glass/bottle/rogue/healthpot/zarum,
 	/obj/item/natural/worms/leech,
 	/obj/item/reagent_containers/lux,
 	/obj/item/reagent_containers/lux_impure,

--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -106,7 +106,7 @@
 	desc = "A short but heavy leather whip, sporting a blunt reinforced tip and a longer handle."
 	icon_state = "nagaika"
 	force = 25		//Same as a cudgel/sword for intent purposes. Basically a 2 range cudgel while one-handing.
-	possible_item_intents = list(/datum/intent/whip/crack/blunt, /datum/intent/whip/lash, /datum/intent/sword/strike)
+	possible_item_intents = list(/datum/intent/whip/lash, /datum/intent/whip/crack/blunt, /datum/intent/sword/strike)
 	wdefense = 1	//Akin to a cudgel, still terrible at parrying though. Better than nothing I guess; thing is used irl as a counter-weapon to knives.
 
 /obj/item/rogueweapon/whip/xylix

--- a/code/modules/mob/living/living_topic.dm
+++ b/code/modules/mob/living/living_topic.dm
@@ -22,7 +22,7 @@
 		if(stat >= DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 			message += "<B>Their core lies silent...</B>"
 		else
-			message += "<B>Their core hums with lyfe.</B>"		
+			message += "<B>Their core hums with lyfe.</B>"
 	var/list/soul_message = soul_examine(user)
 	if(length(soul_message))
 		message += soul_message
@@ -35,7 +35,7 @@
 			message += "<span class='deadsay'>[p_they(TRUE)] commited suicide... Nothing can be done..."
 		if(HAS_TRAIT(src, TRAIT_DNR))
 			message += "<span class='deadsay'>[p_their(TRUE)] heart will never beat again...</span>"
-		if(isobserver(user) || HAS_TRAIT(user, TRAIT_SOUL_EXAMINE) || HAS_TRAIT(user, TRAIT_ZIZOSIGHT) || (user.get_skill_level(/datum/skill/misc/medicine) >= SKILL_LEVEL_MASTER))
+		if(isobserver(user) || HAS_TRAIT(user, TRAIT_SOUL_EXAMINE) || HAS_TRAIT(user, TRAIT_ZIZOSIGHT) || (user.get_skill_level(/datum/skill/misc/medicine) >= SKILL_LEVEL_EXPERT))
 			if(!key && !get_ghost(FALSE, TRUE))
 				message += span_deadsay("[p_their(TRUE)] soul has departed...")
 			else

--- a/code/modules/spells/spell_types/skills/invoked_single_target/takeapprentice.dm
+++ b/code/modules/spells/spell_types/skills/invoked_single_target/takeapprentice.dm
@@ -1,6 +1,6 @@
 // A skill, currently meant to be for towner towner (excluding towner, the more freeform role atm)
 // Allows you to take on an apprentice, giving them one of the skill gating traits
-// And giving them Novice in corresponding skills. 
+// And giving them Novice in corresponding skills.
 // Meant to be used once per round per character. Cannot have more than one apprentice per character.
 // Encourage people to encourage w/ towners to get skills and give them a point of leverage.
 /obj/effect/proc_holder/spell/invoked/takeapprentice
@@ -10,13 +10,13 @@
 	overlay_state = "craft_buff"
 	releasedrain = 50
 	chargedrain = 0
-	chargetime = 3 SECONDS // A charge time mostly to render it useless for putting an input on someone's screen mid combat. 
+	chargetime = 3 SECONDS // A charge time mostly to render it useless for putting an input on someone's screen mid combat.
 	recharge_time = 30 SECONDS
 	antimagic_allowed = TRUE
 	range = 1
 	// Miserere mei, Deus, secundum magnam misericordiam tuam
 	var/list/traits_to_skills = list (
-		TRAIT_HOMESTEAD_EXPERT = list( 
+		TRAIT_HOMESTEAD_EXPERT = list(
 			/datum/skill/labor/fishing,
 			/datum/skill/labor/butchering,
 			/datum/skill/labor/lumberjacking,
@@ -102,12 +102,15 @@
 		to_chat(user, span_warning("You must choose a trait for [L.name] to learn."))
 		revert_cast()
 		return
-		
+
 	// Give the trait and skills.
 	ADD_TRAIT(L, chosen_trait, TRAIT_GENERIC)
 	for(var/skill in traits_to_skills[chosen_trait])
 		// We can just skip the check because it only adjust up to 1 anyway
 		to_chat(L, span_greentext("[user] has taken you as an apprentice, teaching you the basics of being an [chosen_trait]."))
-		L.adjust_skillrank_up_to(skill, SKILL_LEVEL_NOVICE)
+		if(chosen_trait == TRAIT_MEDICINE_EXPERT)
+			L.adjust_skillrank_up_to(skill, SKILL_LEVEL_APPRENTICE)
+		else
+			L.adjust_skillrank_up_to(skill, SKILL_LEVEL_NOVICE)
 		L.set_mentor(user)
 		user.set_apprentice(L)


### PR DESCRIPTION
## About The Pull Request
A few things have irked me while playing, so I bundled up some changes to those. These are :

- swapped the first and second intent of the naigaka whip around, making the order consistent with every other whip in terms of range (the intents are still the same)
- lowered skill requirement to tell if someone is round removed via listening their heartbeat, from Master down to Expert
- made the items in the improvised surgery kit, actually able to be put back inside
- made specifically the Expert Physicker choice of Take Apprentice give apprentice medicine, was novice before

If any of these are disapproved, I'm willing to tweak them accordingly, as to not see the whole PR shot down for it.

## Testing Evidence

tested it all, here's screenshots of the take apprentice one (testing medicine and alchemy) since it's the riskiest one, but work it does
<img width="221" height="253" alt="image" src="https://github.com/user-attachments/assets/9d889d52-8d2a-433e-840c-e2e9ea2ce0cc" />
<img width="236" height="279" alt="image" src="https://github.com/user-attachments/assets/55cce17f-bbfe-4f84-9c45-1e324f78c579" />

## Why It's Good For The Game

- Naigaka whip disobeyed the muscle memory of literally every single over whip, it was awkward and annoying. This finally changes that.
- I really do not think there is much of a point to gatekeeping being able to tell if someone is worth dragging back to town from Decap on my 8 STR, or if I may as well bury them right there. At best, it makes Necrans feel special, but I'd argue hindering everyone else is not the right way to go about it. Lowering it to expert is a small step, and frankly I'd argue Jman medicine would be even better, if not removing the cap outright. But, one step at a time.
- I'm guessing no one really uses the improvised surgery bag if no one fixed the stone knife you get not being able to go back in, lol. This is a much-needed fix. As for the bottles, it DOES come at the downside that people could empty a bunch of beers, fill them with red and walk around with a sloshing medkit of potions... but I think that falls within powergaming rules and not worth compromising the bag, but if it really is a concern I'll make it for just the knife.
- I've been teaching medical as head apothecary lately, taking apprentices SUCKS. Novice medicine is not enough considering surgery starts at Apprentice, which means your student will have to spend a while just cutting and stitching shut a goblin on loop, it's boring, it makes no sense (and even at apprentice you still need to grind surgery anyway). It's arguably a fault of medicine being hard to level up to begin with, this change can be reverted if that ever gets addressed. And I'm not worried about people abusing this, because it's abuse if a head phys gives apprentice to their meta buddy and lets them walk off instead of having them as an assistant.

## Changelog
:cl:
qol: naigaka whip's intents swapped around to have their ranges consistent with other whips
fix: made items that the improvised surgery kit spawns with able to fit back inside
balance: lowered skill requirement of listening to heartbeat to identify RR from master medicine down to expert
balance: Expert Physicker option of Take Apprentice now gives Apprentice medicine skill instead of Novice
/:cl:
