### PR TITLE
shapeshifting no longer misgenders you

### DIFF
--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -98,6 +98,19 @@
 	// Create the new form
 	var/mob/living/shape = new shapeshift_type(get_turf(caster))
 
+	// simples use gender directly instead of pronouns; copied from familiar-binding which had the exact same issue
+	switch(caster.pronouns ? caster.pronouns : THEY_THEM)
+		if(SHE_HER)
+			shape.gender=FEMALE
+		if(HE_HIM)
+			shape.gender=MALE
+		if(THEY_THEM)
+			shape.gender=PLURAL
+		if(IT_ITS)
+			shape.gender=NEUTER
+		else
+			shape.gender=NEUTER
+
 	// Create holder INSIDE the new form, passing shape explicitly
 	H = new /obj/shapeshift_holder(shape, src, caster, shape)
 


### PR DESCRIPTION
## About The Pull Request
Transfers the user's pronouns into the gender of the created mob when a shapeshift spell is cast, instead of using the default (usually male) gender assigned to the mob; this logic was used for familiars previously, just copied it over

## Testing Evidence
<img width="330" height="33" alt="image" src="https://github.com/user-attachments/assets/de28d77a-7d91-4ceb-86f7-2b3b3fc1139e" />

## Why It's Good For The Game
speaks for itself really

## Changelog
:cl:
fix: Your character's pronouns are now preserved when shapeshifting (e.g. wildshape, zad form)
/:cl: