### PR TITLE
polish qol

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -160,7 +160,7 @@
 		if(do_after(user, 50 - user.STASPD*2, target = O))
 			thing.polished = 1
 			uses--
-			if((thing.color == null) || (thing.color == "#ffffff") || (thing.color == CLOTHING_WHITE))
+			if((thing.color == null) || (thing.color == "#ffffff"))
 				thing.remove_atom_colour(FIXED_COLOUR_PRIORITY)
 				thing.add_atom_colour("#635e65", FIXED_COLOUR_PRIORITY)
 			thing.RegisterSignal(thing, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(remove_polish))

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -123,16 +123,18 @@
 	. = ..()
 	switch(polished)
 		if(1)
-			. += span_info("It has some polishing compound on it.")
-		if(2, 3)
-			. += span_info("It's been thoroughly brushed.")
+			. += span_info("It has some polishing compound on it. <i>It needs a coarse brushing.</i>")
+		if(2)
+			. += span_info("It's been roughly brushed. <i>It needs a fine brushing.</i>")
+		if(3)
+			. += span_info("It's been thoroughly brushed. <i>It needs a wash.</i>")
 		if(4)
 			. += span_green("It's been nicely polished.")
 
 /obj/item/polishing_cream
 	icon = 'icons/roguetown/items/misc.dmi'
 	name = "polishing cream"
-	desc = "A pure silver compound made for making the best metals shine."
+	desc = "A pure silver compound made for making even the worst metals shine."
 	icon_state = "cream"
 	w_class = WEIGHT_CLASS_SMALL
 	dropshrink = 0.8
@@ -150,13 +152,17 @@
 	var/obj/item/thing = O
 	if(!thing.anvilrepair)
 		return ..()
-	if((HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) || HAS_TRAIT(user, TRAIT_SELF_SUSTENANCE) || user.get_skill_level(thing.anvilrepair)) && thing.polished == 0 && obj_integrity <= max_integrity)
+	if((HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) || HAS_TRAIT(user, TRAIT_SELF_SUSTENANCE) || user.get_skill_level(thing.anvilrepair)) && thing.polished == 0)
+		if(thing.obj_integrity < thing.max_integrity)
+			user.balloon_alert(user, "<font color = '#ffffff'>Repair it fully first!</font>")
+			return
 		to_chat(user, span_info("I start applying some compound to \the [thing]..."))
 		if(do_after(user, 50 - user.STASPD*2, target = O))
 			thing.polished = 1
 			uses--
-			thing.remove_atom_colour(FIXED_COLOUR_PRIORITY)
-			thing.add_atom_colour("#635e65", FIXED_COLOUR_PRIORITY)
+			if((thing.color == null) || (thing.color == "#ffffff") || (thing.color == CLOTHING_WHITE))
+				thing.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+				thing.add_atom_colour("#635e65", FIXED_COLOUR_PRIORITY)
 			thing.RegisterSignal(thing, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(remove_polish))
 			if(uses <= 8)
 				smeltresult = null
@@ -167,7 +173,7 @@
 /obj/item/armor_brush
 	icon = 'icons/roguetown/items/misc.dmi'
 	name = "fine brush"
-	desc = "A coarse brush for scrubbing armor thoroughly. Made of the finest Lupin hair."
+	desc = "A two-sided brush for scrubbing armor thoroughly. Made of the finest Lupin hair."
 	icon_state = "brush_0"
 	w_class = WEIGHT_CLASS_SMALL
 	smeltresult = null
@@ -205,8 +211,9 @@
 			playsound(loc,"sound/foley/scrubbing[pick(1,2)].ogg", 100, TRUE)
 			if(do_after(user, 50 - user.STASTR*1.5, target = O))
 				thing.polished = 2
-				thing.remove_atom_colour(FIXED_COLOUR_PRIORITY)
-				thing.add_atom_colour("#9e9e9e", FIXED_COLOUR_PRIORITY)
+				if(thing.color == "#635e65")
+					thing.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+					thing.add_atom_colour("#9e9e9e", FIXED_COLOUR_PRIORITY)
 
 	else if(thing.polished == 2 && !roughness)
 		if((HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) || HAS_TRAIT(user, TRAIT_SELF_SUSTENANCE) || user.get_skill_level(thing.anvilrepair)))
@@ -214,8 +221,9 @@
 			playsound(loc,"sound/foley/scrubbing[pick(1,2)].ogg", 100, TRUE)
 			if(do_after(user, 50 - user.STASTR*1.5, target = O))
 				thing.polished = 3
-				thing.remove_atom_colour(FIXED_COLOUR_PRIORITY)
-				thing.add_atom_colour("#cccccc", FIXED_COLOUR_PRIORITY)
+				if(thing.color == "#9e9e9e")
+					thing.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+					thing.add_atom_colour("#cccccc", FIXED_COLOUR_PRIORITY)
 
 /obj/item/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
 	. = ..()
@@ -237,8 +245,8 @@
 /obj/item/proc/remove_polish(datum/source, strength) // kill polska
 	if(polished == 3 && obj_integrity >= max_integrity)
 		polished = 4
-		remove_atom_colour(FIXED_COLOUR_PRIORITY)
-		add_atom_colour("#ffffff", FIXED_COLOUR_PRIORITY)
+		if(color == "#cccccc")
+			remove_atom_colour(FIXED_COLOUR_PRIORITY)
 		polish_bonus = ceil(max_integrity * 0.10)
 		max_integrity += polish_bonus
 		obj_integrity += polish_bonus
@@ -251,8 +259,9 @@
 	else if(polished < 4)
 		polished = 0
 		polish_bonus = 0
-		remove_atom_colour(FIXED_COLOUR_PRIORITY)
-		UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
+		if((color == "#635e65") || (color == "#9e9e9e") || (color == "#cccccc"))
+			remove_atom_colour(FIXED_COLOUR_PRIORITY)
+			UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
 
 /obj/effect/temp_visual/armor_glint
 	name = "glint"
@@ -295,4 +304,4 @@
 
 /datum/component/metal_glint/proc/stop_process()
 	STOP_PROCESSING(SSobj, src)
- 
+


### PR DESCRIPTION
## About The Pull Request

There's probably a way better way to do this.
Polish QOL changes:

- Polished items will now tell you what stage they are on exactly, rather than stages two and three being lumped together.
- Each stage gives you a hint on what needs to be done next in the examine text.
- Polish will yell at you and prevent you from applying it if you are attempting to apply it to an item that isn't at maximum integrity.
- EXTREMELY SHITCODED THERE'S PROBABLY A BETTER WAY TO DO THIS BUT I DIDN'T WANNA CREATE VARS but if an item is dyed or has a color value of anything other than pure white, the color alterations of polishing's stages won't forcibly alter its color. This means you can polish dyed items without fucking up the dye. This is major QOL for anyone who has either tried to polish their dyed or armor, or has had their armor polished, dyed, broken, and then have to reapply the polish.

I also removed a `&& obj_integrity <= max_integrity` check from the initial 'can we polish this' item checks, I'm not sure... what it did? Or what it was supposed to do? It's checking for `obj_integrity` and `max_integrity` seemingly on nothing, since it's not prefixed by `thing.` but I don't see any adverse effects from it?

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Can't really screenshot the process and I didn't wanna make a video so I've done the following tests and they've all worked.

Dyed a piece of armor. Applied polish. Brushed it. It polished properly; armor was still dyed.
Applied polish to an undyed piece of armor. Brushed it. It polished properly; armor went through polish stage colors properly.
Dyed a piece of armor. Applied polish. Immediately washed it; polish was removed, armor was still dyed.
Applied polish to an undyed piece of armor. Immediately washed it; polish was removed, armor returned to default colors.
Damaged a piece of armor. Couldn't apply polish to it. Fixed it. Could apply polish to it.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

QOL? This just fixes some of my grievances with polishing as a mechanic.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Polished items will now tell you what stage they are on exactly, rather than stages two and three being lumped together.
qol: Each stage gives you a hint on what needs to be done next in the examine text.
qol: Polish will yell at you and prevent you from applying it if you are attempting to apply it to an item that isn't at maximum integrity.
qol: If an item is dyed or has a color value of anything other than pure white, polish won't forcibly alter its color. This means you can polish dyed items without fucking up the dye. This is major QOL for anyone who has either tried to polish their dyed or armor, or has had their armor polished, dyed, broken, and then have to reapply the polish.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
