### PR TITLE
[Fix/Request] Mapper's Pressure Plate

### DIFF
--- a/code/game/objects/structures/roguetown/redstone.dm
+++ b/code/game/objects/structures/roguetown/redstone.dm
@@ -339,8 +339,8 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 */
 
 /obj/structure/pressure_plate/once
-	name = "pressure plate"
-	desc = "Be careful. Stepping on this could either mean a bomb exploding or a door closing on you."
+	name = "rusty pressure plate"
+	desc = "Be careful. Stepping on this could either mean a bomb exploding or a door closing on you. Luckily, it seems to have only one last wheeze before it's stuck."
 	var/triggered = FALSE
 
 /obj/structure/pressure_plate/once/Crossed(atom/movable/AM)

--- a/code/game/objects/structures/roguetown/redstone.dm
+++ b/code/game/objects/structures/roguetown/redstone.dm
@@ -329,7 +329,6 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 	else if(istype(item, /obj/item/rogueweapon/chisel/assembly))
 		to_chat(user, span_warning("You most use both hands to rename plates."))
 
-
 /*
 /obj/structure/pressure_plate/attack_hand(mob/user) //commented out for now, they're stuposed to be anchored structures for dungeons. End of vanderlin traps port. Maybe an artificer subtype craft in the future.
 	. = ..()
@@ -338,6 +337,31 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 		triggerplate()
 		anchored = !anchored
 */
+
+/obj/structure/pressure_plate/once
+	name = "pressure plate"
+	desc = "Be careful. Stepping on this could either mean a bomb exploding or a door closing on you."
+	var/triggered = FALSE
+
+/obj/structure/pressure_plate/once/Crossed(atom/movable/AM)
+	. = ..()
+	if(triggered)
+		return
+	if(!anchored)
+		return
+	if(!isliving(AM))
+		return
+	triggered = TRUE
+	var/mob/living/L = AM
+	to_chat(L, "<span class='info'>I feel something permanently click beneath me.</span>")
+	AM.log_message("has activated a permanent pressure plate", LOG_GAME)
+	playsound(src, 'sound/misc/pressurepad_down.ogg', 35, extrarange = 2)
+	triggerplate()
+
+/obj/structure/pressure_plate/once/triggerplate()
+	for(var/obj/structure/O in redstone_attached)
+		spawn(0)
+			O.redstone_triggered()
 
 /obj/structure/englauncher
 	name = "Engineer's Launcher"


### PR DESCRIPTION
## About The Pull Request

- Our vanilla pressure plates are made for multiple uses, this one should only be usable once. Made at the request of a mapper who wants to use this for a dungeon puzzle.

## Testing Evidence

Compiles and it works, just a child of a parent.

## Why It's Good For The Game

Code problem, not map problem. We're leveling our map design up.

## Changelog
:cl:
add: Added a single-use pressure plate object.
/:cl: