### PR TITLE
[QoL] Small gatherers QoL

### DIFF
--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -121,7 +121,7 @@
 	name = "small log"
 	desc = "Piece of lumber cut from a larger log. Suitable for building."
 	icon_state = "logsmall"
-	grid_width = 64
+	grid_width = 32
 	grid_height = 96
 	attacked_sound = 'sound/misc/woodhit.ogg'
 	max_integrity = 30

--- a/code/modules/cargo/packsrogue/merchant/apparel.dm
+++ b/code/modules/cargo/packsrogue/merchant/apparel.dm
@@ -169,6 +169,16 @@
 	cost = 13
 	contains = list(/obj/item/storage/backpack/rogue/satchel/short/black)
 
+/datum/supply_pack/rogue/apparel/meatpouch
+	name = "Game Satchel"
+	cost = 13
+	contains = list(/obj/item/storage/meatbag)
+
+/datum/supply_pack/rogue/apparel/magebag
+	name = "Scholar's Pouch"
+	cost = 13
+	contains = list(/obj/item/storage/magebag)
+
 /datum/supply_pack/rogue/apparel/backpack
 	name = "Backpack"
 	cost = 18

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -8,7 +8,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/miner
 
 	category_tags = list(CTAG_PILGRIM, CTAG_TOWNER)
-	traits_applied = list(TRAIT_DARKVISION, TRAIT_SMITHING_EXPERT) // Smithing Expert, because from what I observe of miner players they tend to do smithing far more than farming etc.
+	traits_applied = list(TRAIT_DARKVISION, TRAIT_SMITHING_EXPERT, TRAIT_MASTER_MASON) // Smithing Expert, because from what I observe of miner players they tend to do smithing far more than farming etc.
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_CON = 1,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
@@ -11,7 +11,7 @@
 	maximum_possible_slots = 1
 	pickprob = 5
 	category_tags = list(CTAG_TOWNER)
-	traits_applied = list(TRAIT_DARKVISION, TRAIT_SMITHING_EXPERT)
+	traits_applied = list(TRAIT_DARKVISION, TRAIT_SMITHING_EXPERT, TRAIT_MASTER_MASON)
 	subclass_stats = list(
 		STATKEY_LCK = 4,
 		STATKEY_STR = 2,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodworker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodworker.dm
@@ -6,7 +6,7 @@
 	forbidden_races = list(RACES_DESPISED)
 
 	outfit = /datum/outfit/job/roguetown/adventurer/woodworker
-	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)
+	traits_applied = list(TRAIT_HOMESTEAD_EXPERT, TRAIT_MASTER_CARPENTER)
 	cmode_music = 'sound/music/cmode/towner/combat_towner2.ogg'
 
 	category_tags = list(CTAG_PILGRIM, CTAG_TOWNER)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Gives Towner Woodworkers the Master_Carpenter trait so they get more logs per harvest.

Gives Towner Miner (and legendary) the master mason one so they get more blocks per chisel.

Adds to the Apparel category (so tailor, wretch and merchant I think) the game satchel (meat bag) and schoolar pouch (reagents bag).

Makes logs 3x1 instead of 3x2.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="657" height="310" alt="image" src="https://github.com/user-attachments/assets/413e48ee-d130-402d-bed3-1247a5129219" />

<img width="1050" height="740" alt="image" src="https://github.com/user-attachments/assets/87c88dcd-bcaa-4031-8736-a83418855a1e" />

<img width="1047" height="713" alt="image" src="https://github.com/user-attachments/assets/056f6568-fd63-40ec-90ca-0c50db0007f8" />

<img width="723" height="542" alt="image" src="https://github.com/user-attachments/assets/68b2dd8e-f2d7-476a-80bc-29493f65e8eb" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

For starters, make building for non architects less of an ordeal, at least when its on their speciality, the architect still has access to all and its aided by the guild, so their place is not in peril at all.

Second, makes the gatherer bags which are as easy to make as short satchel versions more easily available, many dont know they even exist.

Finally, makes the log scarcity more manegeably with the added benefit it makes it less of a hell and doesnt actually changes prices, switching from 2 logs to 4 logs per bag, or 3 to 6 if manually added, shouldnt change the reliaibility on carts, while still making it less of a pain for its users.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol:Gives Towner Woodworkers the Master_Carpenter trait so they get more logs per harvest.
qol:Gives Towner Miner (and legendary) the master mason one so they get more blocks per chisel.
qol:Adds to the Apparel category (so tailor, wretch and merchant I think) the game satchel (meat bag) and schoolar pouch (reagents bag).
qol:Makes logs 3x1 instead of 3x2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
