### PR TITLE
blessed food no longer becomes awful

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -110,7 +110,7 @@
 	quality = F.faretype
 	bitesize_mod = 1 / F.bitesize
 	patron = patron_init
-	F.faretype = clamp(skill, 1, 5)
+	F.faretype = max(clamp(skill, 1, 5), quality)
 	if(skill < 5 || patron.type != /datum/patron/divine/eora)
 		F.add_filter(BLESSED_FOOD_FILTER, 1, list("type" = "outline", "color" = "#ff00ff", "size" = 1))
 	else


### PR DESCRIPTION
## About The Pull Request
bless food didn't account for the initial quality of the food and could actually _lower_ the quality to impoverished at novice miracleskill. that probably should not be a thing! so now it just uses the higher of your skill or the original quality; currently if you bless food nobles will start puking when they eat it unless your miracleskill is high enough

## Testing Evidence
compiles

## Why It's Good For The Game
probably a bug

## Changelog

:cl:
fix: blessing food no longer lowers its quality
/:cl:
