### PR TITLE
Tweaks dagger cut intent to be slighty faster and thus not totally inferior to the stab.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -13,7 +13,7 @@
 	penfactor = PEN_NONE
 	chargetime = 0
 	swingdelay = 0
-	clickcd = CLICK_CD_QUICK
+	clickcd = CLICK_CD_FAST //ever so slightly quicker than a stab, so as to not just be a worse intent.
 	item_d_type = "slash"
 
 // Training dagger-exclusive(?) slash. Could potentially be reused for other blunt-edged handweapons.
@@ -22,6 +22,7 @@
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	penfactor = PEN_NONE
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
+	clickcd = CLICK_CD_QUICK
 
 /// For unusually heavy daggers with a strong cutting edge.
 /datum/intent/dagger/cut/heavy
@@ -29,6 +30,7 @@
 	damfactor = 1.2
 	penfactor = PEN_MEDIUM
 	clickcd = 11
+	clickcd = CLICK_CD_QUICK //slower than normal cut due to the higher damage.
 
 /datum/intent/dagger/thrust
 	name = "thrust"


### PR DESCRIPTION
## About The Pull Request

Most daggers have a cut intent with 1s click delay and no force modifier or penetration. 
Most daggers also have a stab intent with 1s click delay, no force modifier, and 2-pip penetration.

There is essentially no reason/use case for the cut, aside from things that need it specifically (sharpening stakes) or slashing damage to decap corpses. Even if you specifically want to destroy armor instead of penetrating to the flesh beneath, knives get a parry/dodge bypassing blunt punch for that.

This PR drops the click delay on the cut intent down to 0.8s, to make it ever so slightly faster than the stab and give it somewhat of an advantage. It remains inferior for killing light armor things (pen them with stab) penning heavy armor (use pick for that), or breaking armor (use punch for that), but may slightly edge out the punch vs targets that are not defending themselves. 

Will be superior for murdering completely unarmored targets, on knives that lack a rend intent.


Disclaimers:
- This PR does not change the click delay of the heavy cut intent present on a few heavier knives (seaxes, warden knives), as that actually does have a damage modifier and pen.

- The cut intent on a dagger is still not remotely as good as the cut intent on a dedicated cutting weapon like a saber, that boast significantly greater force, a significant force multiplier on the intent, and equal speed to the new cut (as well as vastly better wdef).

## Testing Evidence

Stab intent:
<img width="366" height="157" alt="image" src="https://github.com/user-attachments/assets/66a64a36-2628-461f-a0a0-f51e57d86a5b" />

Cut intent:
<img width="391" height="159" alt="image" src="https://github.com/user-attachments/assets/6867cbfe-a59e-43af-ba50-47beed87e609" />


Heavy cut intent (unchanged):
<img width="345" height="172" alt="image" src="https://github.com/user-attachments/assets/50f5b1ad-1163-4817-94bf-0a949cfcb601" />


Saber cut intent (unchanged, for comparison):
<img width="370" height="170" alt="image" src="https://github.com/user-attachments/assets/919dad68-1dbf-4188-8ae5-e5e4ebcaa187" />


## Why It's Good For The Game

More reason to not constantly sit on a single intent.


## Changelog

:cl:
balance: lowers the click delay of non-heavy knife cut intents from 1.0s to 0.8s, to give a reason for using them instead of stab intents that had identical speed, identical damage, and greater penetration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
