### PR TITLE
[Fix] Blackblooded Inquisition self-scare

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1076,7 +1076,7 @@
 			. += span_redtext("[m3] strange glowing eyes and fangs!")
 
 		//Blackblood Inquisition trauma
-		if(HAS_TRAIT(src, TRAIT_INQUISITION) && HAS_TRAIT(user, TRAIT_BLACKBLOOD))
+		if((HAS_TRAIT(src, TRAIT_INQUISITION) && HAS_TRAIT(user, TRAIT_BLACKBLOOD)) && src != user)
 			var/mob/living/carbon/carbs = user
 			if(HAS_TRAIT(user, TRAIT_PSYDONIAN_GRIT) || HAS_TRAIT(user, TRAIT_NOMOOD))
 				return


### PR DESCRIPTION
## About The Pull Request

- Seems like you could bypass my conditionals for triggering the trauma if you examined yourself. Found this while idly browsing through OV's repository. Nice catch.

## Testing Evidence

Compiles, 1 line of kod.

## Why It's Good For The Game

Fug Bixes

## Changelog
:cl:
fix: Blackblooded Inquisitors are less dramatic now.
/:cl: