### PR TITLE
Fix incisions surgical incisions being rapidly closed by any healing source, like campfires

### DIFF
--- a/code/datums/wounds/types/slashes.dm
+++ b/code/datums/wounds/types/slashes.dm
@@ -50,7 +50,7 @@
 	sewn_clotting_threshold = null
 	sewn_clotting_rate = null
 	sewn_bleed_rate = null
-	
+
 	can_sew = TRUE
 	can_cauterize = TRUE
 	severity_stages = list(
@@ -172,6 +172,12 @@
 	sew_threshold = 75
 	passive_healing = 0
 	sleep_healing = 0
+
+// Incisions are made deliberately for surgery.
+// These should not be shut by healing sources mid-surgery.
+// They are still closed by a single needle stitch, so instant to shut normally.
+/datum/wound/slash/incision/heal_wound(heal_amount)
+	return 0
 
 /datum/wound/slash/incision/sew_wound()
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

Removes that passive healing rapidly closes surgical incisions.
Other wound types, and damage will still be healed like normal, but this will make it so healing does not interrupt surgery anymore.

## Testing Evidence

<img width="827" height="532" alt="image" src="https://github.com/user-attachments/assets/a1135783-a547-4abb-a5d2-b12bf6fc40bf" />
Testing this rigorously. Fires, miracles, etc do not close incisions any more, but a needle still will instantly.
This should stop surgery steps from breaking due to campfires, miracles, and bard songs.

## Why It's Good For The Game

Surgery is something people are wanting to do often times, and having the incision close sometimes nearly instantly, depending on healing sources causes it to become tedious.
This just makes it so that the incision itself cannot be undone by healing magic.
All other damage will be healed though as usual.

## Changelog
:cl: Nova
qol: Passive healing no longer closes surgery sites.
/:cl: