### PR TITLE
Unlocks Noises for Animal Tongues

### DIFF
--- a/code/modules/mob/living/carbon/human/emotes_noises.dm
+++ b/code/modules/mob/living/carbon/human/emotes_noises.dm
@@ -143,13 +143,13 @@
 	is_animal = TRUE
 
 /mob/living/carbon/human/proc/emote_squeak()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/wild_tongue))
-		set name = "Squeak"
-		set category = "Emotes.Wildtongue"
-		emote("squeak", intentional = TRUE, animal = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "Squeak"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard) && !istype(tongue, /obj/item/organ/tongue/moth))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("squeak", intentional = TRUE, animal = TRUE)
 
 /datum/emote/living/hiss
 	key = "hiss"
@@ -162,13 +162,13 @@
 	is_animal = TRUE
 
 /mob/living/carbon/human/proc/emote_hiss()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/wild_tongue))
-		set name = "Hiss"
-		set category = "Emotes.Wildtongue"
-		emote("hiss", intentional = TRUE, animal = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "Hiss"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("hiss", intentional = TRUE, animal = TRUE)
 
 /datum/emote/living/phiss
 	key = "phiss"
@@ -181,13 +181,13 @@
 	is_animal = TRUE
 
 /mob/living/carbon/human/proc/emote_phiss()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/wild_tongue))
-		set name = "PHiss"
-		set category = "Emotes.Wildtongue"
-		emote("phiss", intentional = TRUE, animal = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "PHiss"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("phiss", intentional = TRUE, animal = TRUE)
 
 /datum/emote/living/roar
 	key = "roar"
@@ -351,13 +351,13 @@
 	is_animal = TRUE
 
 /mob/living/carbon/human/proc/emote_purr()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/wild_tongue))
-		set name = "Purr"
-		set category = "Emotes.Wildtongue"
-		emote("purr", intentional = TRUE, animal = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "Purr"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("purr", intentional = TRUE, animal = TRUE)
 
 /datum/emote/living/moo
 	key = "moo"
@@ -408,13 +408,13 @@
 	is_animal = TRUE
 
 /mob/living/carbon/human/proc/emote_growl()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/wild_tongue))
-		set name = "Growl"
-		set category = "Emotes.Wildtongue"
-		emote("growl", intentional = TRUE, animal = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "Growl"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("growl", intentional = TRUE, animal = TRUE)
 
 /datum/emote/living/prbt
 	key = "prbt"
@@ -465,13 +465,13 @@
 	is_animal = TRUE
 
 /mob/living/carbon/human/proc/emote_chitter()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/moth))
-		set name = "Chitter"
-		set category = "Emotes.Wildtongue"
-		emote("chitter", intentional = TRUE, animal = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "Chitter"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/moth))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("chitter", intentional = TRUE, animal = TRUE)
 
 /datum/emote/living/flutter
 	key = "flutter"
@@ -481,13 +481,13 @@
 	show_runechat = FALSE
 
 /mob/living/carbon/human/proc/emote_flutter()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/moth))
-		set name = "Flutter"
-		set category = "Emotes.Wildtongue"
-		emote("flutter", intentional = TRUE)
-	else
-		to_chat(usr, span_warning("Your back doesn't do that"))
+	set name = "Flutter"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/moth))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("flutter", intentional = TRUE)
 
 /datum/emote/living/yip
 	key = "yip"
@@ -499,13 +499,13 @@
 	show_runechat = FALSE
 
 /mob/living/carbon/human/proc/emote_yip()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard))
-		set name = "Yip"
-		set category = "Emotes.Wildtongue"
-		emote("yip", intentional = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "Yip"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("yip", intentional = TRUE)
 
 /datum/emote/living/lizard_bellow
 	key = "bellow"
@@ -517,13 +517,13 @@
 	show_runechat = FALSE
 
 /mob/living/carbon/human/proc/emote_lizard_bellow()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard))
-		set name = "LizBellow"
-		set category = "Emotes.Wildtongue"
-		emote("bellow", intentional = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "LizBellow"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("bellow", intentional = TRUE)
 
 /datum/emote/living/lizard_hiss
 	key = "hiss"
@@ -535,13 +535,13 @@
 	show_runechat = FALSE
 
 /mob/living/carbon/human/proc/emote_lizard_hiss()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard))
-		set name = "LizHiss"
-		set category = "Emotes.Wildtongue"
-		emote("hiss", intentional = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "LizHiss"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("hiss", intentional = TRUE)
 
 /datum/emote/living/lizard_squeal
 	key = "squeal"
@@ -553,13 +553,13 @@
 	show_runechat = FALSE
 
 /mob/living/carbon/human/proc/emote_lizard_squeal()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard))
-		set name = "LizSqueal"
-		set category = "Emotes.Wildtongue"
-		emote("squeal", intentional = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "LizSqueal"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("squeal", intentional = TRUE)
 
 /datum/emote/living/emote_lizard_thump
 	key = "thump"
@@ -570,11 +570,11 @@
 	is_animal = TRUE
 
 /mob/living/carbon/human/proc/emote_lizard_thump()
-	if(istype(usr.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard))
-		set name = "LizThump"
-		set category = "Emotes.Wildtongue"
-		emote("thump", intentional = TRUE)
-	else
-		to_chat(usr, span_warning("Your tongue doesn't do that"))
+	set name = "LizThump"
+	set category = "Emotes.Wildtongue"
+	var/obj/item/organ/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue, /obj/item/organ/tongue/wild_tongue) && !istype(tongue, /obj/item/organ/tongue/lizard))
+		to_chat(src, span_warning("Your tongue doesn't do that"))
 		return
+	emote("thump", intentional = TRUE)
 

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -84,6 +84,11 @@
 		/mob/living/carbon/human/proc/emote_lizard_hiss,
 		/mob/living/carbon/human/proc/emote_lizard_squeal,
 		/mob/living/carbon/human/proc/emote_lizard_thump,
+		/mob/living/carbon/human/proc/emote_growl,
+		/mob/living/carbon/human/proc/emote_purr,
+		/mob/living/carbon/human/proc/emote_squeak,
+		/mob/living/carbon/human/proc/emote_hiss,
+		/mob/living/carbon/human/proc/emote_phiss,
 	)
 //	modifies_speech = TRUE
 /*
@@ -294,6 +299,13 @@
 		/mob/living/carbon/human/proc/emote_growl,
 		/mob/living/carbon/human/proc/emote_prbt,
 		/mob/living/carbon/human/proc/emote_bleat,
+		/mob/living/carbon/human/proc/emote_chitter,
+		/mob/living/carbon/human/proc/emote_flutter,
+		/mob/living/carbon/human/proc/emote_yip,
+		/mob/living/carbon/human/proc/emote_lizard_bellow,
+		/mob/living/carbon/human/proc/emote_lizard_hiss,
+		/mob/living/carbon/human/proc/emote_lizard_squeal,
+		/mob/living/carbon/human/proc/emote_lizard_thump,
 	)
 
 /obj/item/organ/tongue/moth
@@ -302,4 +314,5 @@
 	emote_verbs = list(
 		/mob/living/carbon/human/proc/emote_chitter,
 		/mob/living/carbon/human/proc/emote_flutter,
+		/mob/living/carbon/human/proc/emote_squeak,
 	)


### PR DESCRIPTION
## About The Pull Request

* Allows Half-kin, Wildkin and Verminvolk to use Lizard and Fluvian emotes.
* Allows Lizard and Fluvian to use some more emotes.
* Allows Lizard to purr (important).

## Testing Evidence
<img width="299" height="424" alt="ภาพ" src="https://github.com/user-attachments/assets/48725093-0d8c-4a3d-ae18-b86af5369e31" />

## Why It's Good For The Game

When the noises were initially separated between wild-tongue, lizard, and moth, it was due to UI bloat. 
At the time, the emote panel was split between visual emote and noise emote tab, which clutters up alongside the common noise emotes like 'cry' and 'clap' that all species get.
* Now that we have the emotes separated into sections and a search bar, I think this is good to bring this back again, myself having my own half-spider wild-kin who could use this.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Half-kin, Wild-kin, and Verminvolk can use Lizard and Fluvian sound emotes.
code: Lizard and Fluvian can use some of Wild-tongue emotes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
