### PR TITLE
familiar ability care package

### DIFF
--- a/code/modules/client/familiar_prefs.dm
+++ b/code/modules/client/familiar_prefs.dm
@@ -135,7 +135,7 @@
 		if("familiar_examine")
 			setup_examine_window(user,planar_origin)
 			return
-		
+
 		if("familiar_headshot")
 			to_chat(user, "<span class='notice'>Please use a relatively SFW image of the head and shoulder area to maintain immersion level. <b>Do not use a real life photo or unserious images.</b></span>")
 			to_chat(user, "<span class='notice'>Ensure it's a direct image link. The photo will be resized to 325x325 pixels.</span>")
@@ -242,7 +242,7 @@
 				if(!advertisee.client)
 					continue
 				if(HAS_TRAIT(advertisee, TRAIT_ARCYNE))
-					to_chat(advertisee, span_info("The leylines pulse beneath your feet... a new familiar strains against the veil, seeking to be summoned!"))
+					to_chat(advertisee, span_info("The leylines pulse beneath your feet... a new familiar strains against the veil, seeking to be summoned! (You can summon most familiars at no cost by drawing a binding rune; it doesn't need to be near a leyline.)"))
 			to_chat(user, span_notice("All alive arcyne users have been notified; you may send out another pulse in 10 minutes."))
 			GLOB.familiar_advertised += user.ckey
 			addtimer(CALLBACK(src, PROC_REF(remove_ckey), user.ckey), 10 MINUTES)

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -58,10 +58,10 @@
 	var/tier = 0 // increments once per dae survived; gates the stronger abilities
 	var/mob/living/carbon/familiar_summoner = null
 	var/inherent_spell = null
-	var/t1_spell = null
+	var/t1_spell = list()
 	var/tutorial_message = null
 	var/tierup_messages = list()
-	var/t2_spell = null
+	var/t2_spell = list()
 	var/summoning_emote = null
 	var/list/valid_healing_items = list() // what planar materials can heal you?
 	var/planar_origin = "void" // what plane are we from? avoids a bunch of istype checks
@@ -187,14 +187,16 @@
 	return TRUE
 
 /mob/living/simple_animal/pet/familiar/proc/grant_tier_abilities(tier)
-	if(tier==1 && t1_spell)
-		var/spell_instance = new t1_spell
-		if(spell_instance && src.mind)
-			src.mind.AddSpell(spell_instance)
-	if(tier==2 && t2_spell)
-		var/spell_instance = new t2_spell
-		if(spell_instance && src.mind)
-			src.mind.AddSpell(spell_instance)
+	if(tier==1 && length(t1_spell))
+		for(var/path in t1_spell)
+			var/spell_instance = new path
+			if(spell_instance && src.mind)
+				src.mind.AddSpell(spell_instance)
+	if(tier==2 && length(t2_spell))
+		for(var/path in t2_spell)
+			var/spell_instance = new path
+			if(spell_instance && src.mind)
+				src.mind.AddSpell(spell_instance)
 	return
 
 /mob/living/simple_animal/pet/familiar/proc/debug_force_tierup()
@@ -268,9 +270,9 @@
 	pass_flags = PASSTABLE | PASSMOB
 	inherent_spell = list(/datum/action/cooldown/spell/projectile/lesser_fetch/fae)
 	movement_type = FLYING
-	t1_spell = /obj/effect/proc_holder/spell/invoked/reagent_bite
-	t2_spell = /datum/action/cooldown/spell/fae_brew
-	tutorial_message = span_notice("As a native of the faewyld, you are able to fly, and kneestingers will not harm you. In addition, you can lash out with a vine to retrieve small objects at a distance.")
+	t1_spell = list(/datum/action/cooldown/spell/rootcheck, /datum/action/cooldown/spell/invisibility/fae)
+	t2_spell = list(/datum/action/cooldown/spell/fae_brew, /obj/effect/proc_holder/spell/invoked/reagent_bite)
+	tutorial_message = span_notice("As a native of the faewyld, you are able to fly, and kneestingers will not harm you. In addition, you can lash out with a vine to retrieve small objects at a distance, and force hidden crops to bloom at your command.")
 	tierup_messages = list(
 		span_info("You can now act as a reagent container, holding up to 90 drams of any solution. You can also deliver 5 drams at a time of your stored solution with an alchemical bite."),
 		span_info("You now act as a portable cauldron, able to be fed alchemical reagents and brew them into potions. You do not need water to do so. Any attempts to brew potion beyond your reagent capacity will result in reagents being voided.")
@@ -457,8 +459,8 @@
 		span_info("As your flame grows, you can manifest it more violently, surging around you to burn anything unfortunate enough to be nearby.")
 	)
 	inherent_spell = list(/obj/effect/proc_holder/spell/invoked/incendiary_bite)
-	t1_spell = /datum/action/cooldown/spell/matthios/raze/infernal
-	t2_spell = /obj/effect/proc_holder/spell/self/infernal_surge
+	t1_spell = list(/datum/action/cooldown/spell/matthios/raze/infernal)
+	t2_spell = list(/obj/effect/proc_holder/spell/self/infernal_surge)
 	var/healing_range = 1
 	var/static/list/acceptable_beds = list(/obj/structure/bed, /obj/structure/flora/roguetree/stump, /obj/item/bedsheet)
 	valid_healing_items = list(/obj/item/magic/infernal)
@@ -573,9 +575,9 @@
 	maxHealth = WOLF_HEALTH_UNDEAD // more durable than the others
 	health = WOLF_HEALTH_UNDEAD
 	speak_emote = list ("rumbles", "grinds")
-	inherent_spell = list(/datum/action/cooldown/spell/magicians_stone/elemental)
-	t1_spell = /datum/action/cooldown/spell/arcyne_forge/elemental
-	t2_spell = /datum/action/cooldown/spell/arcyne_forge/elementalt2
+	inherent_spell = list(/datum/action/cooldown/spell/magicians_stone/elemental, /datum/action/cooldown/spell/aetherknife/elemental) // you can at least prep food n such with this right
+	t1_spell = list(/datum/action/cooldown/spell/arcyne_forge/elemental)
+	t2_spell = list(/datum/action/cooldown/spell/arcyne_forge/elementalt2)
 	valid_healing_items = list(/obj/item/magic/elemental)
 	tierup_messages = list(
 		span_info("You can now shape your earthen form into tools and weapons, including those capable of repairing equipment."),
@@ -637,6 +639,7 @@
 			src.movement_type = FLYING
 			TryAddFlight()
 			src.mind.AddSpell(new /datum/action/cooldown/spell/projectile/lesser_fetch/fae/void)
+			src.mind.AddSpell(new /datum/action/cooldown/spell/invisibility/fae)
 		if("infernal") // nerfed abberant beam, fire res
 			to_chat(src, span_notice("As you absorb the essence of the hells, you take on some of their nature. Flames will harm you no more, and you can now manifest an abberant beam to blast your foes."))
 			src.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fire_obelisk_beam/drakeling)

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -103,6 +103,92 @@
 	log_game("[key_name(user)] sent a message to [key_name(summoner)] with contents [message]")
 	return TRUE
 
+/datum/action/cooldown/spell/rootcheck
+	name = "Nature's Bounty"
+	desc = "Invigorate the lyfe in a small area, causing hidden roots to bear fruit instantly."
+	button_icon_state = "ensnare"
+
+	click_to_activate = TRUE
+	self_cast_possible = TRUE
+	charge_required = TRUE
+	charge_time = 1 SECONDS
+	cooldown_time = 10 MINUTES
+
+	primary_resource_type = SPELL_COST_NONE
+	spell_requirements = NONE
+	spell_impact_intensity = SPELL_IMPACT_NONE
+
+	var/static/list/rootpool = list( // basically most crops, including poison berries. also a few alchemically-useful things. and junk items to make it less useful
+		/obj/item/natural/fibers,
+		/obj/item/grown/log/tree/stick,
+		/obj/item/natural/thorn,
+		/obj/item/natural/chaff/wheat, // what, you thought it'd be usable? nah you have to shuck that yourself, it's freshly-grown
+		/obj/item/natural/chaff/oat,
+		/obj/item/natural/chaff/rice,
+		/obj/item/reagent_containers/food/snacks/grown/maize,
+		/obj/item/reagent_containers/food/snacks/grown/apple,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/pear,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/lemon,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/lime,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/tangerine,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/plum,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/strawberry,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/blackberry,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/raspberry,
+		/obj/item/reagent_containers/food/snacks/grown/fruit/tomato,
+		/obj/item/reagent_containers/food/snacks/grown/nut,
+		/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+		/obj/item/reagent_containers/food/snacks/grown/vegetable/turnip,
+		/obj/item/reagent_containers/food/snacks/grown/sunflower,
+		/obj/item/reagent_containers/food/snacks/grown/rogue/fyritius,
+		/obj/item/reagent_containers/food/snacks/grown/rogue/swampweed,
+		/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+		/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+		/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+		/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+		/obj/item/reagent_containers/food/snacks/grown/garlick/rogue,
+		/obj/item/reagent_containers/food/snacks/grown/rogue/poppy,
+		/obj/item/reagent_containers/food/snacks/grown/coffee,
+		/obj/item/reagent_containers/food/snacks/grown/tea,
+		/obj/item/reagent_containers/food/snacks/grown/carrot,
+		/obj/item/reagent_containers/food/snacks/grown/cucumber,
+		/obj/item/reagent_containers/food/snacks/grown/eggplant,
+		/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
+		/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison,
+		/obj/item/alch/atropa, // herbs, synergizes with fae brew and makes the food potential less strong
+		/obj/item/alch/matricaria,
+		/obj/item/alch/symphitum,
+		/obj/item/alch/taraxacum,
+		/obj/item/alch/euphrasia,
+		/obj/item/alch/paris,
+		/obj/item/alch/calendula,
+		/obj/item/alch/mentha,
+		/obj/item/alch/urtica,
+		/obj/item/alch/salvia,
+		/obj/item/alch/hypericum,
+		/obj/item/alch/benedictus,
+		/obj/item/alch/valeriana,
+		/obj/item/alch/artemisia,
+		/obj/item/alch/rosa,
+		/obj/item/reagent_containers/food/snacks/grown/manabloom,
+	)
+
+/datum/action/cooldown/spell/rootcheck/cast(atom/cast_on)
+	. = ..()
+	var/turf/target = get_turf(cast_on)
+	target.visible_message(span_notice("Hidden roots tremble underfoot as crops flourish before your very eyes, bursting through the ground!"))
+	if(!target)
+		return FALSE
+	for(var/i in 1 to 3)
+		var/obj/item/path = pick(rootpool)
+		new path(target)
+
+/datum/action/cooldown/spell/invisibility/fae
+	name = "Fey Shroud"
+	desc = "Cloak yourself, blending into the surroundings. Attacking, being attacked, or casting another ability will break your stealth."
+	click_to_activate = FALSE
+	spell_requirements = SPELL_REQUIRES_SAME_Z
+
 /datum/action/cooldown/spell/fae_brew
 	name = "Alchemical Stomach"
 	desc = "Toggle your brewing ability; while enabled, and you have a stock of reagents inside yourself, you will attempt to brew them into a potion using your summoner's alchemical skill."
@@ -157,7 +243,7 @@
 			span_notice("[user.name] gently bites the top of [targets[1]], filling it with an alchemical cocktail..."),
 			span_notice("You gently bite the top of [targets[1]], filling it with your alchemical cocktail...")
 		)
-		// we're not biting a mob, so we can loop for convenience 
+		// we're not biting a mob, so we can loop for convenience
 		while(do_after(user, 1 SECONDS, FALSE, target) && user.reagents.trans_to(targets[1], 5, transfered_by = user))
 			user.visible_message(
 				span_notice("[user.name] fills [targets[1]] with more of [user.p_their()] alchemical cocktail..."),
@@ -233,6 +319,11 @@
 
 /datum/action/cooldown/spell/magicians_stone/elemental
 	name = "Create Stone"
+	fluff_desc = ""
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_SAME_Z
+
+/datum/action/cooldown/spell/aetherknife/elemental
+	name = "Shape Knife"
 	fluff_desc = ""
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_SAME_Z
 


### PR DESCRIPTION
## About The Pull Request
People were pointing out, rightfully, that the abilities fae familiars get are all things the summoner does to them, rather than letting them have any agency for themselves. And also that elementals were kind of underpowered at base tier. So this one touched them up a bit:
- the fae brewing/bite ability is consolidated into a single tier, there was no reason to separate it like that. in place of the brewing mechanic at t1 they get invisibility and rootcheck (spawns some random plant items that may or may not be useful. can include poison berries, random herbs, crops, or something trash like fiber n sticks)
- elementals get a reskinned aetherknife alongside magician's stone at base tier, in line with their vibe of shaping stuff out of earth

Also touches up the familiar pulse message to let people know how to summon familiars!

## Testing Evidence
<img width="196" height="331" alt="image" src="https://github.com/user-attachments/assets/fce3801d-5b36-43b8-8b8e-e32532a61e43" />
<img width="526" height="235" alt="image" src="https://github.com/user-attachments/assets/0a535882-a296-41c0-b8fd-7a1b8ca6301e" />
<img width="195" height="134" alt="image" src="https://github.com/user-attachments/assets/0ed5a4d9-47dd-4ab4-ab0d-d321a409becd" />
Note that the lootpool (rootpool, even) for this has been nerfed since these scs were taken. You get three items per cast, once per ten minutes.

## Why It's Good For The Game
Gives some more love to familiar abilities, that shouldn't interfere with balance. There aren't that many people that play these but they seem to really like it. Maintaining my features tax.

## Changelog

:cl:
add: Fae familiar abilities have been reshuffled, both potion abilities are now at tier 2. In tier 1 they now get rootcheck (bootcheck but plants) and invis. Elemental gets aetherknife at base tier.
fix: The message displayed when a familiar seeks to be summoned now actually tells you how to do so.
/:cl:
