### PR TITLE
Buff forlorn hope starting gear + give melee mercs real shoes + make merc drip decent + organize gronn armors.

### DIFF
--- a/code/modules/cargo/packsrogue/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/Sellsword.dm
@@ -216,7 +216,7 @@
 
 /datum/supply_pack/rogue/Sellsword/Forlorncrate
 	name = "Forlorn Equipment Crate"
-	cost = 260
+	cost = 280
 	contains = list(/obj/structure/closet/crate/chest/bandit/forlorn)
 
 /obj/structure/closet/crate/chest/bandit/forlorn/Initialize()

--- a/code/modules/cargo/packsrogue/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/Sellsword.dm
@@ -222,7 +222,7 @@
 /obj/structure/closet/crate/chest/bandit/forlorn/Initialize()
 	. = ..()
 	new /obj/item/clothing/head/roguetown/helmet/heavy/volfplate/light(src)
-	new /obj/item/clothing/neck/roguetown/gorget/forlorncollar(src)
+	new /obj/item/clothing/neck/roguetown/gorget/steel/forlorncollar(src)
 	new /obj/item/clothing/suit/roguetown/armor/brigandine(src)
 	new /obj/item/clothing/wrists/roguetown/bracers/brigandine(src)
 	new /obj/item/clothing/under/roguetown/brigandinelegs(src)

--- a/code/modules/clothing/rogueclothes/armor/gronn.dm
+++ b/code/modules/clothing/rogueclothes/armor/gronn.dm
@@ -1,5 +1,96 @@
 // LIGHT ARMORS
 
+
+//armor
+/obj/item/clothing/suit/roguetown/armor/leather/heavy/atgervi //hardened leather armor reskin.
+	name = "shamanic coat"
+	desc = "A furred, protective coat. Often made by hand, it embodies the second trial of the Iskarn Shamans: To honor the leopard is to desire for more."
+	icon_state = "atgervi_shaman_coat"
+	item_state = "atgervi_shaman_coat"
+
+/obj/item/clothing/suit/roguetown/armor/leather/heavy/gronn //hardened leather armor reskin.
+	name = "gronnic ravager mantle"
+	desc = "A carefully created mantle of bone and hardened leather. It offers superior protection against the threats of the wild while remaining light, \
+			A popular design in Iskarn is to adorn a shoulder with a wolf pelt and skull. So that a great beast is always with you."
+	icon = 'icons/roguetown/clothing/special/gronn.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
+	icon_state = "gronnleatherarmor"
+	item_state = "gronnleatherarmor"
+
+//pants
+/obj/item/clothing/under/roguetown/trou/leather/gronn //hardened leather pants reskin.
+	name = "gronnic fur pants"
+	desc = "A pair of hardened leather pants with bone reinforcements along the legs; \
+			Those of Gronn adopt a design that offers superior protection against the blunted hits and slashing claws of beasts."
+	icon_state = "gronnleatherpants"
+	item_state = "gronnleatherpants"
+	icon = 'icons/roguetown/clothing/special/gronn.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
+	max_integrity = ARMOR_INT_LEG_HARDLEATHER
+
+/obj/item/clothing/under/roguetown/trou/leather/atgervi //hardened leather pants reskin.
+	name = "fur pants"
+	desc = "Thick fur pants made to endure the coldest winds, offering a share of protection from the fangs and claws of beasts and men alike."
+	icon_state = "atgervi_pants"
+	item_state = "atgervi_pants"
+	max_integrity = ARMOR_INT_LEG_HARDLEATHER
+
+//gloves
+/obj/item/clothing/gloves/roguetown/angle/gronn //unarmored variant. Used by adv noble, not the mercs.
+	name = "gronnic fur-lined leather gloves"
+	desc = "Thick, padded gloves made for the harshest of climates and the wildest of beasts encountered in the untamed north."
+	icon_state = "gronnleathergloves"
+	item_state = "gronnleathergloves"
+	icon = 'icons/roguetown/clothing/special/gronn.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
+	color = "#ffffff"
+
+/obj/item/clothing/gloves/roguetown/angle/gronnfur //hardened leather glove reskin with unarmed bonus damage. Shaman Unique.
+	name = "gronnic fur-lined bone gloves"
+	desc = "A pair of hardened leather gloves with bone reinforcements across the wrists\
+			and the back of the hand, offering superior protection against\
+			the claws of beasts and plants alike. Commonly worn by gatherers."
+	icon_state = "gronnfurgloves"
+	item_state = "gronnfurgloves"
+	icon = 'icons/roguetown/clothing/special/gronn.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
+	unarmed_bonus = 6
+	color = "#ffffff"
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
+	armor = ARMOR_LEATHER
+
+/obj/item/clothing/gloves/roguetown/angle/atgervi //hardened leather glove reskin.
+	name = "fur-lined leather gloves"
+	desc = "Dense, padded gloves made for the harshest of climates and the wildest of beasts encountered in the untamed highlands."
+	icon_state = "atgervi_raider_gloves"
+	item_state = "atgervi_raider_gloves"
+	color = "#ffffff"
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
+	armor = ARMOR_LEATHER
+
+//boots
+/obj/item/clothing/shoes/roguetown/boots/leather/atgervi //hardened leather boots reskin.
+	name = "atgervi leather boots"
+	desc = "A pair of strong leather boots, designed to endure both the heat of battle and the frigid cold of the Northern Empty."
+	icon_state = "atgervi_boots"
+	item_state = "atgervi_boots"
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
+	armor = ARMOR_LEATHER
+
+//helms
+/obj/item/clothing/head/roguetown/helmet/bascinet/atgervi
+	name = "owl helmet"
+	desc = "A carefully forged steel helmet in the shape of an owl's face, with added chain to cover the face and neck against many blows."
+	icon_state = "atgervi_raider"
+	item_state = "atgervi_raider"
+	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
+	body_parts_covered = FULL_HEAD|NECK
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/32x48/atgervi.dmi'
+	bloody_icon = 'icons/effects/blood64.dmi'
+	block2add = null
+	worn_x_dimension = 32
+	worn_y_dimension = 48
+
 /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi/gronn
 	name = "gronnic ravager helm"
 	desc = "A helmet of hardened leather with a carved animal skull to appear similar to a human; a unique design of The Northern Empty. \
@@ -14,51 +105,22 @@
 	worn_x_dimension = 32
 	worn_y_dimension = 32
 
-
-/obj/item/clothing/suit/roguetown/armor/leather/heavy/gronn
-	name = "gronnic ravager mantle"
-	desc = "A carefully created mantle of bone and hardened leather. It offers superior protection against the threats of the wild while remaining light, \
-			A popular design in Iskarn is to adorn a shoulder with a wolf pelt and skull. So that a great beast is always with you."
-	icon = 'icons/roguetown/clothing/special/gronn.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
-	icon_state = "gronnleatherarmor"
-	item_state = "gronnleatherarmor"
-	armor = ARMOR_LEATHER
-
-/obj/item/clothing/under/roguetown/trou/leather/gronn
-	name = "gronnic fur pants"
-	desc = "A pair of hardened leather pants with bone reinforcements along the legs; \
-			Those of Gronn adopt a design that offers superior protection against the blunted hits and slashing claws of beasts."
-	icon_state = "gronnleatherpants"
-	item_state = "gronnleatherpants"
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_LEG_HARDLEATHER
-	icon = 'icons/roguetown/clothing/special/gronn.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
-
-/obj/item/clothing/gloves/roguetown/angle/gronn
-	name = "gronnic fur-lined leather gloves"
-	desc = "Thick, padded gloves made for the harshest of climates and the wildest of beasts encountered in the untamed north."
-	icon_state = "gronnleathergloves"
-	item_state = "gronnleathergloves"
-	icon = 'icons/roguetown/clothing/special/gronn.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
-	color = "#ffffff"
-
-/obj/item/clothing/gloves/roguetown/angle/gronnfur
-	name = "gronnic fur-lined bone gloves"
-	desc = "A pair of hardened leather gloves with bone reinforcements across the wrists\
-			and the back of the hand, offering superior protection against\
-			the claws of beasts and plants alike. Commonly worn by gatherers."
-	icon_state = "gronnfurgloves"
-	item_state = "gronnfurgloves"
-	icon = 'icons/roguetown/clothing/special/gronn.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
-	unarmed_bonus = 6
+/obj/item/clothing/head/roguetown/helmet/leather/saiga/atgervi //hardened leather helmet + face cover / leather sagia helm but tougher.
+	name = "moose hood" //UNUSED DUPLICATE ITEM
+	desc = "A deceptively strong moosehide hood with a pair of large heavy antlers. It is the reward of the fourth trial of the Iskarn Shamans: To slay a Grinning Moose in the final hunt alone - and fashion a hood from its head."
+	icon_state = "atgervi_shaman"
+	item_state = "atgervi_shaman"
+	flags_inv = HIDEEARS|HIDEFACE
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/32x48/atgervi.dmi'
+	flags_inv = HIDEEARS
+	bloody_icon = 'icons/effects/blood64.dmi'
+	worn_x_dimension = 32
+	worn_y_dimension = 48
+	experimental_inhand = FALSE
+	experimental_onhip = FALSE
 	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
-	color = "#ffffff"
 
-/obj/item/clothing/head/roguetown/helmet/leather/shaman_hood
+/obj/item/clothing/head/roguetown/helmet/leather/shaman_hood //Hardened leather helmet reskin.
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_HIP
 	name = "moose hood"
 	desc = "A deceptively strong moosehide hood with a pair of large heavy antlers. It is the reward of the fourth trial of the Iskarn Shamans: To slay a Grinning Moose in the final hunt alone - and fashion a hood from its head."
@@ -190,6 +252,7 @@
 
 // MEDIUM ARMOR -- Iron reskins
 
+//helmets
 /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi/gronn/ownel
 	name = "gronnic ownel helmet"
 	desc = "A full helmet that adequately protect the eyes and head; \
@@ -197,6 +260,7 @@
 	icon_state = "gronnhelm"
 	item_state = "gronnhelm"
 
+//armor
 /obj/item/clothing/suit/roguetown/armor/brigandine/gronn
 	name = "gronn byrine hauberk"
 	desc = "A chain shirt of Gronnic design with a leather coat layered over, \
@@ -208,6 +272,14 @@
 	smeltresult = /obj/item/ingot/iron
 	armor = ARMOR_MAILLE
 
+//shirts
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/atgervi
+	name = "varangian hauberk"
+	desc = "The pride of the Highland mercenaries, this hauberk is a well crafted blend of chain and leather woven into a dense, protective coat."
+	icon_state = "atgervi_raider_mail"
+	item_state = "atgervi_raider_mail"
+	max_integrity = ARMOR_INT_CHEST_MEDIUM_STEEL + 100
+
 /obj/item/clothing/gloves/roguetown/chain/gronn
 	name = "gronn byrine gloves"
 	desc = "A pair of leather gloves with chain to protects the wrists and back of the hand."
@@ -216,6 +288,7 @@
 	icon_state = "gronnchaingloves"
 	item_state = "gronnchaingloves"
 
+//pants
 /obj/item/clothing/under/roguetown/chainlegs/gronn
 	name = "gronn byrine chausses"
 	desc = "A pair of chain-wrapped pants with a leather subligar, ensuring both protection and comfort."
@@ -284,3 +357,11 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
 	icon_state = "gronnplateboots"
 	item_state = "gronnplateboots"
+
+//fancy claw weapons
+
+/obj/item/clothing/gloves/roguetown/plate/atgervi
+	name = "beast claws"
+	desc = "A menacing pair of plated claws, whose forging methods are a closely protected tradition of the Shamans. The four claws embodying the Four Great Beasts, decorated with symbols of the Gods they praise and the Gods they reject."
+	icon_state = "atgervi_shaman_gloves"
+	item_state = "atergvi_shaman_gloves"

--- a/code/modules/clothing/rogueclothes/gloves/leather.dm
+++ b/code/modules/clothing/rogueclothes/gloves/leather.dm
@@ -126,6 +126,7 @@
 	icon_state = "eastgloves2"
 	item_state = "eastgloves2"
 	armor = ARMOR_LEATHER
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER   //only mercenary ruma get these, they can be equal to hardened leather.
 	resistance_flags = null
 	blocksound = SOFTHIT
 	break_sound = 'sound/foley/cloth_rip.ogg'

--- a/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
@@ -139,7 +139,7 @@
 	sewrepair = TRUE
 	resistance_flags = FIRE_PROOF
 
-// Grenzel unique drip head. Pretend it is a secrete (A type of hat with a hidden helmet underneath). Same stats as kettle
+// Grenzel unique drip head. Pretend it is a secrete (A type of hat with a hidden helmet underneath). Same stats as hardened leather helmet.
 /obj/item/clothing/head/roguetown/grenzelhofthat
 	name = "grenzelhoft plume hat"
 	desc = "Whether it's monsters or fair maidens, a true Grenzelhoftian slays both. This hat contains a hidden metallic cap underneath to protect the head from blows. </br>I can fit this onto a sallet, Etruscan bascinet, or Blacksteel armet for added protection."
@@ -151,9 +151,9 @@
 	detail_tag = "_detail"
 	altdetail_tag = "_detailalt"
 	dynamic_hair_suffix = ""
-	max_integrity = ARMOR_INT_HELMET_LEATHER
+	max_integrity = ARMOR_INT_HELMET_HARDLEATHER //Match their other side-gear, and so it's not replaced early by a 30-mam tailor purchase.
 	body_parts_covered = HEAD|HAIR|EARS
-	armor = ARMOR_LEATHER // spellsinger hat stats
+	armor = ARMOR_LEATHER
 	sewrepair = TRUE
 	resistance_flags = FIRE_PROOF
 	var/picked = FALSE

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -441,7 +441,7 @@
 	color = "#FFFFFF"
 	detail_color = "#5E4440"
 
-/obj/item/clothing/neck/roguetown/gorget/forlorncollar
+/obj/item/clothing/neck/roguetown/gorget/steel/forlorncollar //steel so they're not pressured to upgrade out of their special thing.
 	name = "forlorn collar"
 	desc = "A old reminder."
 	icon_state = "iwolfcollaralt"

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
@@ -2,7 +2,7 @@
 	name = "Atgervi"
 	tutorial = "You are a Varangian of the Gronn Highlands. Warrior-Traders most known for their exploits into the Raneshen Empire, which will be forever remembered by historians."
 	allowed_sexes = list(MALE, FEMALE)
-	
+
 	outfit = /datum/outfit/job/roguetown/mercenary/atgervi
 	subclass_languages = list(/datum/language/gronnic)
 	cmode_music = 'sound/music/combat_vagarian.ogg'
@@ -25,7 +25,7 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/shields = SKILL_LEVEL_EXPERT,	
+		/datum/skill/combat/shields = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
@@ -83,7 +83,7 @@
 	name = "Atgervi Shaman"
 	tutorial = "You are a Shaman of the Fjall, The Northern Empty. Shamans are savage combatants who commune with the Ecclesical Beast Gods through ritualistic violence, rather than idle prayer."
 	allowed_sexes = list(MALE, FEMALE)
-	
+
 	outfit = /datum/outfit/job/roguetown/mercenary/atgervi_shaman
 	subclass_languages = list(/datum/language/gronnic)
 	cmode_music = 'sound/music/combat_shaman2.ogg'
@@ -157,71 +157,6 @@
 		)
 	H.merctype = 1
 
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/atgervi
-	name = "varangian hauberk"
-	desc = "The pride of the Highland mercenaries, this hauberk is a well crafted blend of chain and leather woven into a dense, protective coat."
-	icon_state = "atgervi_raider_mail"
-	item_state = "atgervi_raider_mail"
-	max_integrity = 400
-
-/obj/item/clothing/suit/roguetown/armor/leather/heavy/atgervi
-	name = "shamanic coat"
-	desc = "A furred, protective coat. Often made by hand, it embodies the second trial of the Iskarn Shamans: To honor the leopard is to desire for more."
-	icon_state = "atgervi_shaman_coat"
-	item_state = "atgervi_shaman_coat"
-
-/obj/item/clothing/under/roguetown/trou/leather/atgervi
-	name = "fur pants"
-	desc = "Thick fur pants made to endure the coldest winds, offering a share of protection from the fangs and claws of beasts and men alike."
-	icon_state = "atgervi_pants"
-	item_state = "atgervi_pants"
-	
-/obj/item/clothing/gloves/roguetown/angle/atgervi
-	name = "fur-lined leather gloves"
-	desc = "Dense, padded gloves made for the harshest of climates and the wildest of beasts encountered in the untamed highlands."
-	icon_state = "atgervi_raider_gloves"
-	item_state = "atgervi_raider_gloves"
-	color = "#ffffff"
-
-/obj/item/clothing/gloves/roguetown/plate/atgervi
-	name = "beast claws"
-	desc = "A menacing pair of plated claws, whose forging methods are a closely protected tradition of the Shamans. The four claws embodying the Four Great Beasts, decorated with symbols of the Gods they praise and the Gods they reject."
-	icon_state = "atgervi_shaman_gloves"
-	item_state = "atergvi_shaman_gloves"
-
-/obj/item/clothing/head/roguetown/helmet/bascinet/atgervi
-	name = "owl helmet"
-	desc = "A carefully forged steel helmet in the shape of an owl's face, with added chain to cover the face and neck against many blows."
-	icon_state = "atgervi_raider"
-	item_state = "atgervi_raider"
-	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
-	body_parts_covered = FULL_HEAD|NECK
-	mob_overlay_icon = 'icons/roguetown/clothing/onmob/32x48/atgervi.dmi'
-	bloody_icon = 'icons/effects/blood64.dmi'
-	block2add = null
-	worn_x_dimension = 32
-	worn_y_dimension = 48
-
-/obj/item/clothing/head/roguetown/helmet/leather/saiga/atgervi
-	name = "moose hood"
-	desc = "A deceptively strong moosehide hood with a pair of large heavy antlers. It is the reward of the fourth trial of the Iskarn Shamans: To slay a Grinning Moose in the final hunt alone - and fashion a hood from its head."
-	icon_state = "atgervi_shaman"
-	item_state = "atgervi_shaman"
-	flags_inv = HIDEEARS|HIDEFACE
-	mob_overlay_icon = 'icons/roguetown/clothing/onmob/32x48/atgervi.dmi'
-	flags_inv = HIDEEARS
-	bloody_icon = 'icons/effects/blood64.dmi'
-	worn_x_dimension = 32
-	worn_y_dimension = 48
-	experimental_inhand = FALSE
-	experimental_onhip = FALSE
-
-/obj/item/clothing/shoes/roguetown/boots/leather/atgervi
-	name = "atgervi leather boots"
-	desc = "A pair of strong leather boots, designed to endure both the heat of battle and the frigid cold of the Northern Empty."
-	icon_state = "atgervi_boots"
-	item_state = "atgervi_boots"
-
 /obj/item/rogueweapon/shield/atgervi
 	name = "kite shield"
 	desc = "A large, but light wooden shield with a steel boss in the center to deflect blows more easily."
@@ -285,7 +220,7 @@
 
 /obj/item/clothing/neck/roguetown/psicross/inhumen/baothagronn
 	name = "carved talisman" //relishing talisma
-	desc = "'“The excess of desire, the want of more, the glory of victory, the lover's embrace. Embrace the Leopard, or forget your strength.'  </br>  </br>The Relishing Leopard embodies the virtues of love and glory, both in battle and at home. Enjoy the flesh, the drink, and the spice; but be wary to avoid overindulgence, for it shall leave you despondant and lethargic. To become too comfortable is to become weak, and such weakness would turn you into a delicious snack for the Leopard." 
+	desc = "'“The excess of desire, the want of more, the glory of victory, the lover's embrace. Embrace the Leopard, or forget your strength.'  </br>  </br>The Relishing Leopard embodies the virtues of love and glory, both in battle and at home. Enjoy the flesh, the drink, and the spice; but be wary to avoid overindulgence, for it shall leave you despondant and lethargic. To become too comfortable is to become weak, and such weakness would turn you into a delicious snack for the Leopard."
 	icon_state = "gronnbaotha"
 
 /obj/item/clothing/neck/roguetown/psicross/inhumen/baothagronn/get_examine_highlight_status()

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/forlorn.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/forlorn.dm
@@ -41,7 +41,7 @@
 /datum/outfit/job/roguetown/mercenary/forlorn/pre_equip(mob/living/carbon/human/H)
 	..()
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced //Let them start with some foot protection.
-	neck = /obj/item/clothing/neck/roguetown/gorget/forlorncollar  //steel gorget equiv.
+	neck = /obj/item/clothing/neck/roguetown/gorget/steel/forlorncollar  //steel gorget equiv.
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/volfplate/light
 	pants = /obj/item/clothing/under/roguetown/brigandinelegs		// They're brigandinejaks. ergo have them start w/the whole thing
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/forlorn.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/forlorn.dm
@@ -2,7 +2,7 @@
 	name = "Forlorn Hope Mercenary"
 	tutorial = "The Order of the Forlorn Hope, a order formed off the back of a Ranesheni slave revolt. Drawing from all walks of life, this mercenary company now takes ranks from both purchased and liberated slaves. Coin is power, and power is the path to freedom."
 	allowed_sexes = list(MALE, FEMALE)
-	
+
 	outfit = /datum/outfit/job/roguetown/mercenary/forlorn
 	class_select_category = CLASS_CAT_RANESHENI
 	min_pq = 2
@@ -40,14 +40,14 @@
 
 /datum/outfit/job/roguetown/mercenary/forlorn/pre_equip(mob/living/carbon/human/H)
 	..()
-	shoes = /obj/item/clothing/shoes/roguetown/boots
-	neck = /obj/item/clothing/neck/roguetown/gorget/forlorncollar
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced //Let them start with some foot protection.
+	neck = /obj/item/clothing/neck/roguetown/gorget/forlorncollar  //steel gorget equiv.
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/volfplate/light
 	pants = /obj/item/clothing/under/roguetown/brigandinelegs		// They're brigandinejaks. ergo have them start w/the whole thing
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine		// They're brigandinejaks. ergo have them start w/the whole thing
 	belt = /obj/item/storage/belt/rogue/leather
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord     //a standard arming jacket is not too much to ask.
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
@@ -42,7 +42,7 @@
 	..()
 	head = /obj/item/clothing/head/roguetown/bardhat
 	mouth = /obj/item/alch/rosa
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt


### PR DESCRIPTION
## About The Pull Request

- Forlorn hope gets a standard arming jacket, instead of a discount light one (240 integ instead of 200).
- Forlorn hope collar now counts as a steel gorget, instead of an iron one, so they're not pressured to upgrade out of their unique item for mechanical reasons (350 integ instead of 275). Sure it might be thematically iron, but maybe it's just thicker than a gorget.
- Forlorn hope, vaquero, and atgervi varangian mercenaries now have boots with an actual armor rating instead of zero foot protection (hardened leather boots, reskins for the atgervi).
- Grenzel plume hat, Atgervi gloves, Atgervi trousers, and Ruma stylish gloves now match the integ of a comparable hardened leather item, rather than the unique drip item being inferior to something you can pick up at the tailor for ~30-40 mam or craft with a few hide, particularly considering the unique items have elevated skill and material costs to craft, and greatly elevated mam costs to buy.
- Files for atgervi armor (including unused duplicate shaman hood) moved to the same file as the special gronnic clothing items (many near-identical to the atgervi gear). Added comments noting who gets what & why (shaman unique items, weaker variants used by advent gronnic noble, etc)

## Testing Evidence

Forlorn hope starter gear:
<img width="235" height="415" alt="image" src="https://github.com/user-attachments/assets/4485947f-c0ea-4050-9d40-27319b5beec5" />
<img width="541" height="401" alt="image" src="https://github.com/user-attachments/assets/f633b6b2-fddf-40de-a27c-f1d688473571" />

Collar stats:
<img width="567" height="471" alt="image" src="https://github.com/user-attachments/assets/dd6df671-8d0b-48c5-a287-f613003ced40" />

Buffed merc drip items:
<img width="566" height="277" alt="image" src="https://github.com/user-attachments/assets/ed1bdd74-6204-4a2d-8e78-f23071a4334a" />
<img width="565" height="281" alt="image" src="https://github.com/user-attachments/assets/22bc6ab8-5314-49ee-87d1-a38d67b452ac" />
<img width="554" height="283" alt="image" src="https://github.com/user-attachments/assets/b762d85b-257f-4e6b-a767-f6dfadfb5aef" />
<img width="568" height="281" alt="image" src="https://github.com/user-attachments/assets/9e5e45ed-fc56-4733-a6bb-4e9bfff2018a" />
<img width="564" height="280" alt="image" src="https://github.com/user-attachments/assets/ab3c1d38-c978-49a1-8e54-99ae606c5a89" />



## Why It's Good For The Game

- Forlorn having a good set of quality light armor roundstart was one of it's selling points, so this helps it live up to that.

- Dedicated melee combatant/frontliner mercenaries having at least basic foot armor is nice.

- Unique mercenary drip not being outclassed by cheap generic armor is good to ensure it's not immediately a choice between fashion and decent stats.


## Changelog
:cl:
balance: Forlorn hope now starts with a normal arming jacket instead of a light one (200->240 integ).
balance: Forlorn hope collar now uses steel gorget statistics instead of iron (275->350 integ).
balance: Forlorn hope, Vaquero, and Atgervi varangian mercenaries now get foot armor (hardened leather boots).
balance: Grenzel plume hat now matches a hardened leather helmet in stats.
balance: Ruma stylish gloves now match hardened leather gloves in stats.
balance: Atgervi fur gloves now match hardened leather gloves in stats.
balance: Atgervi fur pants now match hardened leather pants in stats.
code: Atgervi armor items now live in the same file as near-identical gronnic armor items, and have comments to hopefully distinguish the differences between the many similarly described items.
/:cl:
