### PR TITLE
Blindness moment

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -219,8 +219,9 @@
 	if(..())
 		if(HAS_TRAIT(M, TRAIT_HOLDBREATH))
 			return FALSE
-		M.adjust_blurriness(3)
-		M.adjust_blindness(3)
+		if(M.has_status_effect(STATUS_EFFECT_BLINDED))
+			return FALSE
+		M.apply_status_effect(STATUS_EFFECT_BLINDED)
 		M.emote("cry")
 		return TRUE
 

--- a/code/modules/spells/roguetown/necromancer/eyebite.dm
+++ b/code/modules/spells/roguetown/necromancer/eyebite.dm
@@ -13,7 +13,7 @@
 	charge_required = TRUE
 	charge_time = 15
 	associated_skill = /datum/skill/magic/arcane
-	cooldown_time = 15 SECONDS
+	cooldown_time = 35 SECONDS
 	spell_requirements = SPELL_REQUIRES_SAME_Z
 	self_cast_possible = FALSE
 	zizo_spell = TRUE
@@ -24,8 +24,10 @@
 /datum/action/cooldown/spell/eyebite/cast(atom/cast_on)
 	. = ..()
 	var/mob/living/carbon/target = cast_on
+	if(target.has_status_effect(STATUS_EFFECT_BLINDED))
+		owner.visible_message(span_warning("They are already blind!"))
+		return TRUE
+	target.apply_status_effect(STATUS_EFFECT_BLINDED)
 	target.visible_message(span_info("A loud crunching sound has come from [target]!"), span_userdanger("I feel arcane teeth biting into my eyes!"))
 	target.adjustBruteLoss(30)
-	target.blind_eyes(2)
-	target.blur_eyes(10)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Removes the old blindness from eyebite and blindness smoke, instead using the newer one (the one that nukes vision cone and PER instead of blacking out your screen)

## Testing Evidence

Yea

## Why It's Good For The Game

It's probably one of the most frustrating things to play against, especially eyebite being point and click on low cooldown.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Eyebite cooldown 15 > 35 seconds
fix: Eyebite & Blindness grenades not using modern BLIND effect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
