### PR TITLE
voyeur no longer nigh impossible to sate

### DIFF
--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -51,6 +51,11 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 	if(event.stacks >= event.max_stacks)
 		return event
 	event.stacks++
+
+	if(event.stressadd <= -2)
+		for(var/mob/living/carbon/human/L in viewers(4,src))
+			if(L != src && L.has_flaw(/datum/charflaw/addiction/voyeur))
+				L.sate_addiction(/datum/charflaw/addiction/voyeur)
 	return event
 
 /mob/living/carbon/remove_stress(event_type)

--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 	event.stacks++
 
 	if(event.stressadd <= -2)
-		for(var/mob/living/carbon/human/L in viewers(4,src))
+		for(var/mob/living/carbon/human/L in viewers(2,src))
 			if(L != src && L.has_flaw(/datum/charflaw/addiction/voyeur))
 				L.sate_addiction(/datum/charflaw/addiction/voyeur)
 	return event


### PR DESCRIPTION
## About The Pull Request
Voyeur, while flavorful, essentially just leads to you eating a fornuke (not just a moodnuke but an actual debuff to your fortune now! incredible), because the conditions for sating it - being next to someone when they sate an addiction-type vice - are so incredibly specific and awkward to achieve that it's never going to happen without being super gamer about it.

This fixes that by making it so that any positive stress gain - that is, any time someone gains a positive stress event of moderate power, like high-quality food or high-skill music, will also work, if you're nearby when it happens. This should let you roleplay an actual people-pleaser without having to magically know their exact cravings and carry a bunch of zigs around to give to smoker vice havers or something. It also means people running flawless (weirdly common) don't just become useless to you.

## Testing Evidence
This is understandably hard to test on local, but it compiles and the code is copied from the sadist vice sating code with just a bit changed

## Why It's Good For The Game
Answered in part 1. The vice shouldn't just be impossible to sate n this should be better for roleplaying people-pleasers, aka the only reason to take the vice in the first place. Still harder to sate than devout follower, smoker, nympho, etc. so it shouldn't be a balance issue

## Changelog

:cl:
add: Voyeur no longer requires sating other peoples' vices to sate. You now just need to do anything that gives them a sufficiently-strong mood buff; basic things like being full or hydrated or basic-level good food won't work, but higher tier foods and high-skill music should.
/:cl:
