### PR TITLE
suitor preview fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/suitor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/suitor.dm
@@ -22,6 +22,12 @@
 	cmode_music = 'sound/music/combat_noble.ogg'
 	job_traits = list(TRAIT_NOBLE)
 
+	job_subclasses = list(
+		/datum/advclass/suitor/envoy,
+		/datum/advclass/suitor/gallant,
+		/datum/advclass/suitor/schemer,
+	)
+
 
 /datum/outfit/job/roguetown/suitor
 	job_bitflag = BITFLAG_ROYALTY


### PR DESCRIPTION
## About The Pull Request
Suitor had no advclasses set for preview so you couldn't see its options in the class select menu if it was open. You now can. Amazing.

## Testing Evidence
<img width="531" height="542" alt="image" src="https://github.com/user-attachments/assets/4e732eeb-0f50-49aa-85bc-3227b5a4490b" />
<img width="511" height="613" alt="image" src="https://github.com/user-attachments/assets/763363f7-b024-4aa2-84ec-c64a2efde1dc" />

## Why It's Good For The Game
The 2 suitor players will appreciate it

## Changelog

:cl:
fix: Suitor now has a class preview so you can see what its subclasses are
/:cl: