### PR TITLE
Fix painflash not being removed when healed, and fix preference to remove the overlay not working if the overlay is already present

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -169,6 +169,9 @@
 	if(prefs)
 		prefs.no_redflash = !prefs.no_redflash
 		prefs.save_preferences()
+		var/mob/living/carbon/C = mob
+		if(istype(C))
+			C.update_damage_hud() // Fixes that the overlay is not removed when toggling if already present.
 		to_chat(src, "You will see the red flashing effect [prefs.no_redflash ? "less" : "more"] frequently.")
 
 /client/verb/toggle_topexamine()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1005,7 +1005,8 @@
 			if(99 to INFINITY)
 				severity = 6
 		overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
-		if(severity >= 3)
+		//drops to 30 stops rapid health changes at this threshold from spamming the overlay.
+		if(hurtdamage >= 40 || (screens["painflash"] && hurtdamage > 30))
 			overlay_fullscreen("painflash", /atom/movable/screen/fullscreen/painflash)
 		else
 			clear_fullscreen("painflash")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -604,7 +604,7 @@
 /mob/living/carbon/proc/vomit(lost_nutrition = 50, blood = FALSE, stun = TRUE, distance = 1, message = TRUE, toxic = FALSE, harm = FALSE, force = FALSE)
 	if(HAS_TRAIT(src, TRAIT_IRONMAN))
 		return TRUE
-	
+
 	if(HAS_TRAIT(src, TRAIT_TOXINLOVER) && !force)
 		return TRUE
 
@@ -985,31 +985,33 @@
 		overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
 	else
 		clear_fullscreen("brute")*/
+	var/hurtdamage = 0
 	if(show_redflash())
-		var/hurtdamage = ((get_complex_pain() / (STAWIL * 10)) * 100) //what percent out of 100 to max pain
-		if(hurtdamage > 5) //float
-			var/severity = 0
-			switch(hurtdamage)
-				if(5 to 20)
-					severity = 1
-				if(20 to 40)
-					severity = 2
-				if(40 to 60)
-					severity = 3
-					overlay_fullscreen("painflash", /atom/movable/screen/fullscreen/painflash)
-				if(60 to 80)
-					severity = 4
-					overlay_fullscreen("painflash", /atom/movable/screen/fullscreen/painflash)
-				if(80 to 99)
-					severity = 5
-					overlay_fullscreen("painflash", /atom/movable/screen/fullscreen/painflash)
-				if(99 to INFINITY)
-					severity = 6
-					overlay_fullscreen("painflash", /atom/movable/screen/fullscreen/painflash)
-			overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
+		// Divide by 0 prevention, for sanity sake.
+		hurtdamage = ((get_complex_pain() / (max(STAWIL, 1) * 10)) * 100) //what percent out of 100 to max pain
+	if(hurtdamage > 5) //float
+		var/severity = 0
+		switch(hurtdamage)
+			if(5 to 20)
+				severity = 1
+			if(20 to 40)
+				severity = 2
+			if(40 to 60)
+				severity = 3
+			if(60 to 80)
+				severity = 4
+			if(80 to 99)
+				severity = 5
+			if(99 to INFINITY)
+				severity = 6
+		overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
+		if(severity >= 3)
+			overlay_fullscreen("painflash", /atom/movable/screen/fullscreen/painflash)
 		else
-			clear_fullscreen("brute")
 			clear_fullscreen("painflash")
+	else
+		clear_fullscreen("brute")
+		clear_fullscreen("painflash")
 
 /mob/living/carbon/update_health_hud(shown_health_amount)
 	if(!client || !hud_used)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -30,7 +30,6 @@
 		updatehealth()
 	if(client)
 		update_damage_hud()
-
 	if (times_fired % 3 == 0) // every 3rd tick, fire stress handler. it isn't time-critical, so we don't particularly need it to go EVERY tick
 		update_stress()
 	handle_nausea()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -28,6 +28,9 @@
 	if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
 		update_stamina() //needs to go before updatehealth to remove stamcrit
 		updatehealth()
+	if(client)
+		update_damage_hud()
+
 	if (times_fired % 3 == 0) // every 3rd tick, fire stress handler. it isn't time-critical, so we don't particularly need it to go EVERY tick
 		update_stress()
 	handle_nausea()


### PR DESCRIPTION
## About The Pull Request

Reworks the "painflash" overlay to avoid cases where the red overlay never goes away. (Very old bug)
Just in case this issue ever rises again, I also fixed an issue with the preference itself to toggle the red flash overlay, as it only worked if you did not already have the painflash overlay.

## Testing Evidence

Locally tested by injuring myself heavily many times, and testing multiple healing methods. (Admin heal, rest, surgery, and miracles)
I was not able to replicate the old bug after making these changes.
I was able to fully confirm that the preference for disabling this red overlay now ALWAYS works as well, even when the flashing is already present, you can disable it with the pref now, which was not possible before.
Also confirmed to have fixed a rare case where if your health hit a specific threshold, but was healed, then bleeds back to the threshold, you would be spammed by the red overlay very rapidly.

The preference now working to disable the red overlay in all situations is most important I think.

## Why It's Good For The Game

Removes a very intrusive overlay that should not be present in cases where it has now been fixed.
In my case, this also helps with my light sensitive, as the abrupt, red flashes were migraine inducing. 
Also makes the preference to remove the overlay work in all cases, which is what a player should expect.

## Changelog
:cl: Nova
fix: fixed the pref "Toggle Red Flash Overlay" not always working
fix: fixed red pain flash overlay being stuck on screen when uninjured.
/:cl: