### PR TITLE
Devotion Bugfix Package

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -35,6 +35,7 @@
 #define DREAM_ITEM				(1<<13) //Otherworldly items from Abyssor's dream. Tend to have special effects!
 #define FRESH_FOOD_ITEM			(1<<14) // Currently only used for fresh meat from butchering to differentiate it from stockpile magic meat.
 #define HAG_ITEM				(1<<15) // Wyrd hag items, they self repair when on grass tiles!
+#define FLOATING_ITEM			(1<<16) // Prevents falling through z-levels. Applied temporarily to items being retrieved from storage.
 
 // Flags for the clothing_flags var on /obj/item/clothing
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -159,7 +159,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	/// Original values for vars overridden by the active alt grip state.
 	var/list/alt_grip_restore_vars
 	///intents while gripped, replacing main intents. if list != null, will allow the weapon to be wielded. set to null to remove wielding.
-	var/list/gripped_intents 
+	var/list/gripped_intents
 	var/force_wielded = 0
 	var/gripsprite = FALSE //use alternate grip sprite for inhand
 	var/wieldsound = FALSE
@@ -1826,7 +1826,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 * - Second: A short description explaining in-character why this item has that status.
 *
 * When set, highlights the item's mob examine name/tooltip with obvious heretical flavor when worn/held.
-* 
+*
 * If this returns null, the item will not be shown as heretical.*/
 /obj/item/proc/get_examine_highlight_status()
 	return null
@@ -1846,7 +1846,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return get_examine_highlight_labeled_string(severity, "[allcaps ? uppertext(highlight_itis) : highlight_itis]: [allcaps ? uppertext(heresy_desc) : heresy_desc]")
 	return null
 
-/// Returns `label_string` HTML formatted depending on the provided highlight status (see `code\__DEFINES\highlight_examine_defines.dm`). 
+/// Returns `label_string` HTML formatted depending on the provided highlight status (see `code\__DEFINES\highlight_examine_defines.dm`).
 /obj/item/proc/get_examine_highlight_labeled_string(examine_highlight_type, label_string)
 	if(!examine_highlight_type || !label_string)
 		return null
@@ -1854,7 +1854,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/highlight_symbol = get_examine_highlight_symbol(examine_highlight_type)
 	return "<font color = '[highlight_color]'>[highlight_symbol] [label_string] [highlight_symbol]</font>"
 
-/// Returns a full HTML-formatted tooltip string whose contents depend on the given highlight status type (See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`). 
+/// Returns a full HTML-formatted tooltip string whose contents depend on the given highlight status type (See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`).
 /obj/item/proc/get_examine_highlight_tooltip_string(list/examine_highlight_status)
 	if(!examine_highlight_status)
 		return null
@@ -1863,7 +1863,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	return "[highlight_reason]<br>[highlight_explanation]"
 
-/// See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`. 
+/// See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`.
 /obj/item/proc/get_examine_highlight_adjective(highlight_type)
 	switch(highlight_type)
 		if(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING)
@@ -1884,7 +1884,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			return "ALARMINGLY ODD"
 	return null
 
-/// See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`. 
+/// See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`.
 /obj/item/proc/get_examine_highlight_explanation(highlight_type)
 	switch(highlight_type)
 		if(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING)
@@ -1905,7 +1905,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			return EXAMINEHIGHLIGHT_TOOLTIP_HERESYSEVERITY_VERYODD
 	return null
 
-/// See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`. 
+/// See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`.
 /obj/item/proc/get_examine_highlight_color(highlight_type)
 	switch(highlight_type)
 		if(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING)
@@ -1925,8 +1925,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(EXAMINEHIGHLIGHT_HERESYSEVERITY_VERYODD)
 			return COLOR_HERESYSEVERITY_VERYODD //Its meant to be a double-take. Intentional.
 	return null
-	
-/// See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`. 
+
+/// See `proc/get_examine_highlight_status()` and `code\__DEFINES\highlight_examine_defines.dm`.
 /obj/item/proc/get_examine_highlight_symbol(highlight_type)
 	switch(highlight_type)
 		if(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING)
@@ -1946,3 +1946,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(EXAMINEHIGHLIGHT_HERESYSEVERITY_VERYODD)
 			return EXAMINEHIGHLIGHT_SYMBOL_HERESYSEVERITY_VERYODD //Its meant to be a double-take. Intentional.
 	return null
+
+/obj/item/can_zFall(turf/source, levels, turf/target, direction)
+	if(item_flags & FLOATING_ITEM)
+		return FALSE
+	. = ..()
+
+/obj/item/proc/remove_floating() // needed for timers
+	item_flags &= ~FLOATING_ITEM

--- a/code/game/objects/items/storage/new_storage/tetris.dm
+++ b/code/game/objects/items/storage/new_storage/tetris.dm
@@ -771,6 +771,9 @@
 		seeing_mob.client.screen -= removed
 	if(isitem(removed))
 		var/obj/item/removed_item = removed
+		if(!(removed_item.item_flags & FLOATING_ITEM))
+			addtimer(CALLBACK(removed_item, TYPE_PROC_REF(/obj/item, remove_floating)), 1)
+			removed_item.item_flags |= FLOATING_ITEM
 		removed_item.item_flags &= ~IN_STORAGE
 		if(ismob(parent.loc))
 			carrying_mob = parent.loc

--- a/code/modules/mob/living/mob_pickup.dm
+++ b/code/modules/mob/living/mob_pickup.dm
@@ -8,6 +8,7 @@
 /obj/item/mob_item/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_QDELETING, PROC_REF(revert))
+	become_hearing_sensitive()
 
 /obj/item/mob_item/container_resist(mob/living/user)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -7,7 +7,7 @@
 // if you add mechanical differences between the subtypes i will find you.
 
 /*
-	Familiar list and buffs below. 
+	Familiar list and buffs below.
 	Sprites by Diltyrr (those aren't good gah)
 
 	Quick AI pictures idea for each of them : https://imgbox.com/g/MvanomKazA
@@ -161,6 +161,12 @@
 	src.forceMove(vestige)
 	vestige.desc = "The vestige of [src.name], a fallen [GLOB.familiar_display_names[src.type]]. Likely worth a lot to the magos that summoned [src.p_them()]!"
 
+/mob/living/simple_animal/pet/familiar/void/revive(full_heal, admin_revive)
+	if(..()) // successful revive
+		if(essences_consumed.Find("fae")) // flight is lost on death
+			movement_type = FLYING
+		. = TRUE
+
 /mob/living/simple_animal/pet/familiar/proc/TryAddFlight()
 	if(movement_type & (FLYING | FLOATING))
 		add_verb(src, list(/mob/living/simple_animal/proc/fly_up,
@@ -174,7 +180,7 @@
 	for(var/obj/item/grabbing/grab in grabbedby) //Grabbed by the mouth
 		if(grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH)
 			return FALSE
-			
+
 	return TRUE
 
 /mob/living/simple_animal/pet/familiar/is_literate()
@@ -412,7 +418,7 @@
 						qdel(ing)
 					src.reagents.add_reagent(/datum/reagent/yuck, min(reagents.maximum_volume - reagents.total_volume, 90)) // do not overfill
 					// Learn from your failure (Yeah you can technically still grind this way you just blow through a lot of ingredients)
-					familiar_summoner?.adjust_experience(/datum/skill/craft/alchemy, amt2raise, FALSE) 
+					familiar_summoner?.adjust_experience(/datum/skill/craft/alchemy, amt2raise, FALSE)
 					return
 				for(var/obj/item/ing in src.ingredients)
 					qdel(ing)
@@ -567,7 +573,7 @@
 	maxHealth = WOLF_HEALTH_UNDEAD // more durable than the others
 	health = WOLF_HEALTH_UNDEAD
 	speak_emote = list ("rumbles", "grinds")
-	inherent_spell = list(/datum/action/cooldown/spell/magicians_stone/elemental) 
+	inherent_spell = list(/datum/action/cooldown/spell/magicians_stone/elemental)
 	t1_spell = /datum/action/cooldown/spell/arcyne_forge/elemental
 	t2_spell = /datum/action/cooldown/spell/arcyne_forge/elementalt2
 	valid_healing_items = list(/obj/item/magic/elemental)
@@ -615,7 +621,7 @@
 	var/list/ret = ..()
 	var/knows = FALSE
 	knows |= istype(user, /mob/living/simple_animal/pet/familiar)
-	// kind of horrid but this ensures only "proper" casters get to be knowers 
+	// kind of horrid but this ensures only "proper" casters get to be knowers
 	if(user.mind)
 		knows |= (user.mind.mage_aspect_config && user.mind.mage_aspect_config["major"])
 	if(knows)


### PR DESCRIPTION
## About The Pull Request
(note that devotion is my name this doesn't touch the devotion mechanics)
Fixes a few bugs reported in the discord. Namely:
- taking items out of storage while on an open space tile - either by flying, or standing on leaves with woodwalker - caused them to both fall on people below you AND be put in your hand afterwards. fixed by adding a 1-tick floating effect to items removed from storage
- void familiars were losing flight on death, caused by an interaction with the death code removing flying and the revive code checking for initial movement type, not accounting for mobs that gained it later. fixed by adding a check for it to the void familiar revive proc
- familiars, and other picked-up mobs, kept losing their ability to hear - an incredibly inconsistent bug to replicate. turns out this was not because of perspective shenanigans, but because the containing item was never marked as hearing sensitive, and therefore never added to important_recursive_contents. fixed by, you guessed it, marking it as hearing sensitive

## Testing Evidence
Didn't get screenshots, but it tested what it could. The latter two bugfixes are a little hard to test on local, but like. They're like 1 line each. First bugfix has been tested properly, the latter two are assumed to work by way of compiling.

## Why It's Good For The Game
Bugs bad fix good putting in my non-feature PR quota

## Changelog

:cl:
fix: Removing items from storage while standing on open space - flying, climbing, walking on leaves with woodwalker - no longer drops the items on people below you in the same tick they get put in your hand, which could be exploited to infinitely brick people to death with only 1 brick
fix: Void familiars no longer lose flight when dying and reviving
fix: Picked up mobs should no longer be or become deaf
/:cl:
