### PR TITLE
Allows crossbow to be loaded with bolt from pouches with a free hand Slurbow / Staker can do it 1 handed. nocking check now happens before instead of after the action.

### DIFF
--- a/code/game/objects/items/quiver.dm
+++ b/code/game/objects/items/quiver.dm
@@ -115,18 +115,44 @@
 			types[A.type]["count"]++
 	return types
 
-/obj/item/quiver/proc/pick_ammo(ammo_base_type)
+/obj/item/quiver/proc/pick_ammo(ammo_base_type, wanted_caliber)
 	var/obj/item/ammo_casing/caseless/rogue/fallback
 	for(var/obj/item/ammo_casing/caseless/rogue/A in arrows)
 		if(ammo_base_type && !istype(A, ammo_base_type))
+			continue
+		if(wanted_caliber && A.caliber != wanted_caliber)
 			continue
 		if(!fallback)
 			fallback = A
 		if(preferred_ammo_type && istype(A, preferred_ammo_type))
 			return A
-	if(preferred_ammo_type)
+	if(preferred_ammo_type && !wanted_caliber)
 		preferred_ammo_type = fallback?.type
 	return fallback
+
+/obj/item/quiver/proc/try_quick_load(obj/item/gun/ballistic/revolver/grenadelauncher/B, mob/user, params)
+	if(B.chambered)
+		return FALSE
+	if(!B.can_quick_load(user))
+		return FALSE
+	if(!length(arrows))
+		to_chat(user, span_warning("[src] is empty!"))
+		return FALSE
+	var/obj/item/ammo_casing/caseless/rogue/AR = pick_ammo(allowed_ammo_type, B.magazine?.caliber)
+	if(!AR)
+		to_chat(user, span_warning("Nothing in [src] fits [B]."))
+		return FALSE
+	arrows -= AR
+	B.quickloading = TRUE
+	B.attackby(AR, user, params)
+	B.quickloading = FALSE
+	if(!B.chambered)
+		arrows += AR
+		return FALSE
+	if(HAS_TRAIT(user, TRAIT_COMBAT_AWARE))
+		user.balloon_alert(user, "[length(arrows)] left...")
+	update_icon()
+	return TRUE
 
 /obj/item/quiver/attack_turf(turf/T, mob/living/user)
 	if(get_current_weight() >= max_storage)
@@ -163,35 +189,25 @@
 
 	update_icon()
 
-/obj/item/quiver/attackby(obj/A, loc, params)
+/obj/item/quiver/attackby(obj/A, mob/user, params)
 	if(istype(A, /obj/item/ammo_casing/caseless/rogue))
 		if(!istype(A, allowed_ammo_type))
-			to_chat(loc, span_warning("That doesn't fit in [src]."))
+			to_chat(user, span_warning("That doesn't fit in [src]."))
 			return FALSE
 		var/obj/item/ammo_casing/caseless/rogue/ammo = A
 		if(get_current_weight() + ammo.ammo_weight <= max_storage)
-			if(ismob(loc))
-				var/mob/M = loc
-				M.doUnEquip(A, TRUE, src, TRUE, silent = TRUE)
+			if(ismob(user))
+				user.doUnEquip(A, TRUE, src, TRUE, silent = TRUE)
 			else
 				A.forceMove(src)
 			arrows += A
 			update_icon()
 		else
-			to_chat(loc, span_warning("Full!"))
+			to_chat(user, span_warning("Full!"))
 		return
-	if(istype(A, /obj/item/gun/ballistic/revolver/grenadelauncher/bow))
-		var/obj/item/gun/ballistic/revolver/grenadelauncher/bow/B = A
-		if(arrows.len && !B.chambered)
-			var/obj/item/ammo_casing/caseless/rogue/AR = pick_ammo(/obj/item/ammo_casing/caseless/rogue/arrow)
-			if(AR)
-				arrows -= AR
-				B.attackby(AR, loc, params)
-				if(ismob(loc))
-					var/mob/M = loc
-					if(HAS_TRAIT(M, TRAIT_COMBAT_AWARE))
-						M.balloon_alert(M, "[length(arrows)] left...")
-				update_icon()
+	if(istype(A, /obj/item/gun/ballistic/revolver/grenadelauncher))
+		if(ismob(user))
+			try_quick_load(A, user, params)
 		return
 	..()
 
@@ -244,7 +260,7 @@
 
 /obj/item/quiver/get_mechanics_examine(mob/user)
 	. = ..()
-	. += span_info("Left-click the quiver with a bow or sling to quick-load.")
+	. += span_info("Left-click with a compatible ranged weapon to nock straight from it. Bows and crossbows need my other hand free; slings do not.")
 	. += span_info("Left-click on the ground to pick up ammo.")
 	. += span_info("Shift-Right-click to select which ammo type to load first.")
 	. += span_info("Ctrl-Click to drop all ammo on the ground one by one.")
@@ -781,17 +797,6 @@
 			if(!eatarrow(sling_bullet))
 				break
 
-/obj/item/quiver/sling/attackby(obj/A, loc, params)
-	if(istype(A, /obj/item/gun/ballistic/revolver/grenadelauncher/sling))
-		var/obj/item/gun/ballistic/revolver/grenadelauncher/sling/B = A
-		if(arrows.len && !B.chambered)
-			var/obj/item/ammo_casing/caseless/rogue/AR = pick_ammo(/obj/item/ammo_casing/caseless/rogue/sling_bullet)
-			if(AR)
-				arrows -= AR
-				B.attackby(AR, loc, params)
-		return
-	..()
-
 /obj/item/quiver/sling/attack_right(mob/user)
 	if(arrows.len)
 		var/obj/O = arrows[arrows.len]
@@ -1014,12 +1019,12 @@
 	if(holstered_weapon)
 		. += span_notice("Holstered: [holstered_weapon.name].")
 	else
-		. += span_warning("No weapon holstered. Left-click with a compatible weapon to holster it.")
+		. += span_warning("No weapon holstered. Middle-click with a compatible weapon to holster it.")
 
 /obj/item/quiver/mechanized/get_mechanics_examine(mob/user)
 	. = ..()
 	. += span_info("Automatically picks up compatible ammo when you walk over it.")
-	. += span_info("Left-click with a compatible weapon to holster it.")
+	. += span_info("Middle-click with a compatible weapon to holster it.")
 	. += span_info("Right-click to draw the holstered weapon to your active hand.")
 
 //this controls the overlays, you migh need to adjust the bowoverlay_x and bowoverlay_y vars in the specific quiver types depending on the graphic

--- a/code/game/objects/items/rogueweapons/ranged/bows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/bows.dm
@@ -124,10 +124,17 @@
 	var/spill_ammo_on_drop = TRUE
 	var/ranged_skill = /datum/skill/combat/bows
 
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/can_quick_load(mob/user)
+	if(user.get_num_arms(FALSE) < 2 || user.get_inactive_held_item())
+		to_chat(user, span_warning("I need a free hand to nock [src]!"))
+		return FALSE
+	return TRUE
+
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/get_mechanics_examine(mob/user)
 	. = ..()
 	. += span_info("Bows increase in damage and accuracy the higher your <b>PERCEPTION</b>.")
 	. += span_info("Bows with a heavy draw, such as longbows, have an increased draw time for characters with low <b>STRENGTH</b>.")
+	. += span_info("Nocking straight from a quiver requires my other hand to be free.")
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/Initialize()
 	. = ..()

--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -51,7 +51,9 @@
 	. = ..()
 	. += span_info("Crossbows increase in accuracy with a higher <b>PERCEPTION</b>, but deal a static amount of damage \
 	regardless of character stats.")
-	. += span_info("Crossbows cannot be nocked directly from their quiver and require time to load.")
+	. += span_info("Crossbows must be cocked before a bolt can be nocked, but once cocked I can nock straight from a pouch by left-clicking it.")
+	if(!onehanded)
+		. += span_info("Nocking from a pouch requires my other hand to be free.")
 	if(penfactor < 0)
 		. += span_info("This weapon <b>reduces</b> bolt penetration by <b>[abs(penfactor)]</b> tier(s).")
 	else if(penfactor > 0)
@@ -159,11 +161,22 @@
 		cocked = FALSE
 		update_icon()
 
+// Allows slurbow / stakers to be reloaded one handed. Can be adjusted later if it turns out to be an issue
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/proc/free_hand_check(mob/user, action = "cock")
+	if(onehanded)
+		return TRUE
+	if(user.get_num_arms(FALSE) < 2 || user.get_inactive_held_item())
+		to_chat(user, span_warning("I need a free hand to [action] [src]!"))
+		return FALSE
+	return TRUE
+
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/attack_self(mob/living/user)
 	if(chambered)
 		..()
 	else
 		if(!cocked)
+			if(!free_hand_check(user))
+				return
 			to_chat(user, span_info("I step on the stirrup and use all my might..."))
 			if(!movingreload)
 				if(do_after(user, reloadtime - user.STASTR - user.get_skill_level(ranged_skill), target = user ))
@@ -178,10 +191,16 @@
 			cocked = FALSE
 	update_icon()
 
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/can_quick_load(mob/user)
+	if(!cocked)
+		to_chat(user, span_warning("I need to cock [src] first."))
+		return FALSE
+	return free_hand_check(user, "nock")
+
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/attackby(obj/item/A, mob/user, params)
 	if(istype(A, /obj/item/ammo_box) || istype(A, /obj/item/ammo_casing))
 		if(cocked)
-			if((loc == user) && (user.get_inactive_held_item() != src))
+			if((loc == user) && (user.get_inactive_held_item() != src) && !quickloading)
 				return
 			..()
 		else

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -14,9 +14,13 @@
 	var/accfactor = 1 // Multiplier for projectile accuracy. Used by bows and crossbows.
 	var/penfactor = 0 // Additive modifier for projectile PEN tier. Slurbow uses -1 to reduce bolt pen by one tier.
 	var/npc_force_arc = FALSE // Set by AI to force arc shot over allies
+	var/quickloading = FALSE
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/proc/get_npc_chargetime(mob/living/user)
 	return ARCHER_NPC_SIMULATED_CHARGETIME
+
+/obj/item/gun/ballistic/revolver/grenadelauncher/proc/can_quick_load(mob/user)
+	return TRUE
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/proc/get_npc_drawtime(mob/living/user)
 	return max(0, get_npc_chargetime(user) - ARCHER_NPC_NOCK_TIME)

--- a/code/modules/spells/spell_types/wizard/ferramancy/greatbow.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/greatbow.dm
@@ -62,6 +62,10 @@
 	var/lance_cooldown = 10 SECONDS
 	COOLDOWN_DECLARE(lance_cd)
 
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/greatbow/can_quick_load(mob/user)
+	to_chat(user, span_warning("[src] will not take any arrows from a normal quiver."))
+	return FALSE
+
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/greatbow/get_mechanics_examine(mob/user)
 	. = ..()
 	. += span_info("Its draw answers to my <b>Arcyne Armament</b>, not any common archer's training.")
@@ -161,6 +165,10 @@
 	/// Arcyne energy drawn from the wielder each time the string is cocked and a bolt is conjured.
 	var/conjure_cost = 25
 
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/ferramancy/can_quick_load(mob/user)
+	to_chat(user, span_warning("[src] will not take any bolts from a normal quiver."))
+	return FALSE
+
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/ferramancy/get_mechanics_examine(mob/user)
 	. = ..()
 	. += span_info("Drawing the string conjures a bolt of arcyne energy, spending <b>[conjure_cost]</b> of your own energy. It accepts no other ammunition.")
@@ -175,6 +183,8 @@
 		return
 	if(user.energy < conjure_cost)
 		to_chat(user, span_warning("I haven't the arcyne energy to charge [src]!"))
+		return
+	if(!free_hand_check(user))
 		return
 	to_chat(user, span_info("I step on the stirrup and draw [src] taut..."))
 	if(!do_after(user, max(1, reloadtime - user.STASTR - user.get_skill_level(ranged_skill)), target = user))


### PR DESCRIPTION
# About The Pull Request
- Allows crossbow to be loaded with bolt from pouches with a free hand 
- Slurbow / Staker can load bolt 1 handed by clicking pouch.
- Crossbow nocking free hand check now happens before instead of after the action.
- Bow now requires a free hand to quick load an arrow (Not a real issue but consistency)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="948" height="442" alt="dreamseeker_caxcJVhQEH" src="https://github.com/user-attachments/assets/c9f5ef7d-b5e7-4fee-a694-27ca61c4313e" />
<img width="240" height="62" alt="dreamseeker_ATGbJh50dK" src="https://github.com/user-attachments/assets/2d8f7f1f-7651-49fc-92e8-b2a0585f0ab9" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I think this is consistent with how we've treated crossbows. Crossbows / slurbow / stakers has been seen as in somewhat of a dire state for a while and not competitive, and most of the balance has been focused on its alpha strike potential instead of sustained damage potential. 

This maybe add 0.5 - 1s to their ROF and just makes staying in combat and shooting a bit more convenient. 

While at it, I noticed that crossbow were actually loadable with your other hand not free and the check only appeared AFTER it was complete, and inconsistently too. So I fixed it to fire before you start the load so you don't have 16 seconds of siegebow load time only to tell you your hand needs to be free after. That's stupid

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Allows crossbow to be loaded with bolt from pouches with a free hand 
add: Slurbow / Staker can load bolt 1 handed by clicking pouch.
add: Crossbow nocking free hand check now happens before instead of after the action.
add: Bow now requires a free hand to quick load an arrow (Not a real issue but consistency)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
