### PR TITLE
[hotfix] fixes heretic prayers and also other prayers

### DIFF
--- a/code/datums/gods/patrons/inhumen/baotha.dm
+++ b/code/datums/gods/patrons/inhumen/baotha.dm
@@ -31,9 +31,9 @@
 		"Lady of Heartbreak",
 		"Scarlet Lady",
 		"Baosumi",
-		"Thorns", // Queen of thorns, Lady of thorns, etc etc. 
+		"Thorns", // Queen of thorns, Lady of thorns, etc etc.
 		"Belladoth",
-		"Beladoth" //SOMEONE WILL MISPELL IT, I JUST KNOW IT. 
+		"Beladoth" //SOMEONE WILL MISPELL IT, I JUST KNOW IT.
 	)
 
 /datum/patron/inhumen/baotha/can_pray(mob/living/follower)
@@ -42,7 +42,7 @@
 	if(istype(get_area(follower), /area/rogue/under/cave/inhumen))
 		return TRUE
 	// Allows prayer near EEEVIL psycross
-	for(var/obj/structure/fluff/psycross/zizocross/cross in view(4, get_turf(follower)))
+	for(var/obj/structure/fluff/psycross/cross in view(4, get_turf(follower)))
 		if(cross.divine == TRUE)
 			to_chat(follower, span_danger("That acсursed cross interupts my prayers!"))
 			return FALSE

--- a/code/datums/gods/patrons/inhumen/graggar.dm
+++ b/code/datums/gods/patrons/inhumen/graggar.dm
@@ -47,16 +47,16 @@
 
 	for(var/obj/effect/decal/cleanable/blood/blood in oview(5, target))
 		bonus = min(bonus + 0.1, 2.5)
-	
+
 	if(!bonus)
 		return
-		
+
 	*situational_bonus = bonus
 	*conditional_buff = TRUE
 
 /datum/patron/inhumen/graggar/on_gain(mob/living/living)
 	. = ..()
-	
+
 	RegisterSignal(living, COMSIG_LIVING_DRINKED_LIMB_BLOOD, PROC_REF(on_drink_blood))
 
 /datum/patron/inhumen/graggar/proc/on_drink_blood(mob/living/drinker, mob/living/target)
@@ -66,7 +66,7 @@
 
 /datum/patron/inhumen/graggar/on_loss(mob/living/living)
 	. = ..()
-	
+
 	UnregisterSignal(living, COMSIG_LIVING_DRINKED_LIMB_BLOOD)
 
 // When bleeding, near blood on ground, zchurch, bad-cross, or ritual chalk
@@ -76,7 +76,7 @@
 	if(istype(get_area(follower), /area/rogue/under/cave/inhumen))
 		return TRUE
 	// Allows prayer near EEEVIL psycross
-	for(var/obj/structure/fluff/psycross/zizocross/cross in view(4, get_turf(follower)))
+	for(var/obj/structure/fluff/psycross/cross in view(4, get_turf(follower)))
 		if(cross.divine == TRUE)
 			to_chat(follower, span_danger("That accursed cross interupts my prayers!"))
 			return FALSE

--- a/code/datums/gods/patrons/inhumen/matthios.dm
+++ b/code/datums/gods/patrons/inhumen/matthios.dm
@@ -39,7 +39,7 @@
 	if(istype(get_area(follower), /area/rogue/under/cave/inhumen))
 		return TRUE
 	// Allows prayer near EEEVIL psycross
-	for(var/obj/structure/fluff/psycross/zizocross/cross in view(4, get_turf(follower)))
+	for(var/obj/structure/fluff/psycross/cross in view(4, get_turf(follower)))
 		if(cross.divine == TRUE)
 			to_chat(follower, span_danger("That acсursed cross interupts my prayers!"))
 			return FALSE

--- a/code/datums/gods/patrons/inhumen/zizo.dm
+++ b/code/datums/gods/patrons/inhumen/zizo.dm
@@ -14,7 +14,7 @@
 					/datum/action/cooldown/spell/tame_undead/zizo						= CLERIC_T3,
 					/datum/action/cooldown/spell/zizo/rituos 							= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/resurrect/zizo				= CLERIC_T3,
-					/datum/action/cooldown/spell/lacrima/zizo							= CLERIC_T4,	
+					/datum/action/cooldown/spell/lacrima/zizo							= CLERIC_T4,
 	)
 	confess_lines = list(
 		"PRAISE ZIZO!",
@@ -47,7 +47,7 @@
 	if(istype(get_area(follower), /area/rogue/under/cave/inhumen))
 		return TRUE
 	// Allows prayer near EEEVIL psycross
-	for(var/obj/structure/fluff/psycross/zizocross/cross in view(4, get_turf(follower)))
+	for(var/obj/structure/fluff/psycross/cross in view(4, get_turf(follower)))
 		if(cross.divine == TRUE)
 			to_chat(follower, span_danger("That accursed cross interrupts my prayers!"))
 			return FALSE

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -59,13 +59,13 @@
 	if(!prayer)
 		return
 
-	//If God can hear your prayer (long enough, no bad words, etc.)
-	if(patron.hear_prayer(follower, prayer))
-		// Stops prayers if you don't meet your patron's requirements to pray.
-		if(!patron?.can_pray(follower))
-			return
-		else
-			follower.sate_addiction(/datum/charflaw/addiction/godfearing)
+	// Stops prayers if you don't meet your patron's requirements to pray.
+	if(!patron?.can_pray(follower))
+		return
+	//If your patron can hear your prayer (long enough, no bad words, etc.)
+	if(!patron.hear_prayer(follower, prayer))
+		return
+	follower.sate_addiction(/datum/charflaw/addiction/godfearing)
 
 	/* admin stuff - tells you the followers name, key, and what patron they follow */
 	var/follower_ident = "[follower.key]/([follower.real_name]) (follower of [patron])"


### PR DESCRIPTION
## About The Pull Request
Found out that the checks for whether your prayer was valid and for giving you the 30 minute stress event were in the wrong order leading to weirdness, and _that_ was obscuring a second bug where all heretic prayers required specifically zizo crosses (rather than their cool fancy patron specific crosses) so now it properly just checks for any cross with divine = FALSE

## Testing Evidence
<img width="197" height="166" alt="image" src="https://github.com/user-attachments/assets/ba245b7b-7f0a-4592-ba1f-61d7b3c73d6c" /><br/>
<img width="444" height="25" alt="image" src="https://github.com/user-attachments/assets/8433aad0-472f-402e-b000-180e45c693bd" /><br/>
<img width="287" height="278" alt="image" src="https://github.com/user-attachments/assets/769829d8-3073-4d86-ae60-eb40db888157" /><br/>
<img width="518" height="197" alt="image" src="https://github.com/user-attachments/assets/5bfab1ee-11c9-46ce-ac69-cf336434f376" /><br/>

## Why It's Good For The Game
Lady of Heartbreak, ease my burdens

## Changelog

:cl:
fix: Ascendent worshippers may now pray at any inhumen shrine, not just zizocrosses
fix: Praying without meeting patron conditions no longer both tells you it didn't work, and gives you the status effect (without sating devout follower). Those three events are now properly synced to each other.
/:cl: