### PR TITLE
Readds elvish glaive pixel shift

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
@@ -1664,6 +1664,15 @@
 	max_blade_int = 180 //Elven design makes it sharper
 	sellprice = 60
 
+/obj/item/rogueweapon/halberd/glaive/elvish/getonmobprop(tag)
+	. = ..()
+	if(tag)
+		switch(tag)
+			if("gen")
+				return list("shrink" = 0.6,"sx" = -6,"sy" = 2,"nx" = 8,"ny" = 2,"wx" = -4,"wy" = 2,"ex" = 1,"ey" = 2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -38,"sturn" = 300,"wturn" = 32,"eturn" = -23,"nflip" = 0,"sflip" = 100,"wflip" = 8,"eflip" = 0)
+			if("wielded")
+				return list("shrink" = 0.6,"sx" = 4,"sy" = -2,"nx" = -3,"ny" = -2,"wx" = -5,"wy" = -1,"ex" = 3,"ey" = -2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 7,"sturn" = -7,"wturn" = 16,"eturn" = -22,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
+
 /obj/item/rogueweapon/spear/partizan/baotha
 	name = "saccharine swordspear"
 	desc = "Keep the rest at arm's length, lest you're burdened with the pain of rememberance."

--- a/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
@@ -1668,8 +1668,6 @@
 	. = ..()
 	if(tag)
 		switch(tag)
-			if("gen")
-				return list("shrink" = 0.6,"sx" = -6,"sy" = 2,"nx" = 8,"ny" = 2,"wx" = -4,"wy" = 2,"ex" = 1,"ey" = 2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -38,"sturn" = 300,"wturn" = 32,"eturn" = -23,"nflip" = 0,"sflip" = 100,"wflip" = 8,"eflip" = 0)
 			if("wielded")
 				return list("shrink" = 0.6,"sx" = 4,"sy" = -2,"nx" = -3,"ny" = -2,"wx" = -5,"wy" = -1,"ex" = 3,"ey" = -2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 7,"sturn" = -7,"wturn" = 16,"eturn" = -22,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
 


### PR DESCRIPTION
## About The Pull Request

- Fixes elvish glaive to pixel-shift properly once more.

## Testing Evidence

Before v After
<img width="1504" height="461" alt="ภาพ" src="https://github.com/user-attachments/assets/fc0db3d1-6b49-45e8-8334-f27cfefa1615" />


## Why It's Good For The Game

Fixes oversight/bug, the original author of #8258 seemed to have removed this codeblock so that it can use the parent type instead of repeating it. 
- The problem stems from the original glaive not actually having a wielded/two hand sprite, and had it's own pixelshift code compared to halberd and other polearms.

<img width="754" height="207" alt="ภาพ" src="https://github.com/user-attachments/assets/ba698328-b7b6-448c-ac62-a13856bc32dc" />


## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fixes elvish glaive pixelshift
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
