### PR TITLE
Fixes wrong music mood being chosen among other dumb bugs for instruments

### DIFF
--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -86,7 +86,7 @@
 		user.remove_status_effect(/datum/status_effect/buff/playing_music)
 		return
 	else
-		var/playdecision = alert(user, "Would you like to start a band?", "Band Play", "Yes", "No")
+		var/playdecision = alert(user, "Would you like to start a band?", "Band Play", "No", "Yes")
 		switch(playdecision)
 			if("Yes")
 				groupplaying = TRUE
@@ -186,7 +186,7 @@
 				if(theirinstrument.playing)
 					continue
 				if(potentialbandmates != user)
-					if(alert(potentialbandmates, "Would you like to perform in a band?", "Band Play", "Yes", "No") != "Yes")
+					if(alert(potentialbandmates, "Would you like to perform in a band?", "Band Play", "No", "Yes") != "Yes")
 						continue
 				var/songchoice = input(potentialbandmates, "Which song shall [potentialbandmates] perform?", "Music", name) as null|anything in theirinstrument.song_list
 				if(!songchoice)

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -92,6 +92,29 @@
 				groupplaying = TRUE
 			if("No")
 				groupplaying = FALSE
+			else
+				return
+
+		note_color = initial(note_color)
+		if(user.mind)
+			switch(user.get_skill_level(/datum/skill/misc/music))
+				if(2)
+					note_color = "#ffffff"
+					stressevent = /datum/stressevent/music/two
+				if(3)
+					note_color = "#1eff00"
+					stressevent = /datum/stressevent/music/three
+				if(4)
+					note_color = "#0070dd"
+					stressevent = /datum/stressevent/music/four
+				if(5)
+					note_color = "#a335ee"
+					stressevent = /datum/stressevent/music/five
+				if(6)
+					note_color = "#ff8000"
+					stressevent = /datum/stressevent/music/six
+		soundloop.stress2give = stressevent
+
 		if(!groupplaying)
 			var/list/options = song_list.Copy()
 			if(user.mind && user.get_skill_level(/datum/skill/misc/music) >= 4)
@@ -134,35 +157,6 @@
 			curfile = song_list[choice]
 			if(!user || playing || !(src in user.held_items))
 				return
-			if(user.mind)
-				switch(user.get_skill_level(/datum/skill/misc/music))
-					if(1)
-						stressevent = /datum/stressevent/music
-						soundloop.stress2give = stressevent
-					if(2)
-						note_color = "#ffffff"
-						stressevent = /datum/stressevent/music/two
-						soundloop.stress2give = stressevent
-					if(3)
-						note_color = "#1eff00"
-						stressevent = /datum/stressevent/music/three
-						soundloop.stress2give = stressevent
-					if(4)
-						note_color = "#0070dd"
-						stressevent = /datum/stressevent/music/four
-						soundloop.stress2give = stressevent
-					if(5)
-						note_color = "#a335ee"
-						stressevent = /datum/stressevent/music/five
-						soundloop.stress2give = stressevent
-					if(6)
-						note_color = "#ff8000"
-						stressevent = /datum/stressevent/music/six
-						soundloop.stress2give = stressevent
-					else
-						soundloop.stress2give = stressevent
-			if(!(src in user.held_items))
-				return
 			if(user.get_inactive_held_item())
 				playing = FALSE
 				soundloop.stop()
@@ -180,8 +174,9 @@
 				groupplaying = FALSE
 				soundloop.stop()
 				user.remove_status_effect(/datum/status_effect/buff/playing_music)
+
 		if(groupplaying)
-			var/pplnearby =view(7,loc)
+			var/list/pplnearby = view(7,loc)
 			var/list/instrumentsintheband = list()
 			var/list/bandmates = list()
 			for(var/mob/living/carbon/human/potentialbandmates in pplnearby)
@@ -191,27 +186,28 @@
 					var/decision = alert(potentialbandmates, "Would you like to perform in a band?", "Band Play", "Yes", "No")
 					switch(decision)
 						if("No")
-							return
+							continue
 						else
 							bandmates += potentialbandmates
 							instrumentsintheband += iteminhand
 							thisguyinstrument += iteminhand
 							for(var/obj/item/rogue/instrument/bandinstrumentspersonal in thisguyinstrument)
 								if(bandinstrumentspersonal.playing)
-									return
+									continue
 								bandinstrumentspersonal.curfile = input(potentialbandmates, "Which song shall [potentialbandmates] perform?", "Music", name) as null|anything in bandinstrumentspersonal.song_list
 								bandinstrumentspersonal.curfile = bandinstrumentspersonal.song_list[bandinstrumentspersonal.curfile]
 			if(do_after(user, 1))
 				for(var/obj/item/rogue/instrument/bandinstrumentsband in instrumentsintheband)
 					if(!bandinstrumentsband.curfile)
-						return
+						continue
 					bandinstrumentsband.playing = TRUE
 					bandinstrumentsband.groupplaying = TRUE
+					bandinstrumentsband.soundloop.stress2give = stressevent
 					bandinstrumentsband.soundloop.mid_length = rustg_sound_length("[bandinstrumentsband.curfile]")
 					bandinstrumentsband.soundloop.set_mid_sounds(list(bandinstrumentsband.curfile))
 					bandinstrumentsband.soundloop.start()
-					for(var/mob/living/carbon/human/A in bandmates)
-						A.apply_status_effect(/datum/status_effect/buff/playing_music, stressevent, note_color)
+				for(var/mob/living/carbon/human/A in bandmates)
+					A.apply_status_effect(/datum/status_effect/buff/playing_music, stressevent, note_color)
 
 /obj/item/rogue/instrument/lute
 	name = "lute"

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -86,11 +86,11 @@
 		user.remove_status_effect(/datum/status_effect/buff/playing_music)
 		return
 	else
-		var/playdecision = alert(user, "Would you like to start a band?", "Band Play", "No", "Yes")
+		var/playdecision = alert(user, "Would you like to start a band?", "Band Play", "Nay", "Yea")
 		switch(playdecision)
-			if("Yes")
+			if("Yea")
 				groupplaying = TRUE
-			if("No")
+			if("Nay")
 				groupplaying = FALSE
 			else
 				return
@@ -186,7 +186,7 @@
 				if(theirinstrument.playing)
 					continue
 				if(potentialbandmates != user)
-					if(alert(potentialbandmates, "Would you like to perform in a band?", "Band Play", "No", "Yes") != "Yes")
+					if(alert(potentialbandmates, "Would you like to perform in a band?", "Band Play", "Nay", "Yea") != "Yea")
 						continue
 				var/songchoice = input(potentialbandmates, "Which song shall [potentialbandmates] perform?", "Music", name) as null|anything in theirinstrument.song_list
 				if(!songchoice)

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -180,22 +180,20 @@
 			var/list/instrumentsintheband = list()
 			var/list/bandmates = list()
 			for(var/mob/living/carbon/human/potentialbandmates in pplnearby)
-				var/list/thisguyinstrument = list()
-				var/obj/item/iteminhand = potentialbandmates.get_active_held_item()
-				if(istype(iteminhand, /obj/item/rogue/instrument))
-					var/decision = alert(potentialbandmates, "Would you like to perform in a band?", "Band Play", "Yes", "No")
-					switch(decision)
-						if("No")
-							continue
-						else
-							bandmates += potentialbandmates
-							instrumentsintheband += iteminhand
-							thisguyinstrument += iteminhand
-							for(var/obj/item/rogue/instrument/bandinstrumentspersonal in thisguyinstrument)
-								if(bandinstrumentspersonal.playing)
-									continue
-								bandinstrumentspersonal.curfile = input(potentialbandmates, "Which song shall [potentialbandmates] perform?", "Music", name) as null|anything in bandinstrumentspersonal.song_list
-								bandinstrumentspersonal.curfile = bandinstrumentspersonal.song_list[bandinstrumentspersonal.curfile]
+				var/obj/item/rogue/instrument/theirinstrument = potentialbandmates.get_active_held_item()
+				if(!istype(theirinstrument))
+					continue
+				if(theirinstrument.playing)
+					continue
+				if(potentialbandmates != user)
+					if(alert(potentialbandmates, "Would you like to perform in a band?", "Band Play", "Yes", "No") != "Yes")
+						continue
+				var/songchoice = input(potentialbandmates, "Which song shall [potentialbandmates] perform?", "Music", name) as null|anything in theirinstrument.song_list
+				if(!songchoice)
+					continue
+				theirinstrument.curfile = theirinstrument.song_list[songchoice]
+				bandmates += potentialbandmates
+				instrumentsintheband += theirinstrument
 			if(do_after(user, 1))
 				for(var/obj/item/rogue/instrument/bandinstrumentsband in instrumentsintheband)
 					if(!bandinstrumentsband.curfile)


### PR DESCRIPTION
## About The Pull Request

This pull request was brought to you by the siphoned off water supply of a dying African-American child in middle America. I hope you're happy.

Since BYOND is terrible and nests code in tabs instead of brackets like civilized code languages, I had to employ the help of a handy dandy **a**ss**i**stant to figure out why this was breaking. My **a**ss**i**stant was very good at noticing problems that I would miss with my squishy dumb human eyeballs and lazy brain with its unreliable pattern recognition. This made the initial problem obvious, and then we noticed additional problems we weren't originally looking for. However, said **a**ss**i**stant is an idiot if left to code unsupervised, so I personally made sure that I understood how it all worked before making a PR about it.

Here's what changed and why:
- First of all, what the fuck is that switch doing there? No wonder this was broken. I moved that somewhere it actually works now.
- I didn't notice, but my **a**ss**i**stant pointed out that band mechanics were just completely fucked.
- My **a**ss**i**stant gave me fixes to band mechanics. After checking to make sure it wasn't hallucinating (it was, I smacked it, and now it's better), this is what it spat out. Bands can actually form now. Bands also don't get vetoed by one person refusing.
- Polished a bit, added QoL changes and thematically appropriate language because I feel like it.

By the way, my **a**ss**i**stant thought you ought to know.
> One thing the rewrite exposes rather than fixes: alert() and input() both sleep. Polling five people means five sequential dialogs, and whoever's at the end of the list is waiting on everyone before them — plenty of time for people to walk out of view(7) or stow their instrument. The do_after(user, 1) afterward is a single tick and won't catch any of that. If band formation feels flaky in testing, that's where I'd look next.

Already anticipating things to come. Band mechanics actually working now will probably uncover other bugs and annoyances.

## Testing Evidence

Look I even actually tested my shit for once. :)
<img width="1193" height="595" alt="image" src="https://github.com/user-attachments/assets/2f9c9e81-5c5b-47cb-ad5b-0a87395cbc74" />

I can't test band mechanics without a second player so you're on your own testing that.

## Why It's Good For The Game

Bug fixes.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Skill is read for instruments now no matter if you're attempting to be in a band or not.
fix: Band mechanics never actually worked. They probably work now. Probably.
code: Consent is important. Starting or joining a band is no longer the default. Also the yes or no is now yea or nay.
code: Made band code less awful and inefficient.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
