### PR TITLE
Someone fucked up the darksteel lore again

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -436,7 +436,7 @@
 	smeltresult = /obj/item/ingot/component/zizo
 
 /obj/item/rogueweapon/shield/tower/metal/zizo/get_examine_highlight_status()
-	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, "An alloy of Zizo's anointed metals; Avantyne and Darksteel")
+	return list(EXAMINEHIGHLIGHT_HERESYSEVERITY_ALARMING, HERESYDESC_ZIZO_WEAPON)
 
 /obj/item/rogueweapon/shield/tower/metal/zizo/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Darksteel = avantyne they're the same thing i already changed the description of this shield forever ago n now someone has added _back_ text about "alloying darksteel and avantyne" yeah my plate is an armor of steel and steel

## Testing Evidence
text change

## Why It's Good For The Game
People once more getting confused. Darksteel is another word for avantyne. Blacksteel is something else. You can't alloy a metal with itself. The darksteel shield is avantyne-parasitized steel.
