### PR TITLE
Added pickpocketing skill option to the prowler virtue

### DIFF
--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -218,6 +218,7 @@
 		"Stashed Lockpick Ring" = /obj/item/lockpickring/mundane,
 		"Sneak Skill (+2, Up to Legendary)" = /datum/skill/misc/sneaking,
 		"Lockpick Skill (+3, Up to Legendary)" = /datum/skill/misc/lockpicking,
+		"Pickpocketing Skill (+3, Up to Legendary)" = /datum/skill/misc/stealing,
 		"Second Voice"
 		)
 
@@ -236,6 +237,8 @@
 				if(extra_choices[choice] == /datum/skill/misc/sneaking)
 					recipient.adjust_skillrank(extra_choices[choice], SKILL_LEVEL_APPRENTICE, silent = TRUE)
 				else if(extra_choices[choice] == /datum/skill/misc/lockpicking)
+					recipient.adjust_skillrank(extra_choices[choice], SKILL_LEVEL_JOURNEYMAN, silent = TRUE)
+				else if(extra_choices[choice] == /datum/skill/misc/stealing)
 					recipient.adjust_skillrank(extra_choices[choice], SKILL_LEVEL_JOURNEYMAN, silent = TRUE)
 			else if(ispath(extra_choices[choice], /obj/item))
 				var/obj/item/I = extra_choices[choice]


### PR DESCRIPTION
## About The Pull Request

Adds option "Pickpocketing Skill (+3, Up to Legendary)" option to the prowler virtue.

## Testing Evidence
**Prowler bonus selection window**
<img width="504" height="436" alt="pickpocketing_test_1" src="https://github.com/user-attachments/assets/f09ec4c6-d747-405e-a015-185d11e6c9b6" />


**Tailor skillset after taking prowler with pickpocketing**
<img width="373" height="329" alt="tailor_with_prowler" src="https://github.com/user-attachments/assets/aa18d032-405f-4c67-b2c6-48f23cc56fd6" />



## Why It's Good For The Game

Prowler virtue contains different bonuses that allow you to make you character more of a rogue. But pickpocketing skill that is a part of rogue arsenal is not available through this virtue. This pr fixes that.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added pickpocketing skill option to prowler virtue
/:cl:
