### PR TITLE
[BALANCE HOTFIX] Removes Zizo Divine blast from your Spell-list if you do Rituos + axes diagnosis from Zizo miracles.

### DIFF
--- a/code/modules/spells/pantheon/inhumen/_inhumen_spell_utils.dm
+++ b/code/modules/spells/pantheon/inhumen/_inhumen_spell_utils.dm
@@ -50,8 +50,7 @@
 		ADD_TRAIT(user, TRAIT_JACKOFALLTRADES, "[type]")
 		ADD_TRAIT(user, TRAIT_SELF_SUSTENANCE, "[type]")
 		ADD_TRAIT(user, TRAIT_UNLYCKERABLE, "[type]")
-		//Our Spells
-		user.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/zizo)
+		//Our Extra Spell -> Analyise construct/building durability. Zizo-Unique Progress aspect, niché use but y'know. Lady of Artifice and all.
 		user.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/engineeranalyze/zizo)
 		//gigajank to ensure we get both Profane Bone + Strip Knowledge at once for this path
 		user.mind.RemoveSpell(/datum/action/cooldown/spell/zizo/stripknowledgeorprofane)
@@ -60,6 +59,8 @@
 		//re-add our stuff
 		user.mind.AddSpell(new /datum/action/cooldown/spell/zizo/stripknowledge)
 		user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/zizo/profane)
+		//we lose divine blast, we don't need debuffs on top of 4+ offensives w/ magic/miracle
+		user.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/projectile/unholyblast)
 		grant_poke_spell(user)
 
 	user.visible_message(
@@ -118,6 +119,8 @@
 		user.mind.AddSpell(new /datum/action/cooldown/spell/raise_undead_formation/zizo)
 		user.mind.AddSpell(new /datum/action/cooldown/spell/zizo/bone_cataclysm)
 		user.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite)
+		//we lose divine blast, we don't need debuffs on top of magic on top of being immune to bloodloss
+		user.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/projectile/unholyblast)
 		grant_poke_spell(user)
 
 	user.visible_message(

--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -543,8 +543,16 @@
 // Unlife: Full skeletonization (minus head) + MOB_UNDEAD, grants bonechill and raise_deadite. -- Kunai: We already have raise_deadite, so it's a moot point to give them the Necromancer version of it. Just gave them bonemend and a few more traits to give the vibe of a 'half-lich'.
 // Both paths grant undead language and TRAIT_ARCYNE. One-time use - cannot be cast again after completion.
 
-//SOEP -- Undeath gets: miracle-raise undead, bone catacalysm + raise deadite + classic undeath traits. Offensive varient w/ silver weakness and stamina-control for functional immortality.
-//SOEP -- Progress gets: rapid skill leveling, ability to consume lux into health and stamina, more utility points for casting. Defensive varient w/ focus on talent and assistance.
+/*
+SOEP
+ -- Undeath gets: miracle-raise undead, bone catacalysm + raise deadite + classic undeath traits. Offensive varient w/ silver weakness and stamina-control for functional immortality.
+ -- Progress gets: rapid skill leveling, ability to consume lux into health and stamina, more utility points for casting. Defensive varient w/ focus on talent and assistance.
+ -- Both paths will LOSE divine blast if you have it, you don't get to chain 4 offensive spells w/ debuffs and magic all at once. Nessessary, Zizo's divine blast is strong enough to make up for it partly.
+
+ -- Int reduction/Profane both on Progress is still strong tho (you can bleed out w/ this), as well as spite to weaken a singluar target a fair-bit. Nessessary, to keep up w/ undeath route.
+ -- If missionaries become too problematic, give a ritualist trait-check and if you lack it we remove spite on doing rituos and move that over so zeretics can have it but not adv missionaries.
+
+ */
 
 /datum/action/cooldown/spell/zizo/rituos
 	name = "Rituos"
@@ -829,15 +837,6 @@
 	action_icon = 'icons/mob/actions/zizomiracles.dmi'
 	range = SPELL_RANGE_GROUND //Longer than regular diagnosis range. Progress Baby!
 	antimagic_allowed = FALSE //Arcane, duh.
-
-// Diagnosis (T?) - Progress Path: Reflavored version of Pestra's diagnosis, it basically does what you'd expect. Has a highly inefficent cost for some unique perks like extra range.
-/obj/effect/proc_holder/spell/invoked/diagnose/zizo
-	name = "Profane Diagnosis"
-	desc = "Call upon Enochian magicka and Zizo's stolen medical knowledge to read the body's humors and hidden ailments at a sizable distance. Reveals a target's condition with perfect clarity. To perceive one's blood content, all you'll need is but an incision."
-	overlay_icon = 'icons/mob/actions/zizomiracles.dmi'
-	action_icon = 'icons/mob/actions/zizomiracles.dmi'
-	range = SPELL_RANGE_GROUND //Longer than regular diagnosis range. Progress Baby!
-	devotion_cost = 15 //Significantly more expensive (3x)
 
 // Enochian Analyze (T?) - Progress Path: A long-range miracle version of the spell engineering goggles give you, Progress Baby!
 /obj/effect/proc_holder/spell/invoked/engineeranalyze/zizo

--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -541,7 +541,7 @@
 
 // Progress: Arcyne knowledge (2 minor aspects, 4 utilities). No skeletonization. -- Kunai: I made this more distinctive from Undeath, now it also gives you some traits to give a better progress vibe.
 // Unlife: Full skeletonization (minus head) + MOB_UNDEAD, grants bonechill and raise_deadite. -- Kunai: We already have raise_deadite, so it's a moot point to give them the Necromancer version of it. Just gave them bonemend and a few more traits to give the vibe of a 'half-lich'.
-// Both paths grant undead language and TRAIT_ARCYNE. One-time use - cannot be cast again after completion.
+// Both paths grant undead language and TRAIT_ARCYNE. One-time use - cannot be cast again after completion. If you outsmart and try to exploit this, we kill you horrifically.
 
 /*
 SOEP


### PR DESCRIPTION
## About The Pull Request

Doing Rituos removes your divine blast since the miracle-set can stand up w/out it.

Zizite-Diagnosis is just Necro/Lich exclusive now, you don't get it w/ Progress


*Yea Profane Diagnosis is, gone sire.*

---

I was going to get back onto it after a brief break from Azure but my PR got merged so I gotta pick up the slack.
*expected though, I am a contributor, its my duty to fix my own PRs ASAP w/ super glaring issues that make shit a bit too insufferable by obligation of good faith to this codebase. So here we are.*

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Did rituos, no longer have divine blast to spam on top of everything else.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Being able to chain profane -> int reduction -> spite -> offensive cantrip -> hex or w/e -> arcayne ward all back to back is strong but thematic.

Except...
Missionary adventurers have unholy blast on top and you see...

Divine blasts do stabbing damage w/ reverse sunder checks (excluding Necrans/WWs) and on top of all of that, Zizo is far too overbaring for what she should get kit-wise if you do rituos.

No. Just, no.

---

The main issue is divine blast for Zizo sets you on fire and they have so much shit to break your armor and nuke your stats. So we're shooting that. If you want mage stuff, you do rituos. If you want the strong divine blast, you don't.

Shrimple.

This mostly affects missionary advs, because w/out it, Zizo clerics are a lot, more barable. Its a single spell but it makes a huge difference w/ how tuned up it is (60/40-ish damage vs divine/psydonites on top of spells too btw under certain conditions)

Diagnosis is a Pestra thing, you keep your analyize since she's the DAME OF PROGRESS. I probably overcrept the patron W/ that.
*Necromancer/Lich need it because bone chill is a limb-targeted thing and because they'll be busy fighting at a distance anyway.*

---

I plan to come back shortly to Zizo miracles and give them a bit more more exclusive content and chop away some of their skele spam aspect back to lich/necro only in exchange for something cooler to replace it.

You can also not do rituos but I think its fine at that point, you sacrifice 2 minor aspects + cantrip for this. Sure.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Profane diagnosis, the 7 tile spell diagnosis is only exclusive to Necromancer/Lich now who both need it to use bone chill efficiently.
balance: doing rituos removes your unholy blast spells, you have an offensive cantrip that costs you no devotion already. Use profane or w/ever else, you still have a lot you can chain back-to-back, especally w/ Progress path for Zizo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
