### PR TITLE
buffs thespian errant for construct race

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -489,7 +489,7 @@
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 	)
 
-	extra_context = "This subclass can pick from a wide array of bronze weapons, armor, and origins to specialize in. Bronze armor - while easily pierced - is exceptionally durable and resistant against critical hits. A total of four Disciplines are available, each providing a different trait and armoring-tier."
+	extra_context = "This subclass can pick from a wide array of bronze weapons, armor, and origins to specialize in. Bronze armor - while easily pierced - is exceptionally durable and resistant against critical hits. A total of four Disciplines are available, each providing a different trait and armoring-tier. Metal Constructs have the innate speed malus removed due to their innately durable nature."
 
 /datum/outfit/job/roguetown/adventurer/bronzeclad/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -685,6 +685,8 @@
 			id = /obj/item/clothing/neck/roguetown/psicross/noc/bronze
 		else
 			id = /obj/item/clothing/ring/bronze
+	if(isconstruct(H))
+		H.change_stat(STATKEY_SPD, 2)
 
 /datum/advclass/foreigner/lesserblackoak
 	name = "Azurian Grovewalker"


### PR DESCRIPTION
## About The Pull Request

Construct thespian players gain no benefit from TRAIT_BLOOD_RESISTANCE, and as such are uniquely punished with thespian's stat lineup. So this tosses them a bone by giving constructs a bonus of +2 SPD, effectively removing the -2 SPD that thespians normally get, giving them a statweight of 7. Should constructs be reworked further to end up bleeding or otherwise have some sort of interaction with the TRAIT_BLOOD_RESISTANCE then this should be revisited and the buff removed.

## Testing Evidence

Tested locally by loading in as a construct and also as any of the other races, and the stats were appropriately applied. Only the construct got the buff, all others did not. Thus all started with 8 speed (barring statpacks or if you chose the heavy armor option of course).

## Why It's Good For The Game

As said before, constructs who happen to be thespians are uniquely shafted with having only 6 speed, and nothing to show for it either. They gain no benefit from the innate bleed resistance thespians have and suffer quite a bit as a result. I think this change would actually lead to people possibly considering playing as a thespian construct, whereas before it was almost a non-option.

## Changelog

:cl:
balance: Thespian-Errant Constructs no longer have the classes innate speed malus.
/:cl:
