### PR TITLE
bug nobody noticed was a bug because nobody uses these recipes

### DIFF
--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -218,6 +218,7 @@
 		/obj/item/natural/fibers = 1,
 		/obj/item/natural/wood/plank = 1,
 	)
+	subtype_reqs = TRUE
 	structurecraft = /obj/structure/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
@@ -1172,7 +1173,7 @@
 	craftdiff = 4
 
 // ------------ Craftable Traps ----------
-//setting these up as a more "arcane" alternative to trap making done with engineering. 
+//setting these up as a more "arcane" alternative to trap making done with engineering.
 
 /datum/crafting_recipe/roguetown/engineering/rocktrap
 	name = "rock trap (engineered)"

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -349,6 +349,7 @@
 		/obj/item/natural/fur = 1
 		)
 	craftdiff = 1
+	subtype_reqs = TRUE
 
 /datum/crafting_recipe/roguetown/survival/whetstone
 	name = "whetstone"


### PR DESCRIPTION
## About The Pull Request
...they should, pottery's awesome. anyway

allows dye brushes to actually be crafted by allowing them to use subtypes of fur; previously you needed the fur "base item" so like if you killed most things and got their fur it wouldn't work

also upon further inspection the same bug applied to polishing brushes so it went through and checked every recipe that used fur to make sure all of them had subtype_reqs set to true. they do now these were the only two that didn't

## Testing Evidence
var change

## Why It's Good For The Game
pottery's cool everyone look at my glazed circlet 
<img width="208" height="122" alt="image" src="https://github.com/user-attachments/assets/1a3cff87-2a35-4c76-a413-00b0381cb03a" />

## Changelog

:cl:
fix: Dye brushes can now be properly crafted with all types of fur. Same for polishing brushes.
/:cl: