### PR TITLE
Leatherjak

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/leather.dm
+++ b/code/modules/clothing/rogueclothes/armor/leather.dm
@@ -129,8 +129,8 @@
 	name = "hardened leather armor"
 	desc = "A heavy steerhide jerkin with enough body to stand on its own. It forms a stiff, protective mantle \
 	for its wearer, shielding from blows and weather alike."
-	icon_state = "leather_armor"
-	item_state = "leather_armor"
+	icon_state = "roguearmor_belt"
+	item_state = "roguearmor_belt"
 	armor = ARMOR_LEATHER
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
 	color = "#7D6653"

--- a/code/modules/roguetown/roguecrafting/leather/reinforcement.dm
+++ b/code/modules/roguetown/roguecrafting/leather/reinforcement.dm
@@ -23,7 +23,7 @@
 	result = list(/obj/item/clothing/head/roguetown/roguehood/studded)
 	reqs = list(
 		/obj/item/clothing/head/roguetown/roguehood = 1,
-		/obj/item/scrap = 2,
+		/obj/item/scrap = 1,
 		/obj/item/reagent_containers/food/snacks/fat = 1,
 		)
 
@@ -32,7 +32,7 @@
 	result = list(/obj/item/clothing/suit/roguetown/armor/leather/studded)
 	reqs = list(
 		/obj/item/clothing/suit/roguetown/armor/leather = 1,
-		/obj/item/scrap = 3,
+		/obj/item/scrap = 2,
 		/obj/item/reagent_containers/food/snacks/fat = 1,
 		)
 
@@ -41,7 +41,7 @@
 	result = list(/obj/item/clothing/suit/roguetown/armor/leather/studded/cuirbouilli)
 	reqs = list(
 		/obj/item/clothing/suit/roguetown/armor/leather/cuirass = 1,
-		/obj/item/scrap = 3,
+		/obj/item/scrap = 2,
 		/obj/item/reagent_containers/food/snacks/fat = 1,
 		)
 
@@ -50,7 +50,7 @@
 	result = list(/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini)
 	reqs = list(
 		/obj/item/clothing/suit/roguetown/armor/leather = 1,
-		/obj/item/scrap = 2,
+		/obj/item/scrap = 1,
 		/obj/item/reagent_containers/food/snacks/fat = 1,
 		)
 


### PR DESCRIPTION
## About The Pull Request

Reverts Hardened Leather Armor to it's old sprite to match with the coat, we have seperate cuirass item for a reason these days.
Reduces SCRAP required for studded armour by 1 to maybe make it bit more appealing to make.

## Testing Evidence

Naw

## Why It's Good For The Game

Why not.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Reduce METAL SCRAP required for studded armour by 1
image: Changed Hardened Leather Armor back to it's old sprite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
