### PR TITLE
replace woodwalker virtue with outdoorsman

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -35,7 +35,6 @@
 		/datum/virtue/utility/notable, //No resident (????) or free-money-stash gnolls
 		/datum/virtue/utility/bronzelimbs, //They should feel pain in their limbs given their state
 		/datum/virtue/movement/acrobatic, //This should be given to them when they are actually after a Hunted
-		/datum/virtue/utility/woodwalker, //This should be given to them when they are actually after a Hunted
 		/datum/virtue/combat/crossbowman,	//Absolutely not on a class like this
 		/datum/virtue/combat/bowman
 		)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag.dm
@@ -35,7 +35,6 @@
 		/datum/virtue/utility/notable, //No resident (????) or free-money-stash hags
 		/datum/virtue/utility/bronzelimbs, //They should feel pain in their limbs given their state
 		/datum/virtue/movement/acrobatic, //This should be given to them when they are actually after a Hunted
-		/datum/virtue/utility/woodwalker, //This should be given to them when they are actually after a Hunted
 		/datum/virtue/combat/crossbowman,	//Absolutely not on a class like this
 		/datum/virtue/combat/bowman, // I'd rather not see combat Hags
 		/datum/virtue/utility/feytouched, // They are already FAE

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -370,10 +370,11 @@
 		var/obj/item/bodypart/new_limb = new to_attach()
 		new_limb.attach_limb(recipient)
 
+// Type path kept as-is so savefiles that still hold the old Woodwalker virtue load into this one instead of falling back to None.
 /datum/virtue/utility/woodwalker
-	name = "Woodwalker"
-	desc = "After years of training in the wilds, I've learned to traverse the woods confidently, without breaking any twigs. I can even step lightly on leaves without falling."
-	added_traits = list(TRAIT_WOODWALKER, TRAIT_OUTDOORSMAN)
+	name = "Outdoorsman"
+	desc = "Years spent living rough have taught me to make a bed of the wilds. I can sleep on a treebranch as soundly as I would in a bedroll."
+	added_traits = list(TRAIT_OUTDOORSMAN)
 
 /datum/virtue/heretic/zchurch_keyholder
 	name = "Defiled Keyholder"


### PR DESCRIPTION
## About The Pull Request

kills woodwalker as a pickable virtue. the classes getting it keep it.

## Testing Evidence

should be fine

## Why It's Good For The Game

way too good and way too accessible for what it is.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Remove woodwalker as a virtue, replacing with outdoorsman.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
