### PR TITLE
repaths nicotine and space_drugs, changes names & flavor, too.

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -391,7 +391,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/rollie/cannabis
 	name = "swampleaf zig"
 	desc = "A paper wrapped cartridge of sweet smelling smokeleaf."
-	list_reagents = list(/datum/reagent/drug/space_drugs = 30)
+	list_reagents = list(/datum/reagent/drug/swampweed = 30)
 
 /obj/item/clothing/mask/cigarette/rollie/cannabis/cheroot
 	name = "swampleaf cheroot"
@@ -399,7 +399,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	aspects of both."
 	smoketime = 240
 	list_reagents = list(
-		/datum/reagent/drug/space_drugs = 30,
+		/datum/reagent/drug/swampweed = 30,
 		/datum/reagent/drug/nicotine = 15,
 		)
 
@@ -428,7 +428,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	nauseating for the laymen."
 	smoketime = 240
 	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/mentha = 15)
-	
+
 /obj/item/clothing/mask/cigarette/rollie/blackberry
 	name = "blackberry zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a sweet and refreshing effect."
@@ -440,7 +440,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 240
 	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/blackberry = 15)
 
-/obj/item/clothing/mask/cigarette/rollie/apple 
+/obj/item/clothing/mask/cigarette/rollie/apple
 	name = "apple zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a cooling effect."
 	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/apple = 15)
@@ -450,8 +450,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A rewrapped westleach zig with some alchemically extracted apple essence."
 	smoketime = 240
 	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/apple = 15)
-	
-/obj/item/clothing/mask/cigarette/rollie/menthaapple 
+
+/obj/item/clothing/mask/cigarette/rollie/menthaapple
 	name = "mentha-apple zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a cooling effect."
 	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/apple = 7, /datum/reagent/drug/mentha = 8)
@@ -461,7 +461,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A rewrapped westleach zig with some alchemically extracted mentha and apple essence."
 	smoketime = 240
 	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/apple = 7, /datum/reagent/drug/mentha = 8)
-	
+
 /obj/item/clothing/mask/cigarette/rollie/chocolate
 	name = "chocolate zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly bittersweet taste of cocoa."
@@ -472,7 +472,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A rewrapped westleach zig with some alchemically extracted chocolate essence."
 	smoketime = 240
 	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/chocolate = 12, /obj/item/reagent_containers/food/snacks/chocolate = 3)
-	
+
 /obj/item/clothing/mask/cigarette/rollie/strawberry
 	name = "strawberry zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a sweet and refreshing effect."
@@ -483,7 +483,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A rewrapped westleach zig with some alchemically extracted strawberry essence."
 	smoketime = 240
 	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/strawberry = 15)
-	
+
 /obj/item/clothing/mask/cigarette/rollie/carrot
 	name = "carrot zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a sweet and refreshing effect."
@@ -494,7 +494,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A rewrapped westleach zig with some alchemically extracted carrot essence."
 	smoketime = 240
 	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/carrot = 15)
-	
+
 /obj/item/clothing/mask/cigarette/rollie/lime
 	name = "lime zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a sweet and refreshing effect."

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -155,7 +155,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/smoketime = 180 // 1 is 2 seconds, so a single cigarette will last 6 minutes.
 	var/chem_volume = 30
 	var/smoke_all = TRUE /// Should we smoke all of the chems in the cig before it runs out. Splits each puff to take a portion of the overall chems so by the end you'll always have consumed all of the chems inside.
-	var/list/list_reagents = list(/datum/reagent/drug/nicotine = 15)
+	var/list/list_reagents = list(/datum/reagent/drug/westleach = 15)
 
 /obj/item/clothing/mask/cigarette/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is huffing [src] as quickly as [user.p_they()] can! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer."))
@@ -373,19 +373,19 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	pixel_y = rand(-5, 5)
 
 /obj/item/clothing/mask/cigarette/rollie/nicotine
-	list_reagents = list(/datum/reagent/drug/nicotine = 30)
+	list_reagents = list(/datum/reagent/drug/westleach = 30)
 
 /obj/item/clothing/mask/cigarette/rollie/nicotine/cheroot
 	name = "cheroot"
 	desc = "Rich smokeleaf self-rolled into an open-clipped cigarillo. Envigorating for the enthusiast, \
 	nauseating for the laymen."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45)
+	list_reagents = list(/datum/reagent/drug/westleach = 45)
 
 /obj/item/clothing/mask/cigarette/rollie/trippy
 	name = "trippy zig"
 	desc = "A paper wrapped cartridge of... What?"
-	list_reagents = list(/datum/reagent/drug/nicotine = 15, /datum/reagent/drug/mushroomhallucinogen = 35)
+	list_reagents = list(/datum/reagent/drug/westleach = 15, /datum/reagent/drug/mushroomhallucinogen = 35)
 	starts_lit = TRUE
 
 /obj/item/clothing/mask/cigarette/rollie/cannabis
@@ -400,7 +400,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 240
 	list_reagents = list(
 		/datum/reagent/drug/swampweed = 30,
-		/datum/reagent/drug/nicotine = 15,
+		/datum/reagent/drug/westleach = 15,
 		)
 
 /obj/item/clothing/mask/cigarette/rollie/mindbreaker
@@ -420,102 +420,102 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/rollie/mentha // not a subtype of nicotine for crafting reasons
 	name = "mentha zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a cooling effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/mentha = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/mentha = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/mentha/cheroot
 	name = "mentha cheroot"
 	desc = "Rich mentha self-rolled into an open-clipped zig. Envigorating for the enthusiast, \
 	nauseating for the laymen."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/mentha = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/mentha = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/blackberry
 	name = "blackberry zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a sweet and refreshing effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/blackberry = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/blackberry = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/blackberry/cheroot
 	name = "blackberry cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted blackberry essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/blackberry = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/blackberry = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/apple
 	name = "apple zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a cooling effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/apple = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/apple = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/apple/cheroot
 	name = "apple cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted apple essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/apple = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/apple = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/menthaapple
 	name = "mentha-apple zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a cooling effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/apple = 7, /datum/reagent/drug/mentha = 8)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/apple = 7, /datum/reagent/drug/mentha = 8)
 
 /obj/item/clothing/mask/cigarette/rollie/menthaapple/cheroot
 	name = "mentha-apple cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted mentha and apple essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/apple = 7, /datum/reagent/drug/mentha = 8)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/apple = 7, /datum/reagent/drug/mentha = 8)
 
 /obj/item/clothing/mask/cigarette/rollie/chocolate
 	name = "chocolate zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly bittersweet taste of cocoa."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/chocolate = 12, /obj/item/reagent_containers/food/snacks/chocolate = 3)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/chocolate = 12, /obj/item/reagent_containers/food/snacks/chocolate = 3)
 
 /obj/item/clothing/mask/cigarette/rollie/chocolate/cheroot
 	name = "chocolate cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted chocolate essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/chocolate = 12, /obj/item/reagent_containers/food/snacks/chocolate = 3)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/chocolate = 12, /obj/item/reagent_containers/food/snacks/chocolate = 3)
 
 /obj/item/clothing/mask/cigarette/rollie/strawberry
 	name = "strawberry zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a sweet and refreshing effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/strawberry = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/strawberry = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/strawberry/cheroot
 	name = "strawberry cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted strawberry essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/strawberry = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/strawberry = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/carrot
 	name = "carrot zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a sweet and refreshing effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/carrot = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/carrot = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/carrot/cheroot
 	name = "carrot cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted carrot essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/carrot = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/carrot = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/lime
 	name = "lime zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a sweet and refreshing effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/lime = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/lime = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/lime/cheroot
 	name = "lime cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted lime essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/lime = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/lime = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/salvia
 	name = "salvia zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a spicy, earthy and bitter effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/salvia = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/salvia = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/salvia/cheroot
 	name = "salvia cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted salvia essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/salvia = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/salvia = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/salviavaleriana
 	name = "salvia-valeriana zig"
@@ -525,51 +525,51 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "salvia-valeriana cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted salvia and valeriana essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/salvia = 5, /datum/reagent/drug/valeriana = 10)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/salvia = 5, /datum/reagent/drug/valeriana = 10)
 
 /obj/item/clothing/mask/cigarette/rollie/calendula
 	name = "calendula zig"
 	desc = "Dried westleach carefully wrapped in fine paper. It has a bitter taste and light healing properties."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/calendula = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/calendula = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/calendula/cheroot
 	name = "calendula cheroot"
 	desc = "A rewrapped westleach zig with some alchemically extracted calendula essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/calendula = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/calendula = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/jacksberries
 	name = "jacksberries zig"
 	desc = "Dried westleach and jacksberries carefully wrapped in fine paper. It has a particularly smooth taste with a slight sourness and sweetness effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/jacksberries = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/jacksberries = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/jacksberries/cheroot
 	name = "jacksberries cheroot"
 	desc = "A rewrapped jacksberries zig with some alchemically extracted jacksberries essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/jacksberries = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/jacksberries = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/jacksberriespoison
 	name = "jacksberries zig"
 	desc = "Dried westleach and jacksberries carefully wrapped in fine paper. It has a particularly smooth taste with a slight bitterness, sourness and sweetness effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/jacksberries = 12, /datum/reagent/berrypoison = 3)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/jacksberries = 12, /datum/reagent/berrypoison = 3)
 
 /obj/item/clothing/mask/cigarette/rollie/jacksberriespoison/cheroot
 	name = "jacksberries cheroot"
 	desc = "A rewrapped jacksberries zig with some alchemically extracted jacksberries essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/jacksberries = 12, /datum/reagent/berrypoison = 3)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/jacksberries = 12, /datum/reagent/berrypoison = 3)
 
 /obj/item/clothing/mask/cigarette/rollie/abyss
 	name = "jacksberries zig"
 	desc = "Dried westleach and jackberries carefully wrapped in fine paper. It has a particularly smooth taste with a burns and scratches effect."
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/abyss = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/abyss = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/abyss/cheroot
 	name = "jacksberries cheroot"
 	desc = "A rewrapped jacksberries zig with some alchemically extracted jacksberries and salty essence."
 	smoketime = 240
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/abyss = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/abyss = 15)
 
 ////////////
 // CIGARS //
@@ -583,13 +583,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_on = "stogieon"
 	icon_off = "stogieoff"
 	item_state = "stogieoff"
-	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/petun = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 30, /datum/reagent/drug/petun = 15)
 
 /obj/item/clothing/mask/cigarette/rollie/zigar/cheroot
 	name = "zigar cheroot"
 	desc = "A rewrapped zigar with some alchemically extracted hypericum and very more westleach essence."
 	smoketime = 360
-	list_reagents = list(/datum/reagent/drug/nicotine = 45, /datum/reagent/drug/petun = 15)
+	list_reagents = list(/datum/reagent/drug/westleach = 45, /datum/reagent/drug/petun = 15)
 
 /obj/item/clothing/mask/cigarette/cigar
 	name = "premium cigar"
@@ -602,7 +602,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "cigaroff"
 	smoketime = 300 // 11 minutes
 	chem_volume = 40
-	list_reagents = list(/datum/reagent/drug/nicotine = 25)
+	list_reagents = list(/datum/reagent/drug/westleach = 25)
 
 /obj/item/clothing/mask/cigarette/cigar/cohiba
 	name = "\improper Cohiba Robusto cigar"
@@ -612,7 +612,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigar2off"
 	smoketime = 600 // 20 minutes
 	chem_volume = 80
-	list_reagents =list(/datum/reagent/drug/nicotine = 40)
+	list_reagents =list(/datum/reagent/drug/westleach = 40)
 
 /obj/item/clothing/mask/cigarette/cigar/havana
 	name = "premium Havanian cigar"
@@ -622,7 +622,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigar2off"
 	smoketime = 900 // 30 minutes
 	chem_volume = 50
-	list_reagents =list(/datum/reagent/drug/nicotine = 15)
+	list_reagents =list(/datum/reagent/drug/westleach = 15)
 
 /obj/item/cigbutt
 	name = "cigarette butt"

--- a/code/game/objects/items/mundanities.dm
+++ b/code/game/objects/items/mundanities.dm
@@ -165,7 +165,7 @@
 	menu_item = pick(1,2,3,4,5) //get the meal. rand does not work for this and i have no idea why.
 	switch(menu_item)
 		if(1)
-			list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL, /datum/reagent/drug/space_drugs = 2, /datum/reagent/berrypoison = 1)
+			list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_THREE_QUARTER_MEAL, /datum/reagent/drug/swampweed = 2, /datum/reagent/berrypoison = 1)
 			tastes = list("salty bitter syrup" = 2, "bad mushrooms" = 1)
 		if(2)
 			list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_MEAL_AND_QUARTER, /datum/reagent/medicine/stronghealth = 1, /datum/reagent/water/salty = 3)

--- a/code/game/objects/structures/apiary.dm
+++ b/code/game/objects/structures/apiary.dm
@@ -1024,7 +1024,7 @@
 	desc = "Sweet honey with subtle relaxing properties."
 	icon_state = "greyscale_honey"
 	honey_color = COLOR_GREEN_GRAY
-	list_reagents = list(/datum/reagent/consumable/honey = 5, /datum/reagent/consumable/nutriment = 3, /datum/reagent/drug/space_drugs = 2)
+	list_reagents = list(/datum/reagent/consumable/honey = 5, /datum/reagent/consumable/nutriment = 3, /datum/reagent/drug/swampweed = 2)
 
 /obj/item/reagent_containers/food/snacks/rogue/honey/healing
 	name = "medicinal honey"

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -464,7 +464,7 @@
 	filling_color = "#6b4d18"
 	bitesize = 1
 	foodtype = FRUIT
-	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/nicotine = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/westleach = 1)
 	grind_results = list(/datum/reagent/consumable/acorn_powder = 4)
 	mill_result = /obj/item/reagent_containers/powder/rocknut
 
@@ -664,8 +664,8 @@
 	bitesize_mod = 1
 	foodtype = VEGETABLES
 	tastes = list("sweet" = 1,"bitterness" = 1)
-	list_reagents = list(/datum/reagent/drug/nicotine = 2, /datum/reagent/consumable/nutriment = 1, /datum/reagent/berrypoison = 5)
-	grind_results = list(/datum/reagent/drug/nicotine = 5)
+	list_reagents = list(/datum/reagent/drug/westleach = 2, /datum/reagent/consumable/nutriment = 1, /datum/reagent/berrypoison = 5)
+	grind_results = list(/datum/reagent/drug/westleach = 5)
 	eat_effect = /datum/status_effect/debuff/badmeal
 	rotprocess = SHELFLIFE_SHORT
 
@@ -675,10 +675,10 @@
 	desc = "A dried pipeweed, ready to smoke."
 	icon_state = "westleachd"
 	dry = TRUE
-	pipe_reagents = list(/datum/reagent/drug/nicotine = 30)
+	pipe_reagents = list(/datum/reagent/drug/westleach = 30)
 	eat_effect = /datum/status_effect/debuff/badmeal
-	list_reagents = list(/datum/reagent/drug/nicotine = 5, /datum/reagent/consumable/nutriment = 1)
-	grind_results = list(/datum/reagent/drug/nicotine = 10)
+	list_reagents = list(/datum/reagent/drug/westleach = 5, /datum/reagent/consumable/nutriment = 1)
+	grind_results = list(/datum/reagent/drug/westleach = 10)
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry/Initialize()
 	. = ..()

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -699,9 +699,9 @@
 	desc = "A prepared pipeweed prized for its foggy effects."
 	icon_state = "swampweedd"
 	dry = TRUE
-	pipe_reagents = list(/datum/reagent/drug/space_drugs = 30)
-	list_reagents = list(/datum/reagent/drug/space_drugs = 2,/datum/reagent/consumable/nutriment = 1)
-	grind_results = list(/datum/reagent/drug/space_drugs = 5)
+	pipe_reagents = list(/datum/reagent/drug/swampweed = 30)
+	list_reagents = list(/datum/reagent/drug/swampweed = 2,/datum/reagent/consumable/nutriment = 1)
+	grind_results = list(/datum/reagent/drug/swampweed = 5)
 	eat_effect = /datum/status_effect/debuff/badmeal
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry/Initialize()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -5,10 +5,11 @@
 	var/trippy = TRUE //Does this drug make you trip?
 
 /datum/reagent/drug/swampweed
-	name = "Powdered Swampweed"
+	name = "Swamp Oil"
 	description = "The crushed or liquidated essence of the swampweed plant. Produces vivid hallucinations... and, some say, enhances the mentalisms."
 	color = "#388151" // rgb: 96, 165, 132
 	overdose_threshold = 30
+	taste_description = "muddy jacksberries" // apparently weed can taste like berries. idfk get someone who smokes big loud 2 revise this.
 
 /datum/reagent/drug/swampweed/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
@@ -60,11 +61,11 @@
 	M.adjustOxyLoss(1.1  * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 
-/datum/reagent/drug/nicotine
-	name = "Nicotine"
-	description = "Slightly reduces stun times. If overdosed it will deal toxin and oxygen damage."
+/datum/reagent/drug/westleach
+	name = "Westleach Extract"
+	description = "An extract of the westleach plant. Provides a stimulating effect pleasant to many."
 	reagent_state = LIQUID
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#d8e29e" // rgb: 96, 165, 132
 	addiction_threshold = 999
 	taste_description = "smoke"
 	trippy = FALSE
@@ -72,21 +73,21 @@
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 
 
-/datum/reagent/drug/nicotine/on_mob_end_metabolize(mob/living/M)
+/datum/reagent/drug/westleach/on_mob_end_metabolize(mob/living/M)
 //	M.remove_stress(/datum/stressevent/pweed)
 	..()
 
-/datum/reagent/drug/nicotine/on_mob_metabolize(mob/living/M)
+/datum/reagent/drug/westleach/on_mob_metabolize(mob/living/M)
 	var/mob/living/carbon/V = M
 	V.add_stress(/datum/stressevent/pweed)
 	..()
 
-/datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/M)
+/datum/reagent/drug/westleach/on_mob_life(mob/living/carbon/M)
 	M.sate_addiction(/datum/charflaw/addiction/smoker)
 	..()
 	. = 1
 
-/datum/reagent/drug/nicotine/overdose_process(mob/living/M)
+/datum/reagent/drug/westleach/overdose_process(mob/living/M)
 	M.adjustToxLoss(0.1  * REAGENTS_EFFECT_MULTIPLIER, 0)
 	M.adjustOxyLoss(1.1  * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -4,13 +4,13 @@
 	taste_description = "bitterness"
 	var/trippy = TRUE //Does this drug make you trip?
 
-/datum/reagent/drug/space_drugs
-	name = "Space drugs"
-	description = "An illegal chemical compound used as drug."
-	color = "#60A584" // rgb: 96, 165, 132
+/datum/reagent/drug/swampweed
+	name = "Powdered Swampweed"
+	description = "The crushed or liquidated essence of the swampweed plant. Produces vivid hallucinations... and, some say, enhances the mentalisms."
+	color = "#388151" // rgb: 96, 165, 132
 	overdose_threshold = 30
 
-/datum/reagent/drug/space_drugs/on_mob_life(mob/living/carbon/M)
+/datum/reagent/drug/swampweed/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
 	if(prob(5))
 		if(M.gender == FEMALE)
@@ -21,7 +21,7 @@
 	M.sate_addiction(/datum/charflaw/addiction/smoker)
 	..()
 
-/datum/reagent/drug/space_drugs/on_mob_end_metabolize(mob/living/M)
+/datum/reagent/drug/swampweed/on_mob_end_metabolize(mob/living/M)
 	M.clear_fullscreen("weedsm")
 
 /*
@@ -29,7 +29,7 @@
 		SSdroning.play_area_sound(get_area(M), M.client)
 */
 
-/datum/reagent/drug/space_drugs/on_mob_metabolize(mob/living/M)
+/datum/reagent/drug/swampweed/on_mob_metabolize(mob/living/M)
 	..()
 	M.set_drugginess(30)
 	M.overlay_fullscreen("weedsm", /atom/movable/screen/fullscreen/weedsm)
@@ -52,10 +52,10 @@
 //			if(L.has_status_effect(/datum/status_effect/buff/weed))
 	filters += filter(type="angular_blur",x=5,y=5,size=1)
 
-/datum/reagent/drug/space_drugs/overdose_start(mob/living/M)
+/datum/reagent/drug/swampweed/overdose_start(mob/living/M)
 	to_chat(M, "<span class='danger'>I start tripping hard!</span>")
 
-/datum/reagent/drug/space_drugs/overdose_process(mob/living/M)
+/datum/reagent/drug/swampweed/overdose_process(mob/living/M)
 	M.adjustToxLoss(0.1  * REAGENTS_EFFECT_MULTIPLIER, 0)
 	M.adjustOxyLoss(1.1  * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
@@ -377,7 +377,7 @@
 	M.adjustOxyLoss(1.1 * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 	. = 1
-	
+
 /datum/reagent/drug/blackberry
 	name = "Blackberry"
 	description = "Extract from the blackberry. Produces a sweet-tart sensation."
@@ -406,8 +406,8 @@
 	M.adjustOxyLoss(1.1 * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 	. = 1
-	
-/datum/reagent/drug/apple 
+
+/datum/reagent/drug/apple
 	name = "Apple"
 	description = "Extract from the apple. Produces a sourness and coolness sensation."
 	reagent_state = LIQUID
@@ -435,8 +435,8 @@
 	M.adjustOxyLoss(1.1 * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 	. = 1
-	
-/datum/reagent/drug/chocolate 
+
+/datum/reagent/drug/chocolate
 	name = "Chocolate"
 	description = "Extract from the chocolate. Produces a sourness and coolness sensation."
 	reagent_state = LIQUID
@@ -464,8 +464,8 @@
 	M.adjustOxyLoss(1.1 * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 	. = 1
-	
-/datum/reagent/drug/strawberry 
+
+/datum/reagent/drug/strawberry
 	name = "Strawberry"
 	description = "Extract from the strawberry. Produces a sourness and coolness sensation."
 	reagent_state = LIQUID
@@ -493,8 +493,8 @@
 	M.adjustOxyLoss(1.1 * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 	. = 1
-	
-/datum/reagent/drug/carrot  
+
+/datum/reagent/drug/carrot
 	name = "Carrot"
 	description = "Extract from the carrot. Produces a sourness and coolness sensation."
 	reagent_state = LIQUID
@@ -522,7 +522,7 @@
 	M.adjustOxyLoss(1.1 * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 	. = 1
-	
+
 /datum/reagent/drug/lime
 	name = "Lime"
 	description = "Extract from the lime. Produces a sourness and coolness sensation."
@@ -551,7 +551,7 @@
 	M.adjustOxyLoss(1.1 * REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 	. = 1
-	
+
 /datum/reagent/drug/salvia
 	name = "Salvia"
 	description = "Extract from the salvia. Produces a spicy, earthy and bitter sensation."

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -1,5 +1,5 @@
-/datum/chemical_reaction/space_drugs
+/datum/chemical_reaction/swampweed
 	name = "Space Drugs"
-	id = /datum/reagent/drug/space_drugs
-	results = list(/datum/reagent/drug/space_drugs = 3)
+	id = /datum/reagent/drug/swampweed
+	results = list(/datum/reagent/drug/swampweed = 3)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -203,7 +203,7 @@
 	name = /datum/reagent/hair_dye
 	id = /datum/reagent/hair_dye
 	results = list(/datum/reagent/hair_dye = 5)
-	required_reagents = list(/datum/reagent/colorful_reagent = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/drug/space_drugs = 1)
+	required_reagents = list(/datum/reagent/colorful_reagent = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/drug/swampweed = 1)
 
 /datum/chemical_reaction/concentrated_barbers_aid
 	name = /datum/reagent/concentrated_barbers_aid

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -9,7 +9,7 @@
 	name = /datum/reagent/toxin/fentanyl
 	id = /datum/reagent/toxin/fentanyl
 	results = list(/datum/reagent/toxin/fentanyl = 1)
-	required_reagents = list(/datum/reagent/drug/space_drugs = 1)
+	required_reagents = list(/datum/reagent/drug/swampweed = 1)
 	required_temp = 674
 
 /datum/chemical_reaction/cyanide

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -88,7 +88,7 @@
 /obj/item/reagent_containers/pill/happy
 	name = "happy pill"
 	desc = ""
-	list_reagents = list(/datum/reagent/consumable/sugar = 10, /datum/reagent/drug/space_drugs = 10)
+	list_reagents = list(/datum/reagent/consumable/sugar = 10, /datum/reagent/drug/swampweed = 10)
 	icon_state = "pill_happy"
 
 

--- a/modular/Neu_Food/code/cooked/cooked_baked.dm
+++ b/modular/Neu_Food/code/cooked/cooked_baked.dm
@@ -888,7 +888,7 @@
 	icon = 'modular/Neu_Food/icons/cooked/cooked_pasta.dmi'
 	icon_state = "lasagna_pesto"
 	faretype = FARE_LAVISH
-	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_MEAL_AND_QUARTER, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/nicotine = 4)
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_MEAL_AND_QUARTER, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/westleach = 4)
 	tastes = list("richly smooth and salty tomatoes" = 1, "melted cheese between noodle sheets" = 1)
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtype = GRAIN | VEGETABLES

--- a/modular/Neu_Food/code/cooked/cooked_boiled.dm
+++ b/modular/Neu_Food/code/cooked/cooked_boiled.dm
@@ -53,7 +53,7 @@
 	desc = "Noodles mixed with a spiced refined sauce made from smoky rocknut and garlick. A cultural blend of Azurian improvisation and Navarno ingenuity."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_pasta.dmi'
 	icon_state = "spaghetti_pesto"
-	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_FULL_MEAL, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/nicotine = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = NUTRITION_FULL_MEAL, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/westleach = 1)
 	faretype = FARE_LAVISH
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("nutty, herby, and garlicky sauce"=1, "al dente noodles" = 1)

--- a/modular/Neu_Food/code/cooked/cooked_cakes.dm
+++ b/modular/Neu_Food/code/cooked/cooked_cakes.dm
@@ -153,7 +153,7 @@
 	icon_state = "applenutcake"
 	slices_num = 8
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/applenutcakeslice
-	list_reagents = list(/datum/reagent/consumable/nutriment = 48, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/nicotine = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 48, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/westleach = 1)
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("cake"=1,"sugary frosting"=1,"apple"=1,"nutty"=1)
 	foodtype = GRAIN | DAIRY | SUGAR | FRUIT
@@ -581,7 +581,7 @@
 	icon_state = "rocknutcake"
 	slices_num = 8
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/rocknutcakeslice
-	list_reagents = list(/datum/reagent/consumable/nutriment = 48, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/nicotine = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 48, /datum/reagent/consumable/acorn_powder = 4, /datum/reagent/drug/westleach = 1)
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("cake"=1,"sugary frosting"=1,"nutty"=1)
 	foodtype = GRAIN | DAIRY | SUGAR | FRUIT

--- a/modular/Neu_Food/code/raw/raw_veggies.dm
+++ b/modular/Neu_Food/code/raw/raw_veggies.dm
@@ -57,4 +57,4 @@
 	icon_state = "pesto"
 	desc = "A luxurious local blend of rocknut, oil, and garlick. A blend invented by immigrants from Navarno. It's best served in a noodle dish."
 	tastes = list("fresh nutty savoriness" = 1)
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/water/blessed = 1, /datum/reagent/drug/nicotine = 1, /datum/reagent/consumable/acorn_powder = 4)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/water/blessed = 1, /datum/reagent/drug/westleach = 1, /datum/reagent/consumable/acorn_powder = 4)

--- a/modular/Neu_teas_and_brews/code/drink_mixes.dm
+++ b/modular/Neu_teas_and_brews/code/drink_mixes.dm
@@ -54,11 +54,11 @@
 	rotprocess = null
 	slice_sound = TRUE
 	dry = TRUE
-	pipe_reagents = list(/datum/reagent/drug/nicotine = 120) //500 cigarettes
+	pipe_reagents = list(/datum/reagent/drug/westleach = 120) //500 cigarettes
 	eat_effect = /datum/status_effect/debuff/badmeal
 	extra_eat_effect = /datum/status_effect/debuff/rotfood
-	list_reagents = list(/datum/reagent/drug/nicotine = 5, /datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/bad_food = 5)
-	grind_results = list(/datum/reagent/drug/nicotine = 20)
+	list_reagents = list(/datum/reagent/drug/westleach = 5, /datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/bad_food = 5)
+	grind_results = list(/datum/reagent/drug/westleach = 20)
 
 /obj/item/reagent_containers/food/snacks/grown/tar_brick/update_icon()
 	if(slices_num)
@@ -86,6 +86,6 @@
 	dry = TRUE
 	eat_effect = /datum/status_effect/debuff/badmeal
 	extra_eat_effect = /datum/status_effect/debuff/rotfood
-	pipe_reagents = list(/datum/reagent/drug/nicotine = 30) 
-	list_reagents = list(/datum/reagent/drug/nicotine = 5, /datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/bad_food = 1)
-	grind_results = list(/datum/reagent/drug/nicotine = 10)
+	pipe_reagents = list(/datum/reagent/drug/westleach = 30)
+	list_reagents = list(/datum/reagent/drug/westleach = 5, /datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/bad_food = 1)
+	grind_results = list(/datum/reagent/drug/westleach = 10)


### PR DESCRIPTION
## About The Pull Request
### problem
- we've still had "space drugs" as the swampweed reagent since the codebase started
- you can clearly see this if u grind it up at all
- help
- also we use "nicotine" as the reagent for westleach
### solution
- swampweed reagent is now /swampweed and is named "Swamp Oil" (akin to hash oil)
- color = green cus idk its proly green
- tastes like muddy jacksberries
- yea dats it
- westleach is now /westleach
- tastes the same
- color = yellow bc apparently nicotine is yellow sometimes
- also named Westleach Extract bc i dont think we even knew what nicotine was before the 1800s(?) maybe imw rong

all instances of drug/space_drugs and drug/nicotine were repathed

if anything blows up @ me
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
 - everything booted & ran fine. i drank both reagents, smoked, etc. it worked how i expected it to
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- sovl. bugfix. whatever
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: swampweed is now drug/swampweed instead of space_drugs
code: nicotine is now /westleach instead of nicotine
fix: swampweed now displays "Swamp Oil" instead of "space drugs"
fix: westleach now displays "Westleach Extract" instead of "nicotine"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
