### PR TITLE
Squire Polishing 2: Keeping Parity. (retinue squires start w brush+cream, brush skill gate dropped 4->2).

### DIFF
--- a/code/modules/jobs/job_types/roguetown/retinue/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/squire.dm
@@ -89,7 +89,9 @@
 		/obj/item/rogueweapon/scabbard/sheath,
 		/obj/item/storage/belt/rogue/pouch,
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-		/obj/item/rogueweapon/hammer/copper
+		/obj/item/rogueweapon/hammer/copper,
+		/obj/item/armor_brush = 1,
+		/obj/item/polishing_cream = 1
 	)
 	if(H.mind)
 		SStreasury.grant_savings(ECONOMIC_WORKING_CLASS, H)
@@ -138,7 +140,9 @@
 		/obj/item/rogueweapon/scabbard/sheath,
 		/obj/item/storage/belt/rogue/pouch,
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-		/obj/item/rogueweapon/hammer/copper
+		/obj/item/rogueweapon/hammer/copper,
+		/obj/item/armor_brush = 1,
+		/obj/item/polishing_cream = 1
 	)
 	H.adjust_blindness(-3)
 	if(H.mind)
@@ -201,7 +205,9 @@
 		/obj/item/storage/belt/rogue/pouch,
 		/obj/item/rogueweapon/scabbard/sheath,
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-		/obj/item/rogueweapon/hammer/copper
+		/obj/item/rogueweapon/hammer/copper,
+		/obj/item/armor_brush = 1,
+		/obj/item/polishing_cream = 1
 		)
 	if(H.mind)
 		SStreasury.grant_savings(ECONOMIC_WORKING_CLASS , H)

--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -221,7 +221,7 @@
 	subtype_reqs = TRUE
 	structurecraft = /obj/structure/artificer_table
 	skillcraft = /datum/skill/craft/engineering
-	craftdiff = 4
+	craftdiff = 2 //It's a brush. The consumable cream still needs expert, so this can drop to apprentice.
 
 /datum/crafting_recipe/roguetown/engineering/polishcream
 	name = "Polish Cream"
@@ -235,7 +235,7 @@
 	)
 	structurecraft = /obj/structure/artificer_table
 	skillcraft = /datum/skill/craft/engineering
-	craftdiff = 4
+	craftdiff = 4 //high, but we dont want polishing to be come commonplace or an expectation.
 
 //crossbows, crossbow bolts, and specialized arrows and bolts
 


### PR DESCRIPTION
## About The Pull Request

Sort of a follow on from https://github.com/Azure-Peak/Azure-Peak/pull/7406

Gives keep/retinue squires a polishing brush + one pot of polishing cream in their starting loadout, for parity with squire errants and the failed squire virtue. I had presumed the keep had a mapped-in stock, but apparently there's only a single pot of the stuff to go around. By putting it in spawn gear we guarantee them some on all maps.

Additionally, knocks the crafting requirement of the polishing brush down from expert engineering to apprentice engineering, given it is a plank with some fur/fiber, and other brushes have no skill gate at all. This just helps replacing if you lose one.

The polish cream -stays- at expert skill requirement / 150 mams a pop because we don't want polishing to become commonplace, become expected, and lose its charm / get shot for being just boring powercreep. 

## Testing Evidence

Spawn gear (tested for all three variant roles):
<img width="216" height="277" alt="image" src="https://github.com/user-attachments/assets/53f2aa7a-0b59-4f1f-9070-dbeac4900ab1" />
<img width="155" height="200" alt="image" src="https://github.com/user-attachments/assets/448ad45c-6ad8-4018-a4fc-e534ee4d3832" />

Crafting recipes:
<img width="531" height="441" alt="image" src="https://github.com/user-attachments/assets/8dea5111-64b9-4f03-9989-6cd334a6cb95" />

Despite the listed sell price, does not seem to actually be worth too much, given that it costs a fur.
<img width="573" height="30" alt="image" src="https://github.com/user-attachments/assets/45529670-b73e-4dd7-b831-19959582c066" />
<img width="465" height="31" alt="image" src="https://github.com/user-attachments/assets/c2c355ea-c52a-4e57-9b67-0cf42044dd44" />
<img width="451" height="54" alt="image" src="https://github.com/user-attachments/assets/fb11304b-d249-42a5-9791-693b60cb3d1c" />
<img width="704" height="32" alt="image" src="https://github.com/user-attachments/assets/c5051137-c4f8-4521-97f0-947f232304fb" />


## Why It's Good For The Game

It is nice when squires can do their cute little bonus without having to battle to the death over the keep armory's single pot of polish cream. It is also nice when keep squires have parity with errant ones for amenities. 

Replacing the brushes should probably not be that hard, they don't do anything without the consumable cream that is the actual thing to control the flow of.

## Changelog


:cl:
add: Added a polishing brush + pot of polishing cream to the starting gear of retinue squires.
balance: Dropped the skill gate on polishing brushes from expert engineering to apprentice engineering.
/:cl:
