### PR TITLE
DBP2 Addendum: 'idk if this one's a bug so it's atomized' Edition!

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -866,8 +866,6 @@
 
 /mob/living/carbon/human/on_fire_stack(seconds_per_tick, datum/status_effect/fire_handler/fire_stacks/fire_handler)
 	//SEND_SIGNAL(src, COMSIG_HUMAN_BURNING)
-	if(fire_handler.stacks >= 10)
-		burn_clothing(seconds_per_tick, fire_handler.stacks)
 	var/no_protection = FALSE
 	fire_handler.harm_human(seconds_per_tick, no_protection)
 


### PR DESCRIPTION
## About The Pull Request
I swear there was talk about firestacks burning off your clothes being removed, but apparently. It wasn't? Or it's back now? The code looks intentional, so idk if this is actually a bug but it caught us by surprise yesterday.

## Testing Evidence
It's removing 2 lines

## Why It's Good For The Game
This _might_ be a bug, but even if it isn't, having all your gear burn up because you pissed off an astratan is - like, really bad. Idt anyone should be able to do that, no other source of damage just straight up obliterates an entire class of equipment arbitrarily. Sorry to any enjoyers of the "stab a vamp with blessed silver to undress them really quickly" meta.

## Changelog

:cl:
fix: Firestacks, including sunderstacks, no longer set worn items on fire and burn off all your clothes.
/:cl:
