### PR TITLE
axe me a question ! - fixes unwieldable axes and blunt weapons not having functional weapon specials

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -267,7 +267,7 @@
 	thrown_damage_flag = "piercing"
 	minstr = 8
 	smeltresult = /obj/item/ingot/silver
-	special = /datum/special_intent/axe_swing //Cannot be wielded, otherwise.
+	special = /datum/special_intent/axe_swing/unwielded
 	is_tool = FALSE
 	is_silver = TRUE
 
@@ -294,7 +294,7 @@
 	thrown_damage_flag = "piercing"
 	minstr = 8
 	smeltresult = /obj/item/ingot/silverblessed
-	special = /datum/special_intent/axe_swing //Cannot be wielded, otherwise.
+	special = /datum/special_intent/axe_swing/unwielded
 	is_tool = FALSE
 	is_silver = TRUE
 
@@ -464,7 +464,7 @@
 	wdefense = 5
 	is_silver = TRUE
 	blade_dulling = DULLING_SHAFT_METAL
-	special = /datum/special_intent/axe_swing //Cannot be wielded, otherwise.
+	special = /datum/special_intent/axe_swing/unwielded
 
 /obj/item/rogueweapon/stoneaxe/woodcut/silver/ComponentInitialize()
 	AddComponent(\
@@ -489,7 +489,7 @@
 	blade_dulling = DULLING_SHAFT_METAL
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
-	special = /datum/special_intent/axe_swing //Cannot be wielded, otherwise.
+	special = /datum/special_intent/axe_swing/unwielded
 
 /obj/item/rogueweapon/stoneaxe/battle/psyaxe/ComponentInitialize()
 	AddComponent(\
@@ -674,7 +674,6 @@
 /obj/item/rogueweapon/greataxe/steel/knight/attack_self(mob/living/user)
 	. = ..()
 	update_icon()
-
 
 /obj/item/rogueweapon/greataxe/steel/knight/silver
 	force_wielded = 25

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -429,7 +429,7 @@
 	swingsound = BLUNTWOOSH_LARGE
 	minstr = 7
 	wdefense = 3
-
+	special = /datum/special_intent/ground_smash/unwielded
 	smeltresult = /obj/item/ingot/steel
 	icon_state = "flangedmace"
 
@@ -795,6 +795,7 @@
 	smeltresult = /obj/item/ingot/iron
 	wdefense = 3
 	max_integrity = 200
+	special = /datum/special_intent/ground_smash/unwielded
 
 /obj/item/rogueweapon/mace/warhammer/bronze
 	force = 22
@@ -863,7 +864,6 @@
 	max_integrity = 350
 	smeltresult = /obj/item/ingot/blacksteel
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/mace/warhammer/pick, /datum/intent/mace/warhammer/stab)
-	special = /datum/special_intent/ground_smash
 
 /obj/item/rogueweapon/mace/warhammer/steel/silver
 	name = "silver warhammer"
@@ -887,7 +887,6 @@
 		added_int = 50,\
 		added_def = 2,\
 	)
-
 
 /datum/intent/mace/warhammer/stab
 	name = "thrust"

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -654,6 +654,8 @@ SPECIALS START HERE
 	playsound(T, sfx, 100, TRUE)
 	..()
 
+/datum/special_intent/ground_smash/unwielded
+	requires_wielding = FALSE
 
 /datum/special_intent/flail_sweep
 	name = "Flail Sweep"
@@ -824,6 +826,9 @@ SPECIALS START HERE
 	..()
 
 /datum/special_intent/axe_swing/graggarite
+	requires_wielding = FALSE
+
+/datum/special_intent/axe_swing/unwielded
 	requires_wielding = FALSE
 
 #undef AXE_SWING_GRID_DEFAULT


### PR DESCRIPTION
## About The Pull Request

* Adds an '/unwielded' variant to the Axe Swing and Mace Smash specials.
* Adds these variants to the unwieldable Silver War Axes and Tomahawks, alongside the series of Warhammers and Flanged Maces.

## Testing Evidence

<img width="183" height="141" alt="5bddef5ec2ea2a46bd3da42f4db64eb6" src="https://github.com/user-attachments/assets/64b969a4-ea6a-4e6c-8766-cbae46971322" />


## Why It's Good For The Game

* Fixes unintended absence of special mechanics that's been present for a month - chiefly, due to my own neglect with understanding the code _(until fairly recently.)_ Sorry to keep you waiting.

## Changelog

:cl:
fix: Silver War Axes, Silver Tomahawks, Flanged Maces and Warhammers now properly use their special attacks.
/:cl: