### PR TITLE
[BALANCE] Added new spell scrolls to the lootpool.

### DIFF
--- a/code/game/objects/effects/spawners/dungeon_loot_spawner.dm
+++ b/code/game/objects/effects/spawners/dungeon_loot_spawner.dm
@@ -373,5 +373,17 @@
 	junk_loot = list(/obj/item/paper/scroll = 5, /obj/item/ash = 3)
 	loot = list(
 		/obj/item/book/granter/spell/bonechill = 2,
+		/obj/item/book/granter/spell/mending = 1,
+		/obj/item/book/granter/spell/light = 2,
+		/obj/item/book/granter/spell/leap = 1,
+		/obj/item/book/granter/spell/featherfall = 1,
+		/obj/item/book/granter/spell/darkvision = 3,
+		/obj/item/book/granter/spell/message = 3,
+		/obj/item/book/granter/spell/enlarge = 1,
+		/obj/item/book/granter/spell/readomen = 2,
+		/obj/item/book/granter/spell/transcribe = 3,
+		/obj/item/book/granter/spell/guidance = 1,
+		/obj/item/book/granter/spell/magiciansbrick = 2,
+		/obj/item/book/granter/spell/runeward = 2,
 	)
 	lootcount = 1

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -265,7 +265,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Eh...", "Malum?", "Just sounds like a spell to fix things, right?")
+	remarks = list("Opus artis...", "Fractum, sed scientia...", "Luceat sicut caelum lunae...")
 
 /obj/item/book/granter/spell/mending/onlearned(mob/living/carbon/user)
 	..()
@@ -284,7 +284,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Eh...", "Let there be light...", "I can see in the dark now!")
+	remarks = list("Donum Astrata...", "Condensatum...", "Tenebrae fugient...")
 
 /obj/item/book/granter/spell/light/onlearned(mob/living/carbon/user)
 	..()
@@ -303,7 +303,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Oh-", "Hello?", "I can hear the voices of a distant mind!")
+	remarks = list("Vox alterius...", "Mente mea aperta...", "Vox vocat...")
 
 /obj/item/book/granter/spell/mindlink/onlearned(mob/living/carbon/user)
 	..()
@@ -322,7 +322,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Ribbit...", "Croak.", "I can jump really high now!")
+	remarks = list("Crura amphibii...", "Mens leporis...", "Praedatoris saltus...")
 
 /obj/item/book/granter/spell/leap/onlearned(mob/living/carbon/user)
 	..()
@@ -341,7 +341,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Omosign", "Crossigna", "I can see in the dark now!")
+	remarks = list("Oculus felis...", "Umbrae moventur...", "Nihil nunc celari potest...")
 
 /obj/item/book/granter/spell/darkvision/onlearned(mob/living/carbon/user)
 	..()
@@ -360,7 +360,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Bwoing!", "Yippee!", "I can survive falls from great heights now!")
+	remarks = list("Vola ut papilio...", "Munera felina...", "Aer cadutam tuam mollificat...")
 
 /obj/item/book/granter/spell/featherfall/onlearned(mob/living/carbon/user)
 	..()
@@ -379,7 +379,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Bwoing!", "Yippee!", "I can survive falls from great heights now!")
+	remarks = list("Sermo mutus...", "Mea locatio...", "Amico dato...")
 
 /obj/item/book/granter/spell/message/onlearned(mob/living/carbon/user)
 	..()
@@ -398,7 +398,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("The clouds look great from this view.", "The Ground shrinks,", "And now- I have the urge to step on someone...")
+	remarks = list("A minore ad maius...", "pondus insuportabile...", "Confringere inimicos tuos...")
 
 /obj/item/book/granter/spell/enlarge/onlearned(mob/living/carbon/user)
 	..()
@@ -417,7 +417,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("R'ch", "T'h", "Tr'th...")
+	remarks = list("Mens aperta...", "ut verum videas...", "De occultis arcanis mundi...")
 
 /obj/item/book/granter/spell/guidance/onlearned(mob/living/carbon/user)
 	..()
@@ -436,7 +436,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Rocc!", "Booga...", "Ooga...")
+	remarks = list("Lapis aedificii...", "cum fissuris...", "incantatus...")
 
 /obj/item/book/granter/spell/magiciansbrick/onlearned(mob/living/carbon/user)
 	..()
@@ -455,7 +455,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Fate of the world...", "What influences you,", "The future of us all...")
+	remarks = list("Fatum mundi...", "quid te afficit...", "hac hebdomade...")
 
 /obj/item/book/granter/spell/readomen/onlearned(mob/living/carbon/user)
 	..()
@@ -474,7 +474,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("Ashes traced into a pattern,", "Given lyfe from the Arcyne,", "Shock, Trap, Burn...")
+	remarks = list("manet combustum...", "vita data...", "Fulgur, ure, conglacia...")
 
 /obj/item/book/granter/spell/runeward/onlearned(mob/living/carbon/user)
 	..()
@@ -493,7 +493,7 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	oneuse = TRUE
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound = 'sound/blank.ogg'
-	remarks = list("The secrets of the past...", "Books with history,", "Hearing the past, Present, and Future...")
+	remarks = list("Disce ex libris...", "Libri Historiae...", "Ex erroribus discens...")
 
 /obj/item/book/granter/spell/transcribe/onlearned(mob/living/carbon/user)
 	..()

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -141,7 +141,7 @@
 	. = ..()
 	if(!user.mind)
 		return
-	
+
 	for(var/crafting_recipe_type in crafting_recipe_types)
 		var/datum/crafting_recipe/R = crafting_recipe_type
 		user.mind.teach_crafting_recipe(crafting_recipe_type)
@@ -248,6 +248,254 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 	remarks = list("Mediolanum ventis..", "Sana damnatorum..", "Frigidus ossa mortuorum..")
 
 /obj/item/book/granter/spell/bonechill/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+
+/obj/item/book/granter/spell/mending
+	name = "Scroll of Mending"
+	spell = /datum/action/cooldown/spell/mending
+	spellname = "Mending"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Eh...", "Malum?", "Just sounds like a spell to fix things, right?")
+
+/obj/item/book/granter/spell/mending/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/light
+	name = "Scroll of Light"
+	spell = /datum/action/cooldown/spell/light
+	spellname = "Light"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Eh...", "Let there be light...", "I can see in the dark now!")
+
+/obj/item/book/granter/spell/light/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/mindlink /// Seems a little OP as SCOMS are nerfed currently, won't put it into loot piles for now- Unless public uproar screams at me to add it in, then I'll add it in. -Le Suffering Mime Coder
+	name = "Scroll of Mind Link"
+	spell = /datum/action/cooldown/spell/mindlink
+	spellname = "Mind Link"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Oh-", "Hello?", "I can hear the voices of a distant mind!")
+
+/obj/item/book/granter/spell/mindlink/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/leap
+	name = "Scroll of Leap"
+	spell = /datum/action/cooldown/spell/leap
+	spellname = "Leap"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Ribbit...", "Croak.", "I can jump really high now!")
+
+/obj/item/book/granter/spell/leap/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/darkvision
+	name = "Scroll of Dark Vision"
+	spell = /datum/action/cooldown/spell/darkvision
+	spellname = "Dark Vision"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Omosign", "Crossigna", "I can see in the dark now!")
+
+/obj/item/book/granter/spell/darkvision/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/featherfall
+	name = "Scroll of Feather Fall"
+	spell = /datum/action/cooldown/spell/featherfall
+	spellname = "Feather Fall"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Bwoing!", "Yippee!", "I can survive falls from great heights now!")
+
+/obj/item/book/granter/spell/featherfall/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/message
+	name = "Scroll of Message"
+	spell = /datum/action/cooldown/spell/message
+	spellname = "Message"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Bwoing!", "Yippee!", "I can survive falls from great heights now!")
+
+/obj/item/book/granter/spell/message/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/enlarge
+	name = "Scroll of Enlarge"
+	spell = /datum/action/cooldown/spell/augment_buff/enlarge
+	spellname = "Enlarge"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("The clouds look great from this view.", "The Ground shrinks,", "And now- I have the urge to step on someone...")
+
+/obj/item/book/granter/spell/enlarge/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+	/obj/item/book/granter/spell/guidance
+	name = "Scroll of Guidance"
+	spell = /datum/action/cooldown/spell/augment_buff/guidance
+	spellname = "Guidance"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("R'ch", "T'h", "Tr'th...")
+
+/obj/item/book/granter/spell/guidance/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/magiciansbrick
+	name = "Scroll of Magician's Brick"
+	spell = /datum/action/cooldown/spell/magicians_brick
+	spellname = "Magician's Brick"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Rocc!", "Booga...", "Ooga...")
+
+/obj/item/book/granter/spell/magiciansbrick/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/readomen
+	name = "Scroll of Read Omen"
+	spell = /datum/action/cooldown/spell/readomen
+	spellname = "Read Omen"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Fate of the world...", "What influences you,", "The future of us all...")
+
+/obj/item/book/granter/spell/readomen/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/runeward
+	name = "Scroll of Rune Ward"
+	spell = /datum/action/cooldown/spell/touch/rune_ward
+	spellname = "Rune Ward"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("Ashes traced into a pattern,", "Given lyfe from the Arcyne,", "Shock, Trap, Burn...")
+
+/obj/item/book/granter/spell/runeward/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse)
+		name = "siphoned scroll"
+		desc = "A scroll once inscribed with magical scripture. The surface is now barren of knowledge, siphoned by someone else. It's utterly useless."
+		icon_state = "scroll"
+		user.visible_message(span_warning("[src] has had its magic ink ripped from the scroll!"))
+
+/obj/item/book/granter/spell/transcribe
+	name = "Scroll of Transcribe"
+	spell = /datum/action/cooldown/spell/transcribe
+	spellname = "Transcribe"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scrolldarkred"
+	oneuse = TRUE
+	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
+	pickup_sound = 'sound/blank.ogg'
+	remarks = list("The secrets of the past...", "Books with history,", "Hearing the past, Present, and Future...")
+
+/obj/item/book/granter/spell/transcribe/onlearned(mob/living/carbon/user)
 	..()
 	if(oneuse)
 		name = "siphoned scroll"

--- a/code/game/objects/structures/roguetown/loot.dm
+++ b/code/game/objects/structures/roguetown/loot.dm
@@ -40,7 +40,19 @@
 	var/lootnumber = 1
 	for(i=0, i<lootnumber, i++)
 		loot.Add(pickweight(list(
-		/obj/item/book/granter/spell/bonechill = 2)))
+		/obj/item/book/granter/spell/bonechill = 2,
+		/obj/item/book/granter/spell/mending = 1,
+		/obj/item/book/granter/spell/light = 2,
+		/obj/item/book/granter/spell/leap = 1,
+		/obj/item/book/granter/spell/featherfall = 1,
+		/obj/item/book/granter/spell/darkvision = 3,
+		/obj/item/book/granter/spell/message = 3,
+		/obj/item/book/granter/spell/enlarge = 1,
+		/obj/item/book/granter/spell/readomen = 2,
+		/obj/item/book/granter/spell/transcribe = 3,
+		/obj/item/book/granter/spell/guidance = 1,
+		/obj/item/book/granter/spell/magiciansbrick = 2,
+		/obj/item/book/granter/spell/runeward = 2,)))
 	return ..()
 
 /obj/structure/loot/pile/attack_hand(mob/user)


### PR DESCRIPTION
## About The Pull Request
added more scrolls to the dungeon lootpool, aimed to be focusing on minor aspects. Tis probably a bit OP, but scream at me if it gets out of hand I did make Mind Link, but as SCOMS were nerfed recently i won't add them yet
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1020" height="677" alt="Screenshot (36)" src="https://github.com/user-attachments/assets/81a573b4-dd95-46a9-8ab3-89d4c8cd9f4d" />
<img width="1385" height="52" alt="Screenshot (35)" src="https://github.com/user-attachments/assets/e926d42a-2c0e-48db-b017-9332de0e678d" />


## Why It's Good For The Game

I fucking HATE BONE CHILL ONLY SPAWNING!
Doing all the work in any dungeon as a mage, be it a team or otherwise just provides you with three scrolls of bone chill and *maybe* light armor. Aimed to expand on the idea with the focus of making spells like Transcribe the most common.
This change allows mages to progress a little easier with how much work they put in.

Full list of added spells;
	Mending
	Light
	Leap
	Featherfall
	Darkvision
        Message
	Enlarge
	Read Omen
	Transcribe
	Guidance
	Magicians Brick
	Runeward
More are going to be added if people like the change/give me ideas. I might bring back the Utility/Minor aspect point scrolls too at a far rarer rate- And give them values so it's actually worth it to pick up as a non mage.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Added more spells to the lootpool. Ending the long reign of bonechill.
add: Made a few spare spellgranters that admins or other coders to give/look at.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
