### PR TITLE
Moves some mundane fire stack weapons to the new scorch proc

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -199,9 +199,7 @@
 /obj/effect/particle_effect/smoke/fire_gas/smoke_mob(mob/living/carbon/M)
 	breathin = FALSE
 	if(..())
-		M.adjustFireLoss(6, 0)
-		M.adjust_fire_stacks(3)
-		M.ignite_mob()
+		apply_scorch_stack(M, 2, BODY_ZONE_CHEST)
 		M.emote("scream")
 		return TRUE
 

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -480,7 +480,7 @@
 	desc = "A pair of heavily curved claws, styled after beasts and used in combat by some of the more uncivilized warriors who try to mimic the fighting styles of the wild, or by anyone who thinks they can actually do that."
 	icon_state = "ironclaw"
 	icon = 'icons/roguetown/weapons/unarmed32.dmi'
-	wdefense = 3 // this is not a katar? 
+	wdefense = 3 // this is not a katar?
 	force = 20
 	possible_item_intents = list(/datum/intent/claw/cut/iron, /datum/intent/claw/lunge/iron, /datum/intent/claw/rend)
 	wbalance = WBALANCE_NORMAL
@@ -673,7 +673,7 @@
 	use_light = FALSE
 	spread_flame = FALSE
 	icon_state_ignited = "sci_firetongue_on"
-	
+
 /datum/component/ignitable/fluff/sci_sand
 	use_light = FALSE
 	spread_flame = FALSE
@@ -682,7 +682,7 @@
 /datum/component/ignitable/Initialize(...)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
-	
+
 	RegisterSignal(parent, COMSIG_STRUCTURE_ATTACKBY, PROC_REF(item_afterattack))
 	RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(item_afterattack))
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
@@ -743,8 +743,7 @@
 					ignited = TRUE
 			if(isliving(target))
 				var/mob/living/M = target
-				M.adjust_fire_stacks(5)
-				M.ignite_mob()
+				apply_scorch_stack(M, 4, BODY_ZONE_CHEST)
 				ignited = TRUE
 			if(ignited && single_use)
 				is_active = FALSE
@@ -882,9 +881,9 @@
 	desc = "A hardy repurposed dwarven mining warpick. Made to handle the dwellers above and below, both clad in rock and forged rock."
 	icon_state = "dwarpick"
 	possible_item_intents = list(/datum/intent/pick/heavy, /datum/intent/mace/strike)
-	gripped_intents = list(/datum/intent/pick/heavy, /datum/intent/mace/strike, /datum/intent/stab/militia)	
+	gripped_intents = list(/datum/intent/pick/heavy, /datum/intent/mace/strike, /datum/intent/stab/militia)
 	max_blade_int = 200 //10% increase over the steel pick
-	max_integrity = 660 
+	max_integrity = 660
 
 /obj/item/rogueweapon/sword/falchion/militia
 	name = "maciejowski"

--- a/code/game/objects/items/rogueweapons/ranged/ammo_bullets.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bullets.dm
@@ -217,7 +217,7 @@
 	name = "bronze sling bullet"
 	damage = 45
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/bronze
-	speed = 0.25 // Faster! 
+	speed = 0.25 // Faster!
 	icon_state = "bronzeslingbullet_proj"
 
 /obj/projectile/bullet/reusable/sling_bullet/iron
@@ -330,15 +330,15 @@
 
 /obj/projectile/bullet/sling_bullet/fire_pot
 	name = "fire pot"
-	damage = 10
+	damage = 20
 	damage_type = BURN
 	icon = 'icons/roguetown/weapons/ranged/sling_proj.dmi'
 	icon_state = "pot_proj"
 	range = 15
 	hitsound = 'sound/combat/hits/blunt/bluntsmall (1).ogg'
 	embedchance = 0
-	woundclass = BCLASS_BLUNT
-	flag = "blunt"
+	woundclass = BCLASS_BURN
+	flag = "fire"
 	speed = HEAVY_AMMO_SPEED
 	min_range = MIN_BULLET_RANGE
 	max_range = MAX_BULLET_RANGE
@@ -348,12 +348,7 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
-		M.adjust_fire_stacks(2)
-		M.adjustFireLoss(10)
-		M.ignite_mob()
-	var/turf/T = get_turf(target)
-	if(T)
-		new /obj/effect/hotspot(T, null, null, 15)
+		apply_scorch_stack(M, 2, def_zone)
 
 // GUNPOWDER AMMO
 /obj/projectile/bullet/reusable/bullet

--- a/code/game/objects/structures/rune_ward_structure.dm
+++ b/code/game/objects/structures/rune_ward_structure.dm
@@ -96,8 +96,7 @@
 	playsound(src, pick('sound/misc/explode/incendiary (1).ogg', 'sound/misc/explode/incendiary (2).ogg'), 80, TRUE)
 	new /obj/effect/hotspot(get_turf(src))
 	L.Slowdown(4)
-	L.adjust_fire_stacks(6)
-	L.ignite_mob()
+	apply_scorch_stack(L, 4, BODY_ZONE_CHEST)
 
 /obj/structure/rune_ward/chill
 	name = "frost rune"


### PR DESCRIPTION
## About The Pull Request
Currently `adjust_fire_stacks` is called on a lot of non-magic stuff but the new scorch stacks added in mage 3.0 are generally a lot better since they trigger bleeds rather than an arbitrary burndown state, making them more consistent and fun to fight both with and against since it interacts with the rest of the game.

It's been added to ~3~ 4 weapons:
- Militia spear special interaction: grab any `roguegrass` (reeds are a levy favorite) and light it on fire using a brazier or other fire source. Then smack someone, dealing 4 scorch stacks and proccing "charred" on your first hit. This used to be 5 burn stacks.
- Sling Fire Pots: deals 20 burn damage and 2 scorch stacks per hit. 13 shots per pouch, a maximum of 39 shots in your "ready rack" if you sacrifice both hips and your neck slot for sling pouches. Better than a spitfire for getting to charred, but finite (unlike a spitfire) and less per-shot damage. This used to be 10 blunt damage, 10 fire damage with 0 interaction with armor/resists as far as I could tell, and 2 burn stacks. Oh also it added extra burn stacks via putting a fire on a turf, which was removed due to using old burn procs (could be restored with a scorch version maybe).
- Rune ward: Actually kind of a missed one, now just does 4 scorch stacks and instantly procs charred. Seems questionable on its own but lets you instantly get a target to charred, letting all follow up scorch sources instantly proc charred. This used to be 6 burn stacks.
- New! Burning Gas Belchers: This one is kinda weird so I moved it to 2 scorch procs and removed its direct fire loss and burn stacks/ignition. It won't kill on its own but standing in the fire for a prolonged period of time is considered "a bad idea".

I would TM this first personally just to vibe check it although on paper and from playtesting it *seems* about where you'd expect the weapons to be.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Rune (I got stabbed for the vine)

https://github.com/user-attachments/assets/76daf3ee-7c60-430f-8385-284692105f9d

Spear

https://github.com/user-attachments/assets/58417f50-5402-4649-865d-e82a9db5bbdf

Firepot

https://github.com/user-attachments/assets/13b455a9-6390-445a-9cfd-d573f7961985

Burning Gas Belcher Grenade (no goblins were harmed in the making of this test video)

https://github.com/user-attachments/assets/bdac89be-4be3-4dcf-8783-84710a7874f2

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
In general, legacy fire procs kinda just suck for everyone involved in the interaction. They're horribly inconsistent and tend to do somewhere between nothing useful and complete armor bypass damage that eventually just puts you down with minimal warning, telegraphing, or counterplay. For those who remember goblin pyromancers pre-mage 3.0, you get what I mean. The scorch proc is a lot more balanced, compliments people hitting enemies with a stick (in all its many forms), and quite frankly feels a lot more satisfying.

I would argue this should be applied in more places over time but that's way outside the scope of my knowledge and the PR. As that would cover basically anything in the like 50 files that call `adjust_fire_stacks`, including stuff with wider balance implications than a spear, a sling bullet, and a rune.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Changed the adjust_fire_stacks proc to adjust_scorch_stack on the following weapons: Militia Spear special reed attack, Sling Fire pots, burning gas belchers, and Fire rune from the utility spell Rune Ward.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
