### PR TITLE
missed one mindlink bug

### DIFF
--- a/code/datums/mindlink_hag.dm
+++ b/code/datums/mindlink_hag.dm
@@ -24,15 +24,15 @@
 		return
 
 	// Speech logic
-	if(findtext(message, ",y", 1, 3))
+	if(findtext(message, ",m", 1, 3))
 		message = trim(copytext(message, 3))
 		message = span_centcomradio("[message]")
 		var/formatted = "The voice of [speaker] echoes, \"<i>[capitalize(message)]</i>\"."
-		
+
 		for(var/mob/living/M in members)
 			// Slightly more secretive!
 			M.playsound_local(M, 'sound/magic/mindlink.ogg', 75, TRUE)
 			M.audible_message(formatted, hearing_distance = 0, runechat_message = message, custom_spans = list("mindlink", "italic"))
-		
+
 		speaker.log_talk(message, LOG_SAY, tag="Coven Link")
 		speech_args[SPEECH_MESSAGE] = null


### PR DESCRIPTION
## About The Pull Request
thought i got all the ,ys but no i missed one
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- shoul dwork now
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
