### PR TITLE
Remove Soulshots and variations from poke spells. Fixes Arcyne Lance missing icons

### DIFF
--- a/code/datums/actions/action_cooldown.dm
+++ b/code/datums/actions/action_cooldown.dm
@@ -318,7 +318,7 @@
 #undef COOLDOWN_NO_DISPLAY_TIME
 
 /proc/grant_poke_spell(mob/living/carbon/human/user) // unified proc because atm this is spread across like 5-6 places, uughhghghghgh
-	var/list/poke_options = list("Spitfire", "Frost Bolt", "Arc Bolt", "Greater Arcyne Bolt", "Arcyne Lance", "Lesser Soulshot")
+	var/list/poke_options = list("Spitfire", "Frost Bolt", "Arc Bolt", "Greater Arcyne Bolt", "Arcyne Lance")
 	var/poke_choice = tgui_input_list(user, "Choose your offensive cantrip.", "Arcyne Awakening", poke_options)
 	if(!poke_choice || !user.mind)
 		return
@@ -333,24 +333,3 @@
 			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/greater_arcyne_bolt)
 		if("Arcyne Lance")
 			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arcyne_lance)
-		if("Lesser Soulshot")
-			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/soulshot/lesser)
-
-/proc/grant_poke_spell_ex(mob/living/carbon/human/user) // unified proc because atm this is spread across like 5-6 places, uughhghghghgh
-	var/list/poke_options = list("Spitfire", "Frost Bolt", "Arc Bolt", "Greater Arcyne Bolt", "Arcyne Lance", "Soulshot")
-	var/poke_choice = tgui_input_list(user, "Choose your offensive cantrip.", "Arcyne Awakening", poke_options)
-	if(!poke_choice || !user.mind)
-		return
-	switch(poke_choice)
-		if("Spitfire")
-			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/spitfire)
-		if("Frost Bolt")
-			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/frost_bolt)
-		if("Arc Bolt")
-			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arc_bolt)
-		if("Greater Arcyne Bolt")
-			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/greater_arcyne_bolt)
-		if("Arcyne Lance")
-			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arcyne_lance)
-		if("Soulshot")
-			user.mind.AddSpell(new /datum/action/cooldown/spell/projectile/soulshot)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/maestro.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/maestro.dm
@@ -133,22 +133,6 @@
 				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				H.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 5))
 				r_hand = /obj/item/rogueweapon/spellbook
-				var/list/poke_options = list("Spitfire", "Frost Bolt", "Arc Bolt", "Greater Arcyne Bolt", "Arcyne Lance", "Lesser Gravel Blast", "Lesser Soulshot")
-				var/poke_choice = input(H, "Choose your cantrip.", "Choose your cantrip") as anything in poke_options
-				switch(poke_choice)
-					if("Spitfire")
-						H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/spitfire)
-					if("Frost Bolt")
-						H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/frost_bolt)
-					if("Arc Bolt")
-						H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arc_bolt)
-					if("Greater Arcyne Bolt")
-						H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/greater_arcyne_bolt)
-					if("Arcyne Lance")
-						H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arcyne_lance)
-					if("Lesser Gravel Blast")
-						H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/gravel_blast/lesser)
-					if("Lesser Soulshot")
-						H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/soulshot/lesser)
+				grant_poke_spell(H)
 
 		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -289,7 +289,7 @@
 	if(H.mind)
 		detailcolor = input(H, "Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 		detailcolor = naledicolors[detailcolor]
-		grant_poke_spell_ex(H)
+		grant_poke_spell(H)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/blink/shadowstep)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diminish)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/vizier/restoration)

--- a/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
@@ -3,7 +3,7 @@
 	name = "Arcyne Lance"
 	desc = "Hurl a spectral arcyne lance that pierces through up to 3 targets without losing momentum. \
 	Toggle arc mode (Shift+G) to lob over obstacles at reduced damage. Arced projectiles will not pierce multiple targets."
-	button_icon_state = "arcyne_lance"
+	button_icon_state = "sorcerers_lance"
 	sound = 'sound/magic/scrapeblade.ogg'
 	spell_color = GLOW_COLOR_METAL
 	glow_intensity = GLOW_INTENSITY_MEDIUM

--- a/code/modules/spells/spell_types/wizard/kinesis/soulshot.dm
+++ b/code/modules/spells/spell_types/wizard/kinesis/soulshot.dm
@@ -88,20 +88,5 @@
 		return . || BULLET_ACT_HIT
 	return BULLET_ACT_FORCE_PIERCE
 
-/datum/action/cooldown/spell/projectile/soulshot/lesser
-	name = "Lesser Soulshot"
-	desc = "Fire a devastating beam of kinetic force that pierces through up to 2 targets. Stopped by solid objects. \
-	Damage is three-quartered after the first target. \
-	Deals 50% increased damage to simple-minded creechurs. \
-	Basic offensive magic, refined for over a millenium since the first Magi expelled mana from their body with pure malice and determination to destroy another."
-	invocations = list("Animus Ictus!")
-	projectile_type = /obj/projectile/magic/soulshot/lesser
-	attunement_school = null
-	spell_tier = 0
-	point_cost = 0
-
-/obj/projectile/magic/soulshot/lesser
-	max_hits = 2
-
 #undef SOULSHOT_BASE_DAMAGE
 #undef SOULSHOT_PIERCE_DAMAGE_MULT


### PR DESCRIPTION
## About The Pull Request
Soulshot was not part of the original poke spells group. It never should've been added. Lesser Soulshot was not substantially or meaningfully worse than normal Soulshot since it just pierce less targets.

Maestro also moved to use the unified proc.

This remove both normal Soulshot and lesser Soulshot and unify the procs. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="300" height="263" alt="oKCAVVrOAU" src="https://github.com/user-attachments/assets/7e7693aa-1451-49e8-958f-5888bda1f84c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yeah

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Soulshot and Lesser Soulshot removed from poke spells options. It was designed for mage schools without as much rotational offensive power, it never should've been accessible as a regular poke spells.
add: Arcyne Lance poke spell now have an icon, again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
