### PR TITLE
Change 12 points reset aspect budget back to 4

### DIFF
--- a/code/__DEFINES/spell_defines.dm
+++ b/code/__DEFINES/spell_defines.dm
@@ -215,7 +215,7 @@
 #define COMSIG_MOB_KICKED_SUCCESSFUL "mob_kicked_successful" //from /mob/living/proc/try_kick(). Sent to target after a kick lands (past dodge/parry).
 
 // Aspect
-#define ASPECT_RESET_BUDGET 12
+#define ASPECT_RESET_BUDGET 4
 #define ASPECT_RESET_COST_MAJOR 4
 #define ASPECT_RESET_COST_MINOR 2
 #define ASPECT_RESET_COST_UTILITY 1

--- a/tgui/packages/tgui/interfaces/Grimoire/GrimoireUtilitiesDetail.tsx
+++ b/tgui/packages/tgui/interfaces/Grimoire/GrimoireUtilitiesDetail.tsx
@@ -9,7 +9,7 @@ export const GrimoireUtilitiesDetail = ({
   pointsBudget,
   initialSetup,
   resetBudget,
-  resetBudgetMax = 12,
+  resetBudgetMax = 4,
   readOnly = false,
 }: {
   spells: Spell[];


### PR DESCRIPTION
## About The Pull Request
Change 12 points reset aspect budget back to 4
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I did not

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
12 points was meant to be a thing during Mage 3's more volatile day. It is no longer more volatile day. So the budget is going back

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Change 12 points reset aspect budget back to 4 for mage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
