### PR TITLE
adds saddleborn to the last few classes without it

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -47,7 +47,7 @@
 
 	// better movement skills
 	subclass_skills = list(
-		/datum/skill/misc/riding = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -12,7 +12,7 @@
 	is_quest_giver = TRUE
 
 	tutorial = "You may have inherited this position, bought your way into it, or were appointed to it by merit--perish the thought! Whatever the case though, you work as an assistant and agent of the crown in matters of state. Whether this be aiding the steward, the sheriff, or the crown itself, or simply enjoying the free food of the keep, your duties vary day by day. You may be the lowest rung of the ladder, but that rung still towers over everyone else in town."
-	
+
 	whitelist_req = FALSE
 	outfit = /datum/outfit/job/roguetown/councillor
 	advclass_cat_rolls = list(CTAG_COUNCILLOR = 2)
@@ -36,7 +36,6 @@
 	name = "Herald"
 	tutorial = "While lacking in some faculties, such as wealth and courtly advice, you have the uncanny ability to spread the word of the court, and rally people to your liege's cause. The crown saw it fit to employ you as a messenger, but may still lend an ear if you speak your mind. You may be the lowest rung of the ladder, but that rung still towers over everyone else in town."
 	outfit = /datum/outfit/job/roguetown/councillor/herald
-	horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/saigabuck/tame/saddled
 	category_tags = list(CTAG_COUNCILLOR)
 	subclass_stats = list(
 		STATKEY_SPD = 2,
@@ -57,6 +56,9 @@
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+	)
+	subclass_virtues = list(
+		/datum/virtue/utility/riding
 	)
 
 /datum/advclass/councillor/cofferer

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/steppesman.dm
@@ -8,7 +8,6 @@
 	category_tags = list(CTAG_MERCENARY, CTAG_MERCPARTY_MARKSMAN)
 	cmode_music = 'sound/music/combat_steppe.ogg'
 	subclass_languages = list(/datum/language/aavnic)
-	horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled
 	extra_context = "This subclass has 4 loadouts with various stats, skills & equipment."
 	subclass_skills = list(
 	//Universal skills
@@ -21,6 +20,9 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
+	)
+	subclass_virtues = list(
+		/datum/virtue/utility/riding
 	)
 
 /datum/outfit/job/roguetown/mercenary/steppesman/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/steppesman.dm
@@ -12,7 +12,7 @@
 	subclass_skills = list(
 	//Universal skills
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
-		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/tanning = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
@@ -8,7 +8,8 @@
 	subclass_languages = list(/datum/language/etruscan)
 	traits_applied = list(TRAIT_DODGEEXPERT)
 	subclass_virtues = list(
-		/datum/virtue/combat/guarded
+		/datum/virtue/combat/guarded,
+		/datum/virtue/utility/riding
 	)
 	subclass_stats = list(
 		STATKEY_SPD = 3,
@@ -32,11 +33,6 @@
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/music = SKILL_LEVEL_EXPERT,
 	)
-
-/datum/advclass/mercenary/vaquero/equipme(mob/living/carbon/human/H, dummy)
-	if(should_wear_femme_clothes(H))
-		horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled
-	return ..()
 
 /datum/outfit/job/roguetown/mercenary/vaquero/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
@@ -8,8 +8,7 @@
 	subclass_languages = list(/datum/language/etruscan)
 	traits_applied = list(TRAIT_DODGEEXPERT)
 	subclass_virtues = list(
-		/datum/virtue/combat/guarded,
-		/datum/virtue/utility/riding
+		/datum/virtue/combat/guarded
 	)
 	subclass_stats = list(
 		STATKEY_SPD = 3,
@@ -29,10 +28,15 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/music = SKILL_LEVEL_EXPERT,
 	)
+
+/datum/advclass/mercenary/vaquero/equipme(mob/living/carbon/human/H, dummy)
+	if(should_wear_femme_clothes(H))
+		horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled
+	return ..()
 
 /datum/outfit/job/roguetown/mercenary/vaquero/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
@@ -29,7 +29,7 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/music = SKILL_LEVEL_EXPERT,
 	)


### PR DESCRIPTION
## About The Pull Request

This adds the saddleborn virtue to two classes that originally spawned with a saiga and have a reasonable cause to have it; Herald Councillor and Steppesman

On the backend side, this also reduces their riding by a level, as they will otherwise receive an extra level from the virtue. You should not notice this in game.

## Testing Evidence

Spawned in as both classes and received the ability as necessary.

## Why It's Good For The Game

Spawning with the horse is clunky and annoying to deal with. I don't usually mind annoying, but enough people complain about it to where I think it would be for the better.

I do not like the proliferation of virtues as class features, but this is the one instance where I think the virtue is kind of necessary for the class to 'work' as it does.

HERALD - Might be more thematically fitting to have a real horse; plus, they're kind of dependent on it for the class gimmick.
STEPPESMAN - Very thematically a steppe-rider. Ought have gotten it when Knights did, to be honest.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: saddleborn replaces free mounts for steppesman and herald
/:cl: