### PR TITLE
stop taxing your unpaid laborers

### DIFF
--- a/code/__HELPERS/civic_class.dm
+++ b/code/__HELPERS/civic_class.dm
@@ -9,7 +9,7 @@
 	switch(job)
 		if("Grand Duke", "Consort", "Prince", "Princess", "Regent", "Lord", "Lady", "Lord Castellan", "Duke", "Duchess", "Count", "Countess", "Noble")
 			return "KEEP"
-		if("Hand", "Clerk", "Councillor", "Seneschal", "Steward", "Suitor", "Servant")
+		if("Hand", "Clerk", "Councillor", "Seneschal", "Steward", "Suitor", "Servant", "Jester")
 			return "KEEP"
 		if("Knight", "Marshal", "Squire")
 			return "KEEP"
@@ -23,7 +23,7 @@
 			return "TOWN_TRANSIENT"
 		if("Peasant", "Towner", "Sidefolk", "Serf", "Vagabond", "Bathhouse Attendant", "Cook", "Tapster", "Soilson")
 			return "TOWN_PEASANT"
-		if("Innkeeper", "Guildsman", "Archivist", "Apothecary", "Tailor", "Physician", "Tradesmith", "Magicians Associate", "Jester", "Burgher", "Resident", "Keeper")
+		if("Innkeeper", "Guildsman", "Archivist", "Apothecary", "Tailor", "Physician", "Tradesmith", "Magicians Associate", "Burgher", "Resident", "Keeper")
 			return "TOWN_BURGHER"
 		if("Priest", "Vice Priest", "Acolyte", "Druid", "Sexton", "Templar", "Martyr", "Clergy")
 			return "TOWN_CLERGY"

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -104,8 +104,8 @@ SUBSYSTEM_DEF(treasury)
 	/// Steward-settable floor. Stockpile refuses purchases when Crown's Purse would drop below this.
 	var/stockpile_purchase_floor = STOCKPILE_CROWN_PURCHASE_FLOOR_DEFAULT
 	/// A feature for the Steward to unlock once the Crown's trade volume reaches 10k
-	/// Basically help automate the import, fitting in line with my idea of active trade 
-	/// Converting to passive convenience later. Later on I might gate it through a 
+	/// Basically help automate the import, fitting in line with my idea of active trade
+	/// Converting to passive convenience later. Later on I might gate it through a
 	/// Total trade volumes converting into multiple chooseable upgrades but for now
 	/// It just automatically unlock an upgrade with no real choice
 	var/royal_custom_unlocked = FALSE
@@ -719,7 +719,7 @@ SUBSYSTEM_DEF(treasury)
 		return POLL_TAX_CAT_INQUISITION
 	if((H.job in GLOB.church_positions) || HAS_TRAIT(H, TRAIT_AGENT_CHURCH))
 		return POLL_TAX_CAT_CLERGY
-	if(H.job in GLOB.courtier_positions)
+	if((H.job in GLOB.courtier_positions) || H.job == "Court Agent")
 		return POLL_TAX_CAT_COURTIER
 	if((H.job in GLOB.garrison_positions) || H.job == "Squire")
 		return POLL_TAX_CAT_GARRISON


### PR DESCRIPTION
## About The Pull Request
Puts Court Agent in the courtiers tax bracket so they stop getting taxed while doing unpaid labor for the Hand

## Testing Evidence
compiles; same as the check 2 lines below it

## Why It's Good For The Game
cagents being unpaid is one thing, but they probably. shouldn't be taxed the same as advents while risking life and limb for the crown for no pay

## Changelog

:cl:
balance: Court Agents are now in the courtier tax bracket, i.e. they don't get taxed by default
/:cl: