### PR TITLE
Add Allspice to merchant, cheaper sugar

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/food.dm
+++ b/code/modules/cargo/packsrogue/merchant/food.dm
@@ -129,6 +129,16 @@
 	contains = list(
 					/obj/item/reagent_containers/food/snacks/sugar,
 					/obj/item/reagent_containers/food/snacks/sugar,
+					/obj/item/reagent_containers/food/snacks/sugar,
+					/obj/item/reagent_containers/food/snacks/sugar,
+					/obj/item/reagent_containers/food/snacks/sugar,
+				)
+
+/datum/supply_pack/rogue/food/allspice
+	name = "Allspice"
+	cost = 40
+	contains = list(
+					/obj/item/reagent_containers/food/snacks/allspice,
 				)
 
 /datum/supply_pack/rogue/food/chocolate

--- a/code/modules/cargo/packsrogue/merchant/food.dm
+++ b/code/modules/cargo/packsrogue/merchant/food.dm
@@ -136,7 +136,7 @@
 
 /datum/supply_pack/rogue/food/allspice
 	name = "Allspice"
-	cost = 40
+	cost = 50 //about double the price of its crafting ingredients
 	contains = list(
 					/obj/item/reagent_containers/food/snacks/allspice,
 				)


### PR DESCRIPTION
## About The Pull Request

Merchant can now import allspice at a fairly hefty premium 
Made merchant-imported sugar give 5 instead of 2, lowering the base cost to 9 per unit (taxes notwithstanding)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

The spice must flow

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added allspice to merchant
balance: Merchant sugar is cheaper (less cheap than stockpile of course)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
