### PR TITLE
Fulgurmancy PVP Nerfs

### DIFF
--- a/code/modules/spells/spell_types/wizard/fulgurmancy/levinstroke.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/levinstroke.dm
@@ -17,13 +17,13 @@
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = TRUE
-	charge_swingdelay_type = SWINGDELAY_PENALTY
+	charge_swingdelay_type = SWINGDELAY_CANCEL
 	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_MINOR
 	hold_drain = 1
-	charge_slowdown = CHARGING_SLOWDOWN_NONE
+	charge_slowdown = CHARGING_SLOWDOWN_SMALL
 	charge_sound = 'sound/magic/charging.ogg'
-	cooldown_time = 20 SECONDS
+	cooldown_time = 30 SECONDS
 
 	associated_skill = /datum/skill/magic/arcane
 	spell_tier = 2

--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -85,7 +85,7 @@
 	id = "lightningstruck"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/lightningstruck
 	duration = 6 SECONDS
-	effectedstats = list(STATKEY_STR = -2, STATKEY_SPD = -2, STATKEY_PER = -3, STATKEY_INT = -2)
+	effectedstats = list(STATKEY_STR = -2, STATKEY_PER = -3, STATKEY_INT = -2)
 
 /atom/movable/screen/alert/status_effect/buff/lightningstruck
 	name = "Lightning Struck"


### PR DESCRIPTION
## About The Pull Request
After gathering feedbacks it is clear that Fulgurmancy is overperforming in PVP. So, I am adjusting it: 
- Levinstroke CD from 20 -> 30 seconds, now slowdown penalty of small instead of none, consistent with blink, and a SWINGDELAY_CANCEL
- Lightning Bolt no longer applies -2 SPD as a debuff

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Number Adjustment

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fulgurmancy seems to be responsible for around post Mage 3 50 - 70% of the complaints about mage PVP balance due to the combination of hitscan, powerful CC and escape tool. So I am adjusting it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Levinstroke CD from 20 -> 30 seconds, now slowdown penalty of small instead of none, consistent with blink, and a SWINGDELAY_CANCEL
balance: Lightning Bolt no longer applies -2 SPD as a debuff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
