### PR TITLE
removes fog

### DIFF
--- a/code/datums/particle_weathers/datum_types/fog.dm
+++ b/code/datums/particle_weathers/datum_types/fog.dm
@@ -101,7 +101,7 @@
 	maxSeverityChange = 2
 	severitySteps = 5
 	immunity_type = TRAIT_RAINSTORM_IMMUNE
-	probability = 30
+	probability = 0
 	target_trait = PARTICLEWEATHER_RAIN
 	#ifndef  SPACEMAN_DMM
 	filter_type = filter(type="alpha", render_source = O_LIGHTING_VISUAL_RENDER_TARGET, flags = MASK_INVERSE)
@@ -136,15 +136,15 @@
 /datum/particle_weather/fog/swamp
 	name = "Swamp Fog"
 	particleEffectType = /particles/weather/fog/swamp
-	probability = 10
+	probability = 0
 
 /datum/particle_weather/fog/darkness
 	name = "Omen of Darkness Fog"
 	particleEffectType = /particles/weather/dark
-	probability = 1
+	probability = 0
 
 /datum/particle_weather/fog/blood
 	name = "Omen of Blood Feat Fog"
 	particleEffectType = /particles/weather/fog/bloodfog
-	probability = 1
+	probability = 0
 


### PR DESCRIPTION
## About The Pull Request
Despite the title, doesn't actually remove the fog code. Just sets the weight to 0 so it'll never roll

## Testing Evidence
Can't really but it's var changes

## Why It's Good For The Game
Fog is buggy, laggy, looks ugly, and serves no actual gameplay purpose. Half the lights in the game don't work to part it, half the time when you DO have a proper lightsource it won't update properly, and the density - despite being nerfed at least once - is still so over the top that it makes the game nigh unplayable if you're caught out during it. If fog happens and you're caught in it and duck in the nearest building you just have to twiddle your thumbs until it passes (which takes way too long) and there's like- that's not compelling gameplay? It gets that the idea is to force everyone inside to roleplay being home-stuck but that's not, like, actually what happens. All it does is add dead time to your round.

## Changelog

:cl:
del: Fog weather will no longer naturally occur
/:cl:

