### PR TITLE
Adjust silverface price of surgeon's bag and make all sanguine clothes repairable

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/tools.dm
+++ b/code/modules/cargo/packsrogue/merchant/tools.dm
@@ -85,7 +85,7 @@
 
 /datum/supply_pack/rogue/tools/surgeonsbag
 	name = "Surgeon's bag, Full"
-	cost = 80
+	cost = 45
 	contains = list(/obj/item/storage/belt/rogue/surgery_bag)
 
 /datum/supply_pack/rogue/tools/surgeonsbagempty

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -864,6 +864,7 @@
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_courtphys.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/courtphys.dmi'
 	salvage_result = /obj/item/natural/hide/cured
+	sewrepair = TRUE
 
 /obj/item/clothing/shoes/courtphysician/female
 	name = "sanguine heels"

--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -628,6 +628,7 @@
 	icon = 'icons/roguetown/clothing/special/courtphys.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/courtphys.dmi'
 	salvage_result = /obj/item/natural/silk
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/courtphysician/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

- Lowers the base price of the surgeon's bag in the silverface/goldface from 80 down to 45. Keep in mind, in-round the prices will be higher than that.
- Fixes the head physician exclusive shoes and hats not being repairable.

## Testing Evidence
<img width="275" height="45" alt="image" src="https://github.com/user-attachments/assets/b8280160-bfd4-4ebd-b96e-c28c62f4db14" /> goldface price
<img width="274" height="37" alt="image" src="https://github.com/user-attachments/assets/5ad6d9ed-9f31-4bca-84c8-4acba85f7de0" /> silverface price
<img width="274" height="94" alt="image" src="https://github.com/user-attachments/assets/fe063742-1681-45cd-83b4-b83d6191eee0" />

## Why It's Good For The Game

For the sanguine clothes being repairable, this is merely a bug fix.
For the surgeon's bag price... I am fairly convinced that the current price is still set on the old recipe, which I'm told used steel rather than the current cost of iron. This creates a massive, MASSIVE discrepancy in the price of a bag, depending on whether you have a smithy to make one, or a merchant to get the goldface price... We're talking about an absurd price hike of upwards of 500%. Mind, even after this change, it is still vastly, vastly preferable to have the bag made at the smithy, it's simply a more reasonable gap.

## Changelog

:cl:
balance: reduced price of surgeon's bag in the goldface and silverface
fix: fixed sanguine hats and shoes not being repairable
/:cl:
