### PR TITLE
[BALANCE] RAGE rework (burn update)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -257,7 +257,7 @@
 	to_chat(H, span_warning("You are a brutal warrior, who has foregone armor in favor of pure strength. Crush your enemies, see them driven before you, and hear the lamentations of their women! Oh, and you can specialize in unarmed combat and wrestling."))
 	H.dna.species.soundpack_m = GLOB.voice_packs[/datum/voicepack/male/warrior]
 	H.set_blindness(0)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/ragebad)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rage)
 	if(!H.mind)
 		return
 

--- a/code/modules/spells/spell_types/classunique/berserker/berserkrage.dm
+++ b/code/modules/spells/spell_types/classunique/berserker/berserkrage.dm
@@ -6,14 +6,12 @@
 	var/ragedmgbuff = 0
 	if(!HAS_TRAIT (L, TRAIT_RAGE)) //anyone without the trait is locked to small rage
 		return 0
-	if(brute + burn > 125)
+	if(brute + burn > 10) //early trigger, basically if you take PEN attacks
 		ragedmgbuff = 1
-	if(brute + burn > 225)
+	if(brute + burn > 75) //fight's been going on for a while, probably took some hits
 		ragedmgbuff = 2
-	if(brute + burn > 425)
+	if(brute + burn > 160) //getting close to being crit
 		ragedmgbuff = 3
-	if(brute + burn > 625)
-		ragedmgbuff = 4
 	return ragedmgbuff
 
 /obj/effect/proc_holder/spell/self/rage
@@ -22,7 +20,7 @@
 	desc = "GETTING HURT MAKES YOU ANGRY, MAKE THEM HURT BACK- MORE HURT IS MORE ANGRY!"
 	antimagic_allowed = TRUE
 	clothes_req = FALSE
-	recharge_time = 2 MINUTES
+	recharge_time = 1 MINUTES
 	invocations = list("enters a state of furious rage!")
 	invocation_type = "emote"
 
@@ -30,10 +28,14 @@
 	. = ..()
 	if(!ishuman(user))
 		revert_cast()
-		return FALSE		
+		return FALSE
 	user.apply_status_effect(/datum/status_effect/buff/rage)
 	if(get_buff_value(user) >= 1)
+		user.apply_status_effect(/datum/status_effect/buff/adrenaline_rush) //15 seconds of no bleed, stamina restore, minor buff
+	if(get_buff_value(user) >= 2)
 		user.apply_status_effect(/datum/status_effect/buff/rage_stamina)
+	if(get_buff_value(user) >= 3)
+		user.apply_status_effect(/datum/status_effect/buff/berserk_rush)
 	return TRUE
 
 /atom/movable/screen/alert/status_effect/buff/rage
@@ -45,13 +47,12 @@
 	id = "rage"
 	examine_text = "<font color='red'>SUBJECTPRONOUN is frothing at the mouth!</font>"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/rage
-	effectedstats = list(STATKEY_STR = 1)
-	duration = 90 SECONDS
+	effectedstats = list(STATKEY_STR = 2) //higher base, less boring stat scaling
+	duration = 45 SECONDS
 	var/ragebuff = 0
 	var/outline_colour = "#ca0000"
 
 /datum/status_effect/buff/rage/on_apply()
-	update_effects()
 	. = ..()
 	if(.)
 		var/filter = owner.get_filter(RAGE_FILTER)
@@ -66,19 +67,6 @@
 	owner.remove_filter(RAGE_FILTER)
 	to_chat(owner, span_warning("Rage subsides."))
 
-/datum/status_effect/buff/rage/proc/update_effects()
-	ragebuff = get_buff_value(owner)
-	if(ragebuff < 1)
-		effectedstats = list(STATKEY_STR = 1)
-	else if(ragebuff < 2)
-		effectedstats = list(STATKEY_CON = 2, STATKEY_STR = 1)
-	else if(ragebuff < 3)
-		effectedstats = list(STATKEY_CON = 2, STATKEY_STR = 2)
-	else if(ragebuff < 4)
-		effectedstats = list(STATKEY_CON = 2, STATKEY_WIL = 2, STATKEY_STR = 2)
-	else
-		effectedstats = list(STATKEY_CON = 3, STATKEY_WIL = 3, STATKEY_STR = 3)
-
 /atom/movable/screen/alert/status_effect/buff/rage_stamina
 	name = "RAAADRENALINE"
 	desc = "THE ANGER DRAINS MY FATIGUE!"
@@ -87,9 +75,8 @@
 /datum/status_effect/buff/rage_stamina
 	id = "rage stamina"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/rage_stamina
-	duration = 20 SECONDS
-	var/healing_on_tick = 8
-	var/tech_healing_modifier = 1
+	duration = 15 SECONDS
+	var/healing_on_tick = 5
 
 /datum/status_effect/buff/rage_stamina/tick()
 	if(HAS_TRAIT(owner, TRAIT_IRONMAN))
@@ -97,57 +84,26 @@
 	var/stamheal = healing_on_tick
 	owner.energy_add(stamheal)
 
-//worse version for advent barbarian
+/datum/status_effect/buff/berserk_rush
+	id = "berserk rush"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/berserk_rush
+	effectedstats = list(STATKEY_CON = 2)
+	duration = 45 SECONDS
 
-/obj/effect/proc_holder/spell/self/ragebad
-	name = "RAGE"
-	desc = "GETTING HURT MAKES YOU ANGRY, MAKE THEM HURT BACK- MORE HURT IS MORE ANGRY!"
-	antimagic_allowed = TRUE
-	clothes_req = FALSE
-	recharge_time = 2 MINUTES
-	invocations = list("enters a state of furious rage!")
-	invocation_type = "emote"
+/atom/movable/screen/alert/status_effect/buff/berserk_rush
+	name = "THERE'S NO STOPPING ME!"
+	desc = "DON'T STOP ME NOW, I AM HAVING SUCH A GOOD TIME!"
+	icon_state = "buff"
 
-/obj/effect/proc_holder/spell/self/ragebad/cast(mob/living/carbon/human/user)
+/datum/status_effect/buff/berserk_rush/on_apply()
 	. = ..()
-	if(!ishuman(user))
-		revert_cast()
-		return FALSE		
-	user.apply_status_effect(/datum/status_effect/buff/ragebad)
-	return TRUE
+	ADD_TRAIT(owner, TRAIT_HARDDISMEMBER, INNATE_TRAIT) //limbs still get disabled by damage
 
-/datum/status_effect/buff/ragebad
-	id = "ragebad"
-	examine_text = "<font color='red'>SUBJECTPRONOUN is frothing at the mouth!</font>"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/rage
-	effectedstats = list(STATKEY_STR = 1)
-	duration = 90 SECONDS
-	var/ragebuff = 0
-	var/outline_colour = "#ca0000"
-
-/datum/status_effect/buff/ragebad/on_apply()
-	update_effects()
+/datum/status_effect/buff/berserk_rush/on_remove()
 	. = ..()
-	if(.)
-		var/filter = owner.get_filter(RAGE_FILTER)
-		if(!filter)
-			owner.add_filter(RAGE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 120, "size" = 1))
-		owner.emote("rage", forced = TRUE)
-		to_chat(owner, span_notice("PAIN FUELS MY RAGE, MY BODY IS READY TO FIGHT!"))
-		playsound(owner, 'sound/combat/hits/burn (2).ogg', 100, TRUE)
+	clear_berserk_rush()
 
-/datum/status_effect/buff/ragebad/on_remove()
-	. = ..()
-	owner.remove_filter(RAGE_FILTER)
-	to_chat(owner, span_warning("Rage subsides."))
-
-/datum/status_effect/buff/ragebad/proc/update_effects()
-	ragebuff = get_buff_value(owner)
-	if(ragebuff < 1)
-		effectedstats = list(STATKEY_STR = 1)
-	else if(ragebuff < 3)
-		effectedstats = list(STATKEY_CON = 2, STATKEY_STR = 1)
-	else
-		effectedstats = list(STATKEY_CON = 2, STATKEY_WIL = 2, STATKEY_STR = 2)
+/datum/status_effect/buff/berserk_rush/proc/clear_berserk_rush()
+	REMOVE_TRAIT(owner, TRAIT_HARDDISMEMBER, INNATE_TRAIT)
 
 #undef RAGE_FILTER


### PR DESCRIPTION
## About The Pull Request

Hello
Its time for me to touch berserker again for no reason
nobody asked for this
but it's bothered me so yeah

this is probably an improvement

RAGE used to scale of combined brute and burn damage taken, this was back when burn would flat out ignore armour... it no longer does that.
That alone warrants re-evaluation, but while I am at it I've also chosen to mess with the "boring stats" and give it more interesting things.

- RAGE now activates SHARPLY, meaning FAR less damage is required to reach higher stages
- Base RAGE buff (Stage: Unharmed) increased to +2 STR
- RAGE buff stat scaling removed from all stages
- Stage: Injured now grants adrenaline rush, removing bleeding for a short time, restoring green and providing minor stat boots **THIS ACTIVATES SUPER EARLY, BASICALLY ON A SINGLE PEN HIT**
- Stage: Wounded now grants blue regen, the fight's been going on for a while, nerfed slightly
- Stage: Critical grants Hard Dismember as well as a boost to CON, note that limbs will still disable from damage despite this
- Rage Duration adjusted to 45 seconds
- Rage Cooldown adjusted to 60 seconds

The overall intent is to make the ability actually feel like it *does* something instead of giving barely felt background stats
In truth I wanted to expand on this even further and shift more of berserkers power budget into RAGE away from their baseline but eeeeh- maybe another time.

Also unshackles barbarian, allowing them to rage like a grown up. You go King.

## Testing Evidence

Buffs apply, traits apply, buffs expire, traits get removed, looks good to me

<img width="684" height="162" alt="Screenshot 2026-08-07 010704" src="https://github.com/user-attachments/assets/649cf7ab-826c-4e04-a54f-d00dcfd20e8a" />
<img width="280" height="102" alt="Screenshot 2026-08-07 010734" src="https://github.com/user-attachments/assets/44f076f7-c8c4-4878-8ea3-bb27a1ef8164" />


## Why It's Good For The Game

RAGE was made during a time where burns worked differently, and also made for a world where lickers could still cast it.
Burns now have to break armour, and worse, inflict bleeding so having something to mitigate that is sorely needed.
This should bring the ability up to more modern expectations instead of a forgettable basically passive effect.
Since it also restores green you may even want to put some thought into when to pop it.

We'll see if people like this.

## Changelog
:cl:
balance: RAGE duration 90 -> 45 seconds
balance: RAGE CD 2 -> 1 min
balance: RAGE activation threshold scales SHARPLY (activates earlier)
balance: removed RAGE stat scaling
balance: RAGE now grants different effects based on stages instead of flat stats (Adrenaline rush, Blue regen, Hard Dismember)
balance: Barbarian now gets proper RAGE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
