### PR TITLE
altgrip hotfix

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -1064,7 +1064,7 @@ GLOBAL_LIST_EMPTY(reach_dummy_pool)
 
 /* RightClickOn */
 
-/atom/proc/rmb_self(mob/user)
+/atom/proc/rmb_self(mob/user, keybind = FALSE)
 	return
 
 /mob/proc/rmb_on(atom/A, params)

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -288,7 +288,7 @@
 		return FALSE
 	var/obj/item/I = L.get_active_held_item()
 	if(I)
-		I.rmb_self(L)
+		I.rmb_self(L, keybind = TRUE)
 		return TRUE
 	return FALSE
 

--- a/code/game/objects/items/rogueweapons/rogueweapon.dm
+++ b/code/game/objects/items/rogueweapons/rogueweapon.dm
@@ -118,8 +118,8 @@
 	can_parry = initial(can_parry)
 	..()
 
-/obj/item/rogueweapon/rmb_self(mob/user)
-	if(has_altgrip_modes() && user.cmode)
+/obj/item/rogueweapon/rmb_self(mob/user, keybind = FALSE)
+	if(has_altgrip_modes() && (keybind || user.cmode))
 		if(wielded && !altgripped)
 			ungrip(user)
 		altgrip(user)


### PR DESCRIPTION
## About The Pull Request
Didn't realize the altgrip keybind was lazy and just called rmb_self. You can now properly use the altgrip keybind to swap altgrips even outside of cmode

## Testing Evidence
<img width="520" height="75" alt="image" src="https://github.com/user-attachments/assets/c400826c-956e-4d05-a911-1124a4f9b860" />
<img width="123" height="106" alt="image" src="https://github.com/user-attachments/assets/e2abffeb-68c7-47ed-adda-6a1e0c9db04b" />


## Why It's Good For The Game
fix :+1: 

## Changelog

:cl:
fix: The altgrip keybind now actually switches altgrips even out of combat mode. You can no longer twirl weapons with the altgrip keybind.
/:cl:
