### PR TITLE
maintaining my faetures (again)

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -313,9 +313,8 @@
 /mob/living/simple_animal/UnarmedAttack(atom/A, proximity)
 	if(!dextrous)
 		return ..()
-	if(!ismob(A))
-		A.attack_hand(src)
-		update_inv_hands()
+	A.attack_hand(src)
+	update_inv_hands()
 
 
 /*

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -418,20 +418,23 @@
 	return ret
 
 /mob/living/simple_animal/pet/familiar/fae/attackby(obj/item/I, mob/user, params)
+	to_chat(world, span_warning("getting here"))
 	if(istype(I, /obj/item/reagent_containers) && tier >= 2)
+		to_chat(world, span_warning("getting here 2"))
 		var/datum/reagents/container_reagents=I.reagents
 		if(istype(container_reagents) && user.used_intent.type == INTENT_POUR && container_reagents.total_volume>0 && !reagents.holder_full())
+			to_chat(world, span_warning("getting here 3 [container_reagents] [user.used_intent.type]"))
 			user.visible_message(
-				span_notice("I begin feeding [src] from [I]..."),
-				span_notice("[user] begins feeding [src] from [I]...")
+				span_notice("[user] begins feeding [src] from [I]..."),
+				span_notice("I begin feeding [src] from [I]...")
 			)
 			while(!reagents.holder_full() && do_mob(user, src, 1 SECONDS) && container_reagents.trans_to(src,5,transfered_by=user))
 				user.visible_message(
-					span_notice("I feed [src] from [I]..."),
-					span_notice("[user] feeds [src] from [I]...")
+					span_notice("[user] feeds [src] from [I]..."),
+					span_notice("I feed [src] from [I]...")
 				)
 		else if(istype(container_reagents) && user.used_intent.type == /datum/intent/fill)
-			src.visible_message(,
+			src.visible_message(
 				span_notice("I begin filling [user]'s [I.name]..."),
 				span_notice("[src] begins filling [user]'s [I.name]...")
 			)

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -67,6 +67,7 @@
 	var/planar_origin = "void" // what plane are we from? avoids a bunch of istype checks
 	rot_type = null // no rotting inside vestiges please
 	var/datum/voicepack/voice_pack
+	var/obj/item/wear_neck // they can wear pouches please this time can this actually work
 
 /datum/status_effect/buff/healing/familiar
 	alert_type = /atom/movable/screen/alert/status_effect/buff/healing/familiar
@@ -174,7 +175,103 @@
 
 // they can wear pouches and amulets around their neck, for sovl
 /mob/living/simple_animal/pet/familiar/can_equip(obj/item/I, slot, disable_warning, bypass_equip_delay_self)
-	return slot == SLOT_NECK
+	if(slot == SLOT_NECK)
+		if(wear_neck)
+			return FALSE
+		if( !(I.slot_flags & ITEM_SLOT_NECK) )
+			return FALSE
+		return TRUE
+	return FALSE
+
+/mob/living/simple_animal/pet/familiar/equip_to_slot(obj/item/I, slot, initial)
+	if(!slot)
+		return
+	if(!istype(I))
+		return
+
+	var/index = get_held_index_of_item(I)
+	if(index)
+		held_items[index] = null
+
+	if(I.pulledby)
+		I.pulledby.stop_pulling()
+
+	I.screen_loc = null
+	if(client)
+		client.screen -= I
+	if(observers && observers.len)
+		for(var/M in observers)
+			var/mob/dead/observe = M
+			if(observe.client)
+				observe.client.screen -= I
+	I.forceMove(src)
+	I.layer = ABOVE_HUD_LAYER
+	I.plane = ABOVE_HUD_PLANE
+	I.appearance_flags |= NO_CLIENT_COLOR
+	var/not_handled = FALSE
+	switch(slot)
+		if(SLOT_NECK)
+			wear_neck = I
+			update_inv_neck(I)
+		else
+			not_handled = TRUE
+
+	//Item has been handled at this point and equipped callback can be safely called
+	//We cannot call it for items that have not been handled as they are not yet correctly
+	//in a slot
+	if(!not_handled)
+		I.equipped(src, slot)
+
+	if(hud_used)
+		hud_used.throw_icon?.update_icon()
+		hud_used.give_intent?.update_icon()
+
+	return not_handled
+
+/mob/living/simple_animal/pet/familiar/update_inv_neck()
+	remove_overlay(NECK_LAYER)
+
+	if(client && hud_used && hud_used.inv_slots[SLOT_NECK])
+		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[SLOT_NECK]
+		inv.update_icon()
+
+	if(wear_neck)
+		overlays_standing[NECK_LAYER] = wear_neck.build_worn_icon(default_layer = NECK_LAYER, default_icon_file = 'icons/roguetown/clothing/neck.dmi')
+		update_hud_neck(wear_neck)
+
+	apply_overlay(NECK_LAYER)
+
+/mob/living/simple_animal/pet/familiar/proc/update_hud_neck(obj/item/I)
+	I.screen_loc = rogueui_neck
+	if(client && hud_used && hud_used.hud_shown)
+		if(hud_used.inventory_shown)
+			client.screen += I
+	update_observer_view(I,1)
+
+/mob/living/simple_animal/pet/familiar/proc/update_observer_view(obj/item/I, inventory)
+	if(observers && observers.len)
+		for(var/M in observers)
+			var/mob/dead/observe = M
+			if(observe.client && observe.client.eye == src)
+				if(observe.hud_used)
+					if(inventory && !observe.hud_used.inventory_shown)
+						continue
+					observe.client.screen += I
+			else
+				observers -= observe
+				if(!observers.len)
+					observers = null
+					break
+
+/mob/living/simple_animal/pet/familiar/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE)
+	. = ..() //Sets the default return value to what the parent returns.
+	if(!. || !I) //We don't want to set anything to null if the parent returned 0.
+		return
+	if(I == wear_neck)
+		wear_neck = null
+		if(!QDELETED(src))
+			update_inv_neck(I)
+
 
 /mob/living/simple_animal/pet/familiar/proc/can_bite()
 	for(var/obj/item/grabbing/grab in grabbedby) //Grabbed by the mouth
@@ -321,7 +418,7 @@
 	return ret
 
 /mob/living/simple_animal/pet/familiar/fae/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/reagent_containers) && tier >= 1)
+	if(istype(I, /obj/item/reagent_containers) && tier >= 2)
 		var/datum/reagents/container_reagents=I.reagents
 		if(istype(container_reagents) && user.used_intent.type == INTENT_POUR && container_reagents.total_volume>0 && !reagents.holder_full())
 			user.visible_message(
@@ -365,7 +462,7 @@
 		I.loc = M.loc
 		M.put_in_active_hand(I)
 		if(M == src)
-			M.visible_message("<span class='info'>[src] retrieves [I] from [src.p_their()] stomach.</span>")
+			M.visible_message("<span class='info'>[src] spits out [I].</span>")
 		else
 			M.visible_message("<span class='info'>[src] spits [I] into [M]'s hand.</span>")
 		return
@@ -413,6 +510,8 @@
 					brewing = 0
 					src.visible_message(span_info("[src] needs their summoner's alchemical knowledge to brew anything."))
 					return
+				to_chat(world, span_warning("[found_recipe.skill_required]"))
+				to_chat(world, span_warning("[familiar_summoner?.get_skill_level(/datum/skill/craft/alchemy)]"))
 				if(found_recipe.skill_required > familiar_summoner?.get_skill_level(/datum/skill/craft/alchemy))
 					brewing = 0
 					src.visible_message(span_warning("[src] emits a gurgling noise, the ingredients melding into a disgusting mess! Perhaps a more skilled alchemist is needed for this recipe."))

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -272,10 +272,10 @@
 	movement_type = FLYING
 	t1_spell = list(/datum/action/cooldown/spell/rootcheck, /datum/action/cooldown/spell/invisibility/fae)
 	t2_spell = list(/datum/action/cooldown/spell/fae_brew, /obj/effect/proc_holder/spell/invoked/reagent_bite)
-	tutorial_message = span_notice("As a native of the faewyld, you are able to fly, and kneestingers will not harm you. In addition, you can lash out with a vine to retrieve small objects at a distance, and force hidden crops to bloom at your command.")
+	tutorial_message = span_notice("As a native of the faewyld, you are able to fly, and kneestingers will not harm you. In addition, you can lash out with a vine to retrieve small objects at a distance.")
 	tierup_messages = list(
-		span_info("You can now act as a reagent container, holding up to 90 drams of any solution. You can also deliver 5 drams at a time of your stored solution with an alchemical bite."),
-		span_info("You now act as a portable cauldron, able to be fed alchemical reagents and brew them into potions. You do not need water to do so. Any attempts to brew potion beyond your reagent capacity will result in reagents being voided.")
+		span_info("You may now blend into your surroundings at will, and force hidden crops to bloom at your command."),
+		span_info("You can now act as a reagent container, holding up to 90 drams of any solution. You can also deliver 5 drams at a time of your stored solution with an alchemical bite. You may also act as a portable cauldron, able to be fed alchemical reagents and brew them into potions. You do not need water to do so. Any attempts to brew potion beyond your reagent capacity will result in reagents being voided.")
 	)
 	valid_healing_items = list(/obj/item/magic/fae)
 	planar_origin = "fae"

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -418,12 +418,9 @@
 	return ret
 
 /mob/living/simple_animal/pet/familiar/fae/attackby(obj/item/I, mob/user, params)
-	to_chat(world, span_warning("getting here"))
 	if(istype(I, /obj/item/reagent_containers) && tier >= 2)
-		to_chat(world, span_warning("getting here 2"))
 		var/datum/reagents/container_reagents=I.reagents
 		if(istype(container_reagents) && user.used_intent.type == INTENT_POUR && container_reagents.total_volume>0 && !reagents.holder_full())
-			to_chat(world, span_warning("getting here 3 [container_reagents] [user.used_intent.type]"))
 			user.visible_message(
 				span_notice("[user] begins feeding [src] from [I]..."),
 				span_notice("I begin feeding [src] from [I]...")

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -191,7 +191,7 @@
 
 /datum/action/cooldown/spell/fae_brew
 	name = "Alchemical Stomach"
-	desc = "Toggle your brewing ability; while enabled, and you have a stock of reagents inside yourself, you will attempt to brew them into a potion using your summoner's alchemical skill."
+	desc = "Toggle your brewing ability; while enabled, and you have a stock of reagents inside yourself, you will attempt to brew them into a potion using your summoner's alchemical skill. Click yourself (or have someone else click you) with reagents to add them, or empty hand to remove them."
 	button_icon_state = "create_campfire"
 
 	click_to_activate = FALSE
@@ -218,7 +218,7 @@
 
 /obj/effect/proc_holder/spell/invoked/reagent_bite
 	name = "Alchemical Bite" // placeholder
-	desc = "Bite a target, delivering a 5-dram dose of whatever is in your stomach. Cast on a reagent container to transfer its contents into your stomach, or fill it if it's empty."
+	desc = "Bite a target, delivering a 5-dram dose of whatever is in your stomach. Cast on a reagent container to transfer its contents into your stomach, or fill it if it's empty. You can also drink from containers directly to similar effect."
 	range = 1
 	recharge_time = 10 SECONDS
 	overlay_icon = 'icons/mob/actions/mage_hex.dmi'

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -239,7 +239,7 @@
 		revert_cast()
 		return FALSE
 	if(!isliving(target))
-		if(user.reagents.total_volume && (target.reagents.holder_full()))
+		if(user.reagents.total_volume && (!target.reagents.holder_full()))
 			user.visible_message(
 				span_notice("[user.name] gently bites the top of [targets[1]], filling it with an alchemical cocktail..."),
 				span_notice("You gently bite the top of [targets[1]], filling it with your alchemical cocktail...")
@@ -255,7 +255,7 @@
 				span_notice("You let go of [targets[1]].")
 			)
 			return TRUE
-		else if(target.reagents.total_volume && (user.reagents.holder_full())) // suckle it up!
+		else if(target.reagents.total_volume && (!user.reagents.holder_full())) // suckle it up!
 			user.visible_message(
 				span_notice("[user.name] latches onto [targets[1]], beginning to drink..."),
 				span_notice("You latch onto [targets[1]], and begin to drink...")

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -218,7 +218,7 @@
 
 /obj/effect/proc_holder/spell/invoked/reagent_bite
 	name = "Alchemical Bite" // placeholder
-	desc = "Bite a target, delivering a 5-dram dose of whatever is in your stomach."
+	desc = "Bite a target, delivering a 5-dram dose of whatever is in your stomach. Cast on a reagent container to transfer its contents into your stomach, or fill it if it's empty."
 	range = 1
 	recharge_time = 10 SECONDS
 	overlay_icon = 'icons/mob/actions/mage_hex.dmi'

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -226,16 +226,12 @@
 
 /obj/effect/proc_holder/spell/invoked/reagent_bite/cast(list/targets, mob/living/simple_animal/pet/familiar/fae/user)
 	. = ..()
-	if(!user) // literally how
+	if(!user || !user.reagents) // literally how
 		revert_cast()
 		return FALSE
 	var/atom/target = targets.len?targets[1]:null
 	if(!targets.len || !(isliving(target) || target.is_refillable()) || !target.reagents)
 		to_chat(user, span_notice("I need to select a valid target to bite!"))
-		revert_cast()
-		return FALSE
-	if(!user.reagents || user.reagents.total_volume == 0)
-		to_chat(user, span_notice("I need to have a potion in my stomach to inject!"))
 		revert_cast()
 		return FALSE
 	if(!isliving(target))

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -238,22 +238,41 @@
 		to_chat(user, span_notice("I need to have a potion in my stomach to inject!"))
 		revert_cast()
 		return FALSE
-	if(!isliving(targets[1]))
-		user.visible_message(
-			span_notice("[user.name] gently bites the top of [targets[1]], filling it with an alchemical cocktail..."),
-			span_notice("You gently bite the top of [targets[1]], filling it with your alchemical cocktail...")
-		)
-		// we're not biting a mob, so we can loop for convenience
-		while(do_after(user, 1 SECONDS, FALSE, target) && user.reagents.trans_to(targets[1], 5, transfered_by = user))
+	if(!isliving(target))
+		if(user.reagents.total_volume && (target.reagents.holder_full()))
 			user.visible_message(
-				span_notice("[user.name] fills [targets[1]] with more of [user.p_their()] alchemical cocktail..."),
-				span_notice("You fill [targets[1]] with more of your alchemical cocktail...")
+				span_notice("[user.name] gently bites the top of [targets[1]], filling it with an alchemical cocktail..."),
+				span_notice("You gently bite the top of [targets[1]], filling it with your alchemical cocktail...")
 			)
-		user.visible_message(
-			span_notice("[user.name] lets go of [targets[1]]."),
-			span_notice("You let go of [targets[1]].")
-		)
-		return TRUE
+			// we're not biting a mob, so we can loop for convenience
+			while(do_after(user, 1 SECONDS, FALSE, target) && user.reagents.trans_to(targets[1], 5, transfered_by = user))
+				user.visible_message(
+					span_notice("[user.name] fills [targets[1]] with more of [user.p_their()] alchemical cocktail..."),
+					span_notice("You fill [targets[1]] with more of your alchemical cocktail...")
+				)
+			user.visible_message(
+				span_notice("[user.name] lets go of [targets[1]]."),
+				span_notice("You let go of [targets[1]].")
+			)
+			return TRUE
+		else if(target.reagents.total_volume && (user.reagents.holder_full())) // suckle it up!
+			user.visible_message(
+				span_notice("[user.name] latches onto [targets[1]], beginning to drink..."),
+				span_notice("You latch onto [targets[1]], and begin to drink...")
+			)
+			// we're not biting a mob, so we can loop for convenience
+			while(do_after(user, 1 SECONDS, FALSE, target) && target.reagents.trans_to(user, 5, transfered_by = user))
+				user.visible_message(
+					span_notice("[user.name] drinks from [targets[1]]..."),
+					span_notice("You drink from [targets[1]]...")
+				)
+			user.visible_message(
+				span_notice("[user.name] lets go of [targets[1]]."),
+				span_notice("You let go of [targets[1]].")
+			)
+			return TRUE
+		return FALSE
+
 	var/mob/living/living_target = targets[1]
 	user.visible_message(
 		span_notice("[user.name] attempts to bite [living_target.name]!"),


### PR DESCRIPTION
## About The Pull Request
Fixes a couple of bugs found during familiar gameplay + some found during localhost testing also. idk read the changelog we're not duplicating everything up here

## Testing Evidence
didn't get screenshots of most of it but like it works. yea
<img width="530" height="525" alt="image" src="https://github.com/user-attachments/assets/486558ff-e9bd-48ee-aa3a-55d62a0f2f0a" />

## Why It's Good For The Game
faeries are the most oppressed class in azure peak

## Changelog

:cl:
fix: Fae familiars no longer get misleading tutorial text; it's been updated to match their new ability tiering. Their spell descriptions have also been updated to clarify their mechanics.
fix: Fae familiars can now remove reagents from themselves, and can drink (and be fed) from containers as intended. Reagent bite also now works to fill and empty containers, and says as much in its description.
fix: Familiars can now wear neck items like pouches and amulets on their neck. For real this time, we promise.
/:cl: