### PR TITLE
The De-Snoutening

### DIFF
--- a/code/modules/client/customizer/customizers/organ/snout.dm
+++ b/code/modules/client/customizer/customizers/organ/snout.dm
@@ -121,13 +121,13 @@
 		)
 
 /datum/customizer/organ/snout/anthro
-	allows_disabling = FALSE
-	default_disabled = FALSE
+	allows_disabling = TRUE
+	default_disabled = TRUE
 	customizer_choices = list(/datum/customizer_choice/organ/snout/anthro)
 
 /datum/customizer/organ/snout/anthrosmall
-	allows_disabling = FALSE
-	default_disabled = FALSE
+	allows_disabling = TRUE
+	default_disabled = TRUE
 	customizer_choices = list(/datum/customizer_choice/organ/snout/anthro)
 
 /datum/customizer/organ/snout/anthro/dullahan


### PR DESCRIPTION
## About The Pull Request

Restores the ability for players to make wildkin (and verminfolk, since they're just little wildkin) characters without snouts

## Testing Evidence

Compiles and runs, tested on localhost and didn't explode my pc

## Why It's Good For The Game

I havent really seen a compelling argument as to why the snouts should be mandatory. Wildkin are meant to be able to embody all kinds of animals, many of which do not have a snout. I've heard that this was removed because people were playing widkin as halfkin for the minor stat changes, but the actual difference between wildkin and halfkin seems to be only  that halfkin are arbitrarily 'more humen' which i do not believe the relaxing of the constrictive forced-snouts violates. Now, in my opinion, racial stats should be abolished altogether, but this minor change is just removing a barrier to creativity that was only in place for the sake of a frankly insignificant issue. This will also allow people to play un-snouted characters with mutant skin tones, which was actually included in the original pr that removed the snouts in the form of removing ancestry from halfkin. This change was reverted the next day for messing with existing character presets, and so i hope this change will open up the possibility for this kind of character in a less intrusive way. Any perceived issue arising from wrong-race characters should be handled on a case-by-case basis, if it warrants intervention at all, rather than a blanket restriction.

tl;dr the boundary between half and wild kin is hazy, allowing for freer customisation takes precedence over a very minor racial stat issue

## Changelog

:cl:
fix: restored the ability for wildkin and verminfolk to toggle off snouts
/:cl:

