### PR TITLE
Twirls n Flourishes

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -183,6 +183,10 @@
 			if("onbelt")
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
+/obj/item/rogueweapon/huntingknife/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("You can twirl this weapon by right-clicking it in your hand. Doing so safely requires [skill_to_string(SKILL_LEVEL_JOURNEYMAN)] skills; anything less risks harming yourself.")
+
 /obj/item/rogueweapon/huntingknife/rmb_self(mob/user)
 	. = ..()
 	if(.)
@@ -194,7 +198,7 @@
 		return
 
 	COOLDOWN_START(src, flip_cooldown, 3 SECONDS)
-	if((user.get_skill_level(/datum/skill/combat/knives) < 3) && prob(40))
+	if((user.get_skill_level(/datum/skill/combat/knives) < SKILL_LEVEL_JOURNEYMAN) && prob(40))
 		user.visible_message(
 			span_danger("While trying to flip [src] [user] drops it instead!"),
 			span_userdanger("While trying to flip [src] you drop it instead!"),

--- a/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
@@ -248,6 +248,7 @@
 	special = /datum/special_intent/quarterstaff_sweep
 	anvilrepair = /datum/skill/craft/carpentry
 	resistance_flags = FLAMMABLE
+	twirly = SKILL_LEVEL_JOURNEYMAN
 
 /obj/item/rogueweapon/woodstaff/getonmobprop(tag)
 	. = ..()
@@ -452,6 +453,7 @@
 	throwforce = 25
 	resistance_flags = FLAMMABLE
 	special = /datum/special_intent/polearm_backstep
+	twirly = SKILL_LEVEL_EXPERT // safely twirling like, a halberd, is going to be harder than a blunt staff
 
 /obj/item/rogueweapon/spear/short
 	force = 25

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -43,6 +43,7 @@
 	inv_storage_delay = 1.5 SECONDS
 	edelay_type = 1
 	special = /datum/special_intent/shin_swipe
+	twirly = SKILL_LEVEL_EXPERT // possible, but harder than staves n knives
 
 /obj/item/rogueweapon/sword/Initialize()
 	. = ..()
@@ -263,12 +264,12 @@
 	. = ..()
 	if(used)
 		return
-		
+
 	var/list/special_options = list()
 	for(var/intent in selection)
 		var/datum/special_intent/S = intent // Hate this DM quirk.
 		special_options[S::name] = S
-	
+
 	var/choice = input(user, "Choose the Manoeuvre", "MANOEUVRE") as anything in special_options
 	if(choice)
 		qdel(special)
@@ -345,7 +346,7 @@
 	icon_state = "sbroadsword"
 	sheathe_icon = "sbroadsword"
 	max_blade_int = 330 //Sharper than a longsword, but with reduced defense. The use of steel balances its integrity out with a slight +10 bonus.
-	max_integrity = 160 
+	max_integrity = 160
 	wdefense_wbonus = 3
 	smeltresult = /obj/item/ingot/steel
 
@@ -708,7 +709,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	swingsound = BLADEWOOSH_HUGE
 	smeltresult = /obj/item/ingot/iron
-	max_blade_int = 330 
+	max_blade_int = 330
 	smelt_bar_num = 2 // 1 bar loss
 	vorpal = TRUE // snicker snack this shit cuts heads off effortlessly (DO NOT PUT THIS ON ANYTHING ELSE UNLESS IT'S SUPER FUCKING RARE!!!)
 
@@ -755,7 +756,7 @@
 				return list("shrink" = 0.6,"sx" = 9,"sy" = -4,"nx" = -7,"ny" = 1,"wx" = -9,"wy" = 2,"ex" = 10,"ey" = 2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 5,"sturn" = -190,"wturn" = -170,"eturn" = -10,"nflip" = 8,"sflip" = 8,"wflip" = 1,"eflip" = 0)
 			if("onback")
 				return list("shrink" = 0.6,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
-			if("altgrip") 
+			if("altgrip")
 				return list("shrink" = 0.45,"sx" = 2,"sy" = 3,"nx" = -7,"ny" = 1,"wx" = -8,"wy" = 0,"ex" = 8,"ey" = -1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -135,"sturn" = -35,"wturn" = 45,"eturn" = 145,"nflip" = 8,"sflip" = 8,"wflip" = 1,"eflip" = 0)
 
 /obj/item/rogueweapon/sword/long/exe/cloth
@@ -765,7 +766,7 @@
 	winds around the ricasso, ever-present to keep its edge spotless for the executionee's final \
 	judgement. The stout-angled blade bears an enscription along its length; </br>'WHEN THIS SWORDE I DOTH LYFT, I WISH THE SINNER ETERNAL LYFE AS THINE GYFT.'"
 	smeltresult = /obj/item/ingot/gold // It is the most valuable component
-	max_blade_int = 363 
+	max_blade_int = 363
 	smelt_bar_num = 2
 
 /obj/item/rogueweapon/sword/long/exe/cloth/rmb_self(mob/user)
@@ -1230,7 +1231,7 @@
 	name = "silver shortsword"
 	desc = "A shortsword with a blade of pure silver. In the marginalia of tomes depicting Psydonia's crusading orders, there is no sight more iconic than that of \
 	the hauberk-draped paladin; a kite shield in one hand, and this glimmering sidearm in the other."
-	icon = 'icons/roguetown/weapons/daggers32.dmi'	
+	icon = 'icons/roguetown/weapons/daggers32.dmi'
 	icon_state = "silverswordshort"
 	sheathe_icon = "psyswordshort"
 	force = 20
@@ -1700,12 +1701,12 @@
 	. = ..()
 	if(used)
 		return
-		
+
 	var/list/special_options = list()
 	for(var/intent in selection)
 		var/datum/special_intent/S = intent // Hate this DM quirk.
 		special_options[S::name] = S
-	
+
 	var/choice = input(user, "Choose the Manoeuvre", "MANOEUVRE") as anything in special_options
 	if(choice)
 		qdel(special)
@@ -2002,7 +2003,7 @@
 				return list("shrink" = 0.45,"sx" = 9,"sy" = -4,"nx" = -7,"ny" = 1,"wx" = -9,"wy" = 2,"ex" = 10,"ey" = 2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 5,"sturn" = -190,"wturn" = -170,"eturn" = -10,"nflip" = 8,"sflip" = 8,"wflip" = 1,"eflip" = 0)
 			if("onback")
 				return list("shrink" = 0.7,"sx" = -3,"sy" = -2,"nx" = -7,"ny" = -2,"wx" = -11,"wy" = 7,"ex" = 11,"ey" = -3,"nturn" = -28,"sturn" = -30,"wturn" = 160,"eturn" = 32,"nflip" = 5,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
-			if("altgrip") 
+			if("altgrip")
 				return list("shrink" = 0.45,"sx" = 2,"sy" = 3,"nx" = -7,"ny" = 1,"wx" = -8,"wy" = 0,"ex" = 8,"ey" = -1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -135,"sturn" = -35,"wturn" = 45,"eturn" = 145,"nflip" = 8,"sflip" = 8,"wflip" = 1,"eflip" = 0)
 
 /obj/item/rogueweapon/sword/long/rhomphaia/copper
@@ -2033,13 +2034,13 @@
 				return list("shrink" = 0.4,"sx" = -14,"sy" = -8,"nx" = 13,"ny" = -8,"wx" = -10,"wy" = -5,"ex" = 7,"ey" = -6,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -13,"sturn" = 110,"wturn" = -60,"eturn" = -30,"nflip" = 1,"sflip" = 1,"wflip" = 8,"eflip" = 1)
 			if("onbelt")
 				return list("shrink" = 0.4,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
-			if("wielded") 
+			if("wielded")
 				return list("shrink" = 0.5,"sx" = 9,"sy" = -4,"nx" = -7,"ny" = 1,"wx" = -9,"wy" = 2,"ex" = 10,"ey" = 2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 5,"sturn" = -190,"wturn" = -170,"eturn" = -10,"nflip" = 8,"sflip" = 8,"wflip" = 1,"eflip" = 0)
-			if("onback") 
+			if("onback")
 				return list("shrink" = 0.45, "sx" = -1, "sy" = 2, "nx" = 0, "ny" = 2, "wx" = 2, "wy" = 1, "ex" = 0, "ey" = 1, "nturn" = 0, "sturn" = 0, "wturn" = 70, "eturn" = 15, "nflip" = 1, "sflip" = 1, "wflip" = 1, "eflip" = 1, "northabove" = 1, "southabove" = 0, "eastabove" = 0, "westabove" = 0)
-			if("onbelt") 
+			if("onbelt")
 				return list("shrink" = 0.4, "sx" = -4, "sy" = -6, "nx" = 5, "ny" = -6, "wx" = 0, "wy" = -6, "ex" = -1, "ey" = -6, "nturn" = 100, "sturn" = 156, "wturn" = 90, "eturn" = 180, "nflip" = 0, "sflip" = 0, "wflip" = 0, "eflip" = 0, "northabove" = 0, "southabove" = 1, "eastabove" = 1, "westabove" = 0)
-			if("altgrip") 
+			if("altgrip")
 				return list("shrink" = 0.45,"sx" = 2,"sy" = 3,"nx" = -7,"ny" = 1,"wx" = -8,"wy" = 0,"ex" = 8,"ey" = -1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -135,"sturn" = -35,"wturn" = 45,"eturn" = 145,"nflip" = 8,"sflip" = 8,"wflip" = 1,"eflip" = 0)
 
 /obj/item/rogueweapon/sword/long/hand
@@ -2201,7 +2202,7 @@
 	The unique colour of the blade is due to a forging technique combining Manablooms with the steel, giving the weapon better attunement with the Acryne."
 	icon_state = "mkriegmesser"
 	smeltresult = /obj/item/ingot/steel
-	sheathe_icon = "mkriegmesser" 
+	sheathe_icon = "mkriegmesser"
 
 /obj/item/rogueweapon/sword/long/kriegmesser/ssangsudo
 	name = "ssangsudo"
@@ -2448,7 +2449,7 @@
 	desc = "A stained sabre made of blacksteel, its edge is coated in long-dried blood as well as poison."
 	icon_state = "poisonsaber"
 	force = 25
-	max_integrity = 200 
+	max_integrity = 200
 	parrysound = list('sound/combat/parry/bladed/bladedthin (1).ogg', 'sound/combat/parry/bladed/bladedthin (2).ogg', 'sound/combat/parry/bladed/bladedthin (3).ogg')
 	sellprice = 50
 	smeltresult = null

--- a/code/game/objects/items/rogueweapons/rogueweapon.dm
+++ b/code/game/objects/items/rogueweapons/rogueweapon.dm
@@ -42,18 +42,21 @@
 	var/datum/special_intent/special
 
 	var/malumblessed_w = FALSE
-	
+
 	// whether this is actually a tool, like hoes and hammers, not a weapon proper. used to allow TRAIT_TINYPAWS users to conduct repairs and such
 	var/is_tool = FALSE
 	/// sigh
 	var/hoe_damage = null //the durability damage recieved for every work cycle
 	var/work_time = 3 SECONDS // the time it takes to make new soil or till soil
 
+	var/twirly // set this to a skill level to gate twirling. if it's falsy, you can't twirl the weapon. knives and staves are jman, swords are expert
+	COOLDOWN_DECLARE(twirl_cooldown) //twirling has a cooldown on to_chat to reduce chatspam
+
 /obj/item/rogueweapon/Initialize()
 	. = ..()
 	if(!destroy_message)
 		destroy_message = span_warning("\The [src] shatters!")
-	
+
 	if(ispath(special))
 		special = new special()
 
@@ -176,3 +179,36 @@
 	blade_dulling = new_shaft
 	qdel(S)
 	new replaced_shaft(src.drop_location())
+
+/obj/item/rogueweapon/rmb_self(mob/user)
+	. = ..()
+	if(. || !twirly)
+		return
+
+	SpinAnimation(4, 2) // The spin happens regardless of the cooldown
+
+	if(!COOLDOWN_FINISHED(src, twirl_cooldown))
+		return
+
+	COOLDOWN_START(src, twirl_cooldown, 3 SECONDS)
+	var/twirlskill = twirly - ((associated_skill == /datum/skill/combat/arcyne) ? 1 : 0) // AA is proliferated quite sparingly, jman AA is like expert in most wskills
+	if((user.get_skill_level(associated_skill) < twirlskill) && prob(40))
+		user.visible_message(
+			span_danger("While trying to twirl [src] [user] drops it instead!"),
+			span_userdanger("While trying to twirl [src] you drop it instead!"),
+		)
+		var/mob/living/carbon/human/unfortunate_idiot = user
+		var/dropped_knife_target = pick(
+			BODY_ZONE_PRECISE_L_FOOT,
+			BODY_ZONE_PRECISE_R_FOOT,
+			)
+		unfortunate_idiot.apply_damage(src.force, BRUTE, dropped_knife_target)
+		user.dropItemToGround(src, TRUE)
+	else
+		user.visible_message(
+			span_notice("[user] twirls [src] in a dramatic flourish!"),
+			span_notice("You twirl [src] dramatically."),
+		)
+		playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
+
+	return

--- a/code/game/objects/items/rogueweapons/rogueweapon.dm
+++ b/code/game/objects/items/rogueweapons/rogueweapon.dm
@@ -119,12 +119,37 @@
 	..()
 
 /obj/item/rogueweapon/rmb_self(mob/user)
-	if(!has_altgrip_modes())
-		return ..()
-	if(wielded && !altgripped)
-		ungrip(user)
-	altgrip(user)
-	user.update_inv_hands()
+	if(has_altgrip_modes() && user.cmode)
+		if(wielded && !altgripped)
+			ungrip(user)
+		altgrip(user)
+		user.update_inv_hands()
+	else if(twirly)
+		SpinAnimation(4, 2) // The spin happens regardless of the cooldown
+
+		if(!COOLDOWN_FINISHED(src, twirl_cooldown))
+			return ..()
+
+		COOLDOWN_START(src, twirl_cooldown, 3 SECONDS)
+		var/twirlskill = twirly - ((associated_skill == /datum/skill/combat/arcyne) ? 1 : 0) // AA is proliferated quite sparingly, jman AA is like expert in most wskills
+		if((user.get_skill_level(associated_skill) < twirlskill) && prob(40))
+			user.visible_message(
+				span_danger("While trying to twirl [src] [user] drops it instead!"),
+				span_userdanger("While trying to twirl [src] you drop it instead!"),
+			)
+			var/mob/living/carbon/human/unfortunate_idiot = user
+			var/dropped_knife_target = pick(
+				BODY_ZONE_PRECISE_L_FOOT,
+				BODY_ZONE_PRECISE_R_FOOT,
+				)
+			unfortunate_idiot.apply_damage(src.force, BRUTE, dropped_knife_target)
+			user.dropItemToGround(src, TRUE)
+		else
+			user.visible_message(
+				span_notice("[user] twirls [src] in a dramatic flourish!"),
+				span_notice("You twirl [src] dramatically."),
+			)
+			playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
 	return ..()
 
 /obj/item/shaft
@@ -180,41 +205,8 @@
 	qdel(S)
 	new replaced_shaft(src.drop_location())
 
-/obj/item/rogueweapon/rmb_self(mob/user)
-	. = ..()
-	if(. || !twirly)
-		return
-
-	SpinAnimation(4, 2) // The spin happens regardless of the cooldown
-
-	if(!COOLDOWN_FINISHED(src, twirl_cooldown))
-		return
-
-	COOLDOWN_START(src, twirl_cooldown, 3 SECONDS)
-	var/twirlskill = twirly - ((associated_skill == /datum/skill/combat/arcyne) ? 1 : 0) // AA is proliferated quite sparingly, jman AA is like expert in most wskills
-	if((user.get_skill_level(associated_skill) < twirlskill) && prob(40))
-		user.visible_message(
-			span_danger("While trying to twirl [src] [user] drops it instead!"),
-			span_userdanger("While trying to twirl [src] you drop it instead!"),
-		)
-		var/mob/living/carbon/human/unfortunate_idiot = user
-		var/dropped_knife_target = pick(
-			BODY_ZONE_PRECISE_L_FOOT,
-			BODY_ZONE_PRECISE_R_FOOT,
-			)
-		unfortunate_idiot.apply_damage(src.force, BRUTE, dropped_knife_target)
-		user.dropItemToGround(src, TRUE)
-	else
-		user.visible_message(
-			span_notice("[user] twirls [src] in a dramatic flourish!"),
-			span_notice("You twirl [src] dramatically."),
-		)
-		playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
-
-	return
-
 /obj/item/rogueweapon/get_mechanics_examine(mob/user)
 	. = ..()
 	if(twirly)
 		var/twirlskill = twirly - ((associated_skill == /datum/skill/combat/arcyne) ? 1 : 0)
-		. += span_info("You can twirl this weapon by right-clicking it in your hand. Doing so safely requires [skill_to_string(twirlskill)] skills; anything less risks harming yourself.")
+		. += span_info("You can twirl this weapon by right-clicking it in your hand[has_altgrip_modes()?" out of combat mode":""]. Doing so safely requires [skill_to_string(twirlskill)] skills; anything less risks harming yourself.")

--- a/code/game/objects/items/rogueweapons/rogueweapon.dm
+++ b/code/game/objects/items/rogueweapons/rogueweapon.dm
@@ -212,3 +212,9 @@
 		playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
 
 	return
+
+/obj/item/rogueweapon/get_mechanics_examine(mob/user)
+	. = ..()
+	if(twirly)
+		var/twirlskill = twirly - ((associated_skill == /datum/skill/combat/arcyne) ? 1 : 0)
+		. += span_info("You can twirl this weapon by right-clicking it in your hand. Doing so safely requires [skill_to_string(twirlskill)] skills; anything less risks harming yourself.")

--- a/modular/Neu_Food/code/cookware/pan.dm
+++ b/modular/Neu_Food/code/cookware/pan.dm
@@ -24,6 +24,8 @@
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	obj_flags = CAN_BE_HIT
 
+	COOLDOWN_DECLARE(twirl_cooldown) //twirling has a cooldown on to_chat to reduce chatspam
+
 /obj/item/cooking/pan/getonmobprop(tag)
 	. = ..()
 	if(tag)
@@ -40,6 +42,7 @@
 	. += span_info("Frying pans can be placed atop a hearth by left-clicking it. Left-click the placed frying pan with an ingredient to begin frying - so long as the hearth is lit.")
 	. += span_info("Meats, cackleberries, and sliced vegetables are the ideal choices for frying. Other ingredients and recipes might require the gentle caress of an oven, instead.")
 	. += span_info("Leaving a fully baked item on the pan for too long will cause it to burn away.")
+	. += span_info("You can twirl [src] by right-clicking it in your hand while in combat mode. Doing so safely requires Expert skill; anything less risks harming yourself.")
 
 /datum/intent/mace/strike/pan
 	hitsound = list('sound/combat/hits/blunt/frying_pan(1).ogg', 'sound/combat/hits/blunt/frying_pan(2).ogg', 'sound/combat/hits/blunt/frying_pan(3).ogg', 'sound/combat/hits/blunt/frying_pan(4).ogg')
@@ -82,3 +85,37 @@
 		switch(tag)
 			if("gen")
 				return list("shrink" = 0.6,"sx" = -7,"sy" = -4,"nx" = 7,"ny" = -4,"wx" = -4,"wy" = -4,"ex" = 2,"ey" = -4,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
+/obj/item/cooking/pan/rmb_self(mob/user)
+	. = ..()
+	if(. || !user.cmode) // don't want people to accidentally do this while cooking
+		return
+
+	SpinAnimation(4, 2) // The spin happens regardless of the cooldown
+
+	if(!COOLDOWN_FINISHED(src, twirl_cooldown))
+		return
+
+	COOLDOWN_START(src, twirl_cooldown, 3 SECONDS)
+	if((user.get_skill_level(associated_skill) < SKILL_LEVEL_EXPERT) && prob(40))
+		var/crit = prob(60) // separate role to KO
+		var/critmsg = " <span class='crit'><b>Critical hit!</b> [user] is knocked out!</span>"
+		user.visible_message(
+			span_danger("While trying to twirl [src] [user] flings it instead, hitting [user.p_themselves()] in the head![crit ? critmsg : ""]"),
+			span_userdanger("While trying to twirl [src] you fling it instead, hitting yourself in the head![crit ? critmsg : ""]"),
+		)
+		var/mob/living/carbon/human/unfortunate_idiot = user
+		unfortunate_idiot.apply_damage(src.force, BRUTE, BODY_ZONE_PRECISE_SKULL)
+		if(crit)
+			unfortunate_idiot.flash_fullscreen("whiteflash3")
+			unfortunate_idiot.Unconscious(5 SECONDS)
+		playsound(get_turf(unfortunate_idiot), 'sound/combat/hits/blunt/frying_pan(1).ogg', 100, FALSE)
+		user.dropItemToGround(src, TRUE)
+	else
+		user.visible_message(
+			span_notice("[user] twirls [src] in a dramatic flourish!"),
+			span_notice("You twirl [src] dramatically."),
+		)
+		playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
+
+	return


### PR DESCRIPTION
## About The Pull Request
Expands the knife-flipping mechanic to more weapon types with an appropriate level of gating: wooden staves can be twirled with jman skills, swords and polearms (almost entirely because the ducal standard is a polearm) with expert. This is both because bladed weapons are harder to twirl safely, and because staff classes tend to have low wskills (mages, for example, almost all get apprentice staves, whereas a poor sword-using adventurer might have journeyman - with expert being specialized classes). Mage-conjured blades will usually require jman skill instead, because expert AA is absurdly rare. Pans can be twirled as well at expert cooking (so roundstart seneschal) but it requires you to be in combat mode, so that you don't accidentally do it while cooking. All this information is conveyed through mechanics examines on the relevant items.

Also fixes a bug where knives that used any wskill other than knives couldn't use their actual weaponskill to twirl.

## Testing Evidence

https://github.com/user-attachments/assets/93c11e1e-db2f-47fc-bd5b-bdecfa00e9d3

## Why It's Good For The Game
dramatic flourishes for characters with a notable level of skill in a weapon r cool. folk emote twirling staves often enough that there's certainly a desire for it. the way this is gated should prevent it from being _too_ proliferated (only classes actually designed to use a weapon type can twirl with it for the most part) n it's nice flavor for bombastic characters

## Changelog

:cl:
add: Wooden staves and conjured blades can now be twirled like daggers at journeyman skill; swords and polearms at expert. Pans can be twirled at expert cooking, but you must be in cmode to do so.
fix: Knives that don't use knives skill (e.g. if you bind one as a ferramancer) can now be twirled using their actual associated skill, instead of being hardcoded to use knives.
/:cl: