### PR TITLE
[Cl*ss Edit] Gives Swashbuckler trapmaking

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -224,6 +224,7 @@
 		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/music = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/traps = SKILL_LEVEL_APPRENTICE,
 	)
 
 /datum/outfit/job/roguetown/adventurer/swashbuckler/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

title
its a rogue, in fact its the only rogue without trapmaking
now they get at least apprentice, which is terrible, but lets them disarm things... very carefully

## Testing Evidence

<img width="365" height="444" alt="Screenshot 2026-07-30 191004" src="https://github.com/user-attachments/assets/bf461123-1b4f-411c-8088-00dd029f4e73" />

## Why It's Good For The Game

suggested
what sort of self respecting rogue can't disarm traps?
at least now they sort of got a place in the classic adventure party

## Changelog
:cl:
balance: gives swashbuckler apprentice trapmaking
/:cl:
