### PR TITLE
remove forced scream/freakout from mimic

### DIFF
--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -7,7 +7,7 @@
 				delay = 13
 			if("night", "dusk")
 				delay = 16
-	if(world.time > last_fatigued + delay) //regen fatigue 
+	if(world.time > last_fatigued + delay) //regen fatigue
 		var/added = energy / max_energy
 		added = round(-10 + (added * - 40))
 		if(src.climbing) // no stam regen while climbing guh
@@ -262,24 +262,6 @@
 				continue
 			animate(whole_screen, transform = newmatrix, time = 3, easing = QUAD_EASING)
 			animate(transform = -newmatrix, time = 40, easing = QUAD_EASING)
-
-/mob/living/carbon/proc/freak_out_mimic(mob/target)
-	if(mob_timers["freakout"])
-		if(world.time < mob_timers["freakout"] + 10 SECONDS)
-			flash_fullscreen("stressflash")
-			return
-	if(HAS_TRAIT(src, TRAIT_NOMOOD))
-		return
-	mob_timers["freakout"] = world.time
-	shake_camera(src, 1, 3)
-	flash_fullscreen("stressflash")
-	changeNext_move(CLICK_CD_EXHAUSTED)
-	add_stress(/datum/stressevent/mimic_jumpscare)
-	var/randdelay = rand(5, 150)
-	var/balloon_text = pick("<font color='#ffffff'>WHAT IS THAT?!</font>","<font color='#ffffff'>WTF?!</font>","<font color='#ffffff'>WHAT?!</font>","<font color='#ffffff'>WHAT THE-?!</font>","<font color='#ffffff'>MIMIC?!</font>","<font color='#ffffff'>SERIOUSLY?!</font>","<font color='#ffffff'>REALLY?!</font>",)
-	spawn(randdelay)
-		balloon_alert_to_viewers(balloon_text, balloon_text, DEFAULT_MESSAGE_RANGE)
-		emote("scream", forced = TRUE)
 
 /mob/living/proc/stamina_reset()
 	stamina = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/mimic.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mimic.dm
@@ -108,12 +108,6 @@
 	visible_message(span_warning("[src] suddenly bursts open, revealing gnashing fangs!"))
 	playsound(loc, pick('sound/misc/jumpscare (1).ogg','sound/misc/jumpscare (2).ogg','sound/misc/jumpscare (3).ogg','sound/misc/jumpscare (4).ogg'), 100)
 
-	for(var/mob/living/carbon/C in view(4, src))
-		if(C == src || HAS_TRAIT(C, TRAIT_NOMOOD))
-			continue
-		if(!HAS_TRAIT(C, TRAIT_PSYDONIAN_GRIT) && (!HAS_TRAIT(C, TRAIT_STEELHEARTED) || prob(50)))
-			C.freak_out_mimic(src)
-
 /mob/living/simple_animal/hostile/retaliate/rogue/mimic/Aggro()
 	..()
 	// go mask-off!


### PR DESCRIPTION
## About The Pull Request
title

## Testing Evidence
compiles; it's just removing stuff anyway

## Why It's Good For The Game
forcing characters to emote is not something that should be done lightly. it ESPECIALLY should not be done for something that is decently common to run into, with no exceptions maid for experienced adventurers (most of whom don't get steelhearted and even if they do steelhearted doesn't block it). forced freakouts are bad, if your character is getting surprised by a mimic they can roleplay it when they're done defending themselves. also, if you're being paranoid and poke the chest first or use any of the other ways to distinguish it's a mimic, it makes zero sense for it to jumpscare you - you're expecting it.

## Changelog

:cl:
del: Mimics revealing themselves or being attacked no longer forces all characters in a 4-tile radius to scream and freak out.
/:cl:
