### PR TITLE
Changes peppermill recipe

### DIFF
--- a/code/modules/roguetown/roguecrafting/crafting/houseware.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/houseware.dm
@@ -113,9 +113,9 @@
 	result = list(
 		/obj/item/reagent_containers/peppermill
 		)
-	reqs = list(/obj/item/grown/log/tree/small = 1, /obj/item/natural/whetstone = 1, /obj/item/reagent_containers/food/snacks/pepper = 5) //Currently unrefillable, so see this as an equal exchange.
-	skillcraft = /datum/skill/craft/carpentry //If this feels a bit too oppressive, try reducing the difficulty level a bit. Remember that it shouldn't be easier to obtain than importing, otherwise.
-	craftdiff = 4
+	reqs = list(/obj/item/grown/log/tree/small = 1, /obj/item/reagent_containers/food/snacks/pepper = 5) //Currently unrefillable, so see this as an equal exchange.
+	skillcraft = /datum/skill/craft/cooking //If this feels a bit too oppressive, try reducing the difficulty level a bit. Remember that it shouldn't be easier to obtain than importing, otherwise.
+	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/survival/woodtray
 	name = "wooden trays (x2)"


### PR DESCRIPTION
## About The Pull Request

Changes peppermill recipe to be more geared towards cooking skill. Removes millstone from recipe (crafting pepper already uses a mill)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Carpentry skill effectively locked out peppermill crafting from roles that actually plan to cook. The recipe doesn't really have a place in the game where no job is likely to have the means to make and use it in a round.

Recipe still requires 5 pepper, making obtaining the ingredients quite time consuming, needing farming or a lot of bush-picking. It's still generally easier to just go to the merchant and buy it.

5 cooking skill is still a steep crafting requirement, necessitating a dedicated cooking job to make.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: rebalanced peppermill recipe to cooking 5(M) instead of carpentry 4(E)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
