### PR TITLE
Neatens skin armor files, removes sojourner chest layer (ward reasons), fixes disciple loadout descriptions.

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -300,7 +300,7 @@
 	</br>To give into despair and hopelessness, however, is to rob all meaning from His sacrifice. \
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //125% of a leather armor.
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //a leather armor.
 
 /*
  * EMOTE ARMOUR
@@ -371,7 +371,7 @@
 	name = "tough skin"
 	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
 	armor = ARMOR_PADDED
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //A gambeson.
+	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //A light gambeson.
 
 /*
  * REST ARMOUR
@@ -437,6 +437,7 @@
 /obj/item/clothing/suit/roguetown/armor/manual/resting/body/thug
 	name = "calloused skin"
 	desc = "A brawler's hide, thickened by a hard life. A spell of rest is enough to knit it whole again."
+	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //a light gambeson.
 
 /obj/item/clothing/suit/roguetown/armor/manual/resting/body/barbarian
 	name = "hardened skin"
@@ -462,12 +463,12 @@
 /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/thug
 	name = "calloused chest"
 	desc = "A brawler's hide, thickened by a hard life. A spell of rest is enough to knit it whole again."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //A leather armor with gambeson integ (slightly weaker).
+	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //A leather armor with light gambeson integ.
 
 /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/monk
 	name = "tough chest"
 	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //A leather armor with gambeson integ (slightly weaker).
+	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE //A leather armor with light gambeson integ.
 
 /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/barbarian
 	name = "hardened chest"

--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -7,18 +7,18 @@
 	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR
 
 	resistance_flags = FIRE_PROOF
-	body_parts_covered = COVERAGE_FULL
+	body_parts_covered = COVERAGE_FULL //everything but head and it's subzones (neck, skull, ears, eyes, nose, mouth)
 	body_parts_inherent = COVERAGE_FULL
 	flags_inv = null //Exposes the chest and-or breasts.
 	surgery_cover = FALSE //Should permit surgery and other invasive processes.
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	armor_class = ARMOR_CLASS_LIGHT
-	blocksound = SOFTUNDERHIT
+	blocksound = SOFTUNDERHIT //chest underlayers must use a different hit sound, or they cannot be applied.
 	armor = ARMOR_PADDED
 	max_integrity = ARMOR_INT_CHEST_CIVILIAN
 	unenchantable = TRUE
-	blocking_behavior = BLOCKSHIRT | BLOCKARMOR // Skins block layering real armor (armor_class > NONE); plain shirts still layer. Arbalist/berserker override below.
+	blocking_behavior = SAMEWEAR //skin roles either start with a secondary skin layer or are intended to layer with armor.
 
 	var/repairmsg_end = "My skin has become taut with newfound vigor!"
 	var/repairmsg_continue = "My armour mends some of its abuse.."
@@ -56,7 +56,6 @@
 //35% repair per proc, procs taking ~10-11s for sewing, pushup set, or meditation emote. Thus ~30-33s to fullrepair.
 
 
-
 /*
  * PUSHUP ARMOUR
  */
@@ -74,19 +73,18 @@
 
 	. += span_info("Repairable via push-up emotes.")
 
-
 /obj/item/clothing/suit/roguetown/armor/manual/pushups/barbarian
 	armor = ARMOR_LEATHER
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //A full-body leather armor.
 
-//Muscle barbarian skin equates to a leather on the chest, and a second leather armor layering over chest and limbs. Only the latter regens via pushups, but it does so quite rapidly (~20-22sec fullrepair).
-
+/*
+ * MEDITATION ARMOUR
+ */
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation
 	name = "harmonious skin"
 	desc = "Exotic skin armor that can be renewed via meditation. If you see this ingame, something went wrong."
+	blocking_behavior = SAMEWEAR
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
@@ -112,72 +110,71 @@
 		return
 	armour_regen()
 
-/obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats //Only for roles with Honorbound, as the restrictions offset the better head coverage.
-	resistance_flags = FIRE_PROOF
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/body
+	body_parts_covered = COVERAGE_FULL //everything but head and it's subzones (neck, skull, ears, eyes, nose, mouth)
+	body_parts_inherent = COVERAGE_FULL
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/body/disciple //alternative repair option for sojourner.
+	name = "enduring skin"
+	desc = "It's far more than just an oath. \
+	</br>Aeon, Psydon, Adonai. Entropy, Humenity, Divinity; a trinity known to all, yet forgotten to tyme. \
+	</br>A corpse. I am living on a fucking corpse. He is the world, and the world is rotting away. \
+	</br>To give into despair and hopelessness, however, is to rob all meaning from His sacrifice. \
+	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
+	</br>Happiness must be fought for."
+	armor = ARMOR_PADDED
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //125% of a heavy gambeson.
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats //Only for roles with Honorbound, as the restrictions offset the better head coverage.
 	icon_state = "easttats"
+	icon = 'icons/roguetown/clothing/shirts.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
+	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
 	body_parts_covered = COVERAGE_FULL | COVERAGE_HEAD | NECK //This does not cover eyes/nose/mouth. Use a mask.
 	body_parts_inherent = COVERAGE_FULL | COVERAGE_HEAD | NECK
 	//allowed_race = NON_DWARVEN_RACE_TYPES
-
 	repairmsg_end = "The tattoos flow more calmly, as the meditation renews their strength."
 	repairmsg_continue = "The tattoos mend some of their abuse..."
 
-/obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats/ruma
 	name = "bouhoi bujeog tattoos"
 	desc = "A mystic style of tattoos adopted by the Ruma Clan, emulating a practice performed by warrior monks of the Xinyi Dynasty. They are your way of identifying fellow clan members, a sign of companionship and secretive brotherhood. These are styled into the shape of clouds, created by a mystical ink which shifts and moves in ripples like a pond to harden where your skin is struck. Its movement causes you to shudder, and meditation restores its strength."
-	icon = 'icons/roguetown/clothing/shirts.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
-	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
 	armor = ARMOR_PLATE //Will stop most things, but will also pop fast.
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //Feels much too low, but shall see how it goes.
 
-/obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma/chest
-	name = "bouhoi bujeog core"
-	desc = "A mystic style of tattoos adopted by the Ruma Clan, emulating a practice performed by warrior monks of the Xinyi Dynasty. They are your way of identifying fellow clan members, a sign of companionship and secretive brotherhood. These are styled into the shape of clouds, created by a mystical ink which shifts and moves in ripples like a pond to harden where your skin is struck. Its movement causes you to shudder, and meditation restores its strength."
-	icon_state = null
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	blocksound = SOFTHIT
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats/mistwalker
+	name = "seon-mul tattoos"
+	desc = "The flowing clouds of the Ruma are but fleeting shadow across the plains, pale imitation of Xinyi's spiritual alchemy. Imperfect, impotent. Their legend is one writ in avarice and hate.</br></br>Recount yours in love."
+	armor = ARMOR_LEATHER
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //150% of a leather armor with full-body coverage.
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/chest
 	body_parts_covered = COVERAGE_VEST
 	body_parts_inherent = COVERAGE_VEST
+	blocksound = SOFTHIT
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats
+	repairmsg_end = "The tattoos flow more calmly, as the meditation renews their strength."
+	repairmsg_continue = "The tattoos mend some of their abuse..."
+
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats/ruma
+	name = "bouhoi bujeog core"
+	desc = "A mystic style of tattoos adopted by the Ruma Clan, emulating a practice performed by warrior monks of the Xinyi Dynasty. They are your way of identifying fellow clan members, a sign of companionship and secretive brotherhood. These are styled into the shape of clouds, created by a mystical ink which shifts and moves in ripples like a pond to harden where your skin is struck. Its movement causes you to shudder, and meditation restores its strength."
 	armor = ARMOR_BRIGANDINE //Fallback once the main skin pops, you will get stabbed through this.
 	max_integrity = ARMOR_INT_CHEST_PLATE_BRIGANDINE - ARMOR_INT_CHEST_PLATE_BRIGANDINE_WEIGHT_MODIFIER //Identical to a suit of light brig.
 
-//Ruma skin roughly equates to a set of light brigadine over an iron maille.
-
-/obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/mistwalker
-	name = "seon-mul tattoos"
-	desc = "The flowing clouds of the Ruma are but fleeting shadow across the plains, pale imitation of Xinyi's spiritual alchemy. Imperfect, impotent. Their legend is one writ in avarice and hate.</br></br>Recount yours in love."
-	icon = 'icons/roguetown/clothing/shirts.dmi'
-	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
-	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
-	armor = ARMOR_LEATHER
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //A 50% better leather armor with full-body coverage.
-
-/obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/mistwalker/chest
+/obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats/mistwalker
 	name = "seon-mul core"
 	desc = "The flowing clouds of the Ruma are but fleeting shadow across the plains, pale imitation of Xinyi's spiritual alchemy. Imperfect, impotent. Their legend is one writ in avarice and hate.</br></br>Recount yours in love."
-	icon_state = null
 	armor = ARMOR_LEATHER
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	blocksound = SOFTHIT
-	body_parts_covered = COVERAGE_VEST
-	body_parts_inherent = COVERAGE_VEST
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //A leather armor.
-
-//Mistwalker skin equates to 2.5 layers of hardened leather armor, relatively simple. Should last well while getting penetrated fairly often, allowing the role's special trait to scale.
 
 
 /*
- * SEWABLE ARMOUR
+ * SEWABLE (& potentially hammerable) ARMOUR
  */
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable
+/obj/item/clothing/suit/roguetown/armor/manual/tool
 	repair_fraction = 0.35 //35% per 7s of sewing, ~21s to full. Have to mend both layers seperately.
 	var/list/repair_items[] = list(
 		/obj/item/needle = 'sound/foley/sewflesh.ogg',
@@ -186,14 +183,14 @@
 		/obj/item/needle/pestra = 'sound/foley/sewflesh.ogg'
 	)
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/get_mechanics_examine(mob/user)
+/obj/item/clothing/suit/roguetown/armor/manual/tool/get_mechanics_examine(mob/user)
 	. = ..()
 
 	for(var/repair_thing in repair_items)
 		var/obj/item/thing = new repair_thing
 		. += span_info("Repairable via [thing.name].")
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/attackby(obj/item/I, mob/user, params)
+/obj/item/clothing/suit/roguetown/armor/manual/tool/attackby(obj/item/I, mob/user, params)
 	if(user != loc)
 		return FALSE
 	if(obj_integrity == max_integrity)
@@ -210,7 +207,7 @@
 	playsound(loc, repair_items[I.type], 100, TRUE)
 	return TRUE
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/proc/repair_check(mob/user, obj/item/I)
+/obj/item/clothing/suit/roguetown/armor/manual/tool/proc/repair_check(mob/user, obj/item/I)
 	if(!(I.type in repair_items))
 		return FALSE
 
@@ -222,7 +219,7 @@
 
 	return TRUE
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/repair_check(mob/user, obj/item/I)
+/obj/item/clothing/suit/roguetown/armor/manual/tool/repair_check(mob/user, obj/item/I)
 	. = ..()
 
 	if(!.)
@@ -237,13 +234,9 @@
 	return TRUE
 
 //PADDED
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded
+/obj/item/clothing/suit/roguetown/armor/manual/tool/needle
 	name = "sewable skin armor"
 	desc = "This should not spawn naturally. If you see this ingame, something went wrong."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	armor = ARMOR_PADDED
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //Identical to a glued-on gambeson in armor slot, with bonus hand+foot coverage.
 	repair_items = list(
 		/obj/item/needle = 'sound/foley/sewflesh.ogg',
 		/obj/item/needle/thorn = 'sound/foley/sewflesh.ogg',
@@ -252,7 +245,13 @@
 		/obj/item/rogueweapon/surgery/cautery = 'sound/surgery/cautery1.ogg'
 	)
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/monke
+/obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body
+	body_parts_covered = COVERAGE_FULL //everything but head and it's subzones (neck, skull, ears, eyes, nose, mouth)
+	body_parts_inherent = COVERAGE_FULL
+	armor = ARMOR_PADDED
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //a gambeson.
+
+/obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/monke
 	name = "trained skin"
 	desc = "They say I've taken the first step on a path older than memory.\
 	</br>Aeon, Psydon, Adonai… I don't fully understand what those names mean yet, but I repeat them as I was taught.\
@@ -260,38 +259,9 @@
 	</br>I came here because I wanted purpose, something solid to believe in.\
 	</br>They tell me doubt is natural, and that understanding comes with time.\
 	</br>For now, I will listen, learn, and try to live in a way that does not waste what was given to us."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //a heavy gambeson.
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/monke/chest
-	name = "trained chest"
-	desc = "They say I've taken the first step on a path older than memory.\
-	</br>Aeon, Psydon, Adonai… I don't fully understand what those names mean yet, but I repeat them as I was taught.\
-	</br>The world is said to be held together by His sacrifice. I can't imagine something like that, but the Disciples say it is true.\
-	</br>I came here because I wanted purpose, something solid to believe in.\
-	</br>They tell me doubt is natural, and that understanding comes with time.\
-	</br>For now, I will listen, learn, and try to live in a way that does not waste what was given to us."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	blocksound = SOFTHIT
-	body_parts_covered = COVERAGE_VEST
-	body_parts_inherent = COVERAGE_VEST
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
-
-//Psy-monk skin is equivalent to a chest-only leather armor and a second chest-and-limbs gambeson. Noticably tougher than non-psydonic monks, due to more limited miracle set and more manual repair.
-
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/confessor
-	name = "arbalist's skin"
-	desc = "Taut lyke the bow I draw."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	max_integrity = ARMOR_INT_CHEST_CIVILIAN
-
-//Confessor skin is equivalent to a light gambeson, and uniquely allows layering armor over the top of it.
-
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/disciple
+/obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple
 	name = "enduring skin"
 	desc = "It's far more than just an oath. \
 	</br>Aeon, Psydon, Adonai. Entropy, Humenity, Divinity; a trinity known to all, yet forgotten to tyme. \
@@ -299,11 +269,31 @@
 	</br>To give into despair and hopelessness, however, is to rob all meaning from His sacrifice. \
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //125% of a heavy gambeson.
 
-/obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/disciple/chest
+/obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest
+	body_parts_covered = COVERAGE_VEST
+	body_parts_inherent = COVERAGE_VEST
+	blocksound = SOFTHIT
+	armor = ARMOR_LEATHER
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //defaults to a leather armor
+
+/obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/confessor
+	name = "arbalist's skin"
+	desc = "Taut lyke the bow I draw."
+	armor = ARMOR_PADDED
+	max_integrity = ARMOR_INT_CHEST_CIVILIAN //Half of a gambeson. Allows armor layering atop it.
+
+/obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/monke
+	name = "trained chest"
+	desc = "They say I've taken the first step on a path older than memory.\
+	</br>Aeon, Psydon, Adonai… I don't fully understand what those names mean yet, but I repeat them as I was taught.\
+	</br>The world is said to be held together by His sacrifice. I can't imagine something like that, but the Disciples say it is true.\
+	</br>I came here because I wanted purpose, something solid to believe in.\
+	</br>They tell me doubt is natural, and that understanding comes with time.\
+	</br>For now, I will listen, learn, and try to live in a way that does not waste what was given to us."
+
+/obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/disciple
 	name = "enduring chest"
 	desc = "It's far more than just an oath. \
 	</br>Aeon, Psydon, Adonai. Entropy, Humenity, Divinity; a trinity known to all, yet forgotten to tyme. \
@@ -311,16 +301,7 @@
 	</br>To give into despair and hopelessness, however, is to rob all meaning from His sacrifice. \
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	blocksound = SOFTHIT
-	body_parts_covered = COVERAGE_VEST
-	body_parts_inherent = COVERAGE_VEST
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
-
-//Disciple skin is equivalent to a chest-only hardened leather armor and a chest-and-limbs heavy gambeson. Durable, but nothing any random dodge expert or mage cannot obtain, and inferior to light brig.
-
+	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //125% of a leather armor.
 
 /*
  * EMOTE ARMOUR
@@ -391,12 +372,7 @@
 	name = "tough skin"
 	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
 	armor = ARMOR_PADDED
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE
-
-//Monk skin is equivalent to a chest-only light gambeson and a second chest-and-limbs light gambeson. Weaker than other advents, due to miracles.
-
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //A gambeson.
 
 /*
  * REST ARMOUR
@@ -453,100 +429,57 @@
 				return TRUE
 	return FALSE
 
-/obj/item/clothing/suit/roguetown/armor/manual/resting/monk/chest
-	name = "tough chest"
-	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	blocksound = SOFTHIT
-	body_parts_covered = COVERAGE_VEST
-	body_parts_inherent = COVERAGE_VEST
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE
-
-//Monk skin is equivalent to a chest-only light leather armor and a second chest-and-limbs light gambeson. Weaker than other advents, due to miracles. Have to use resting for this second layer, since the prayer repair does not work on two layers at once, like the meditation system.
-
-/obj/item/clothing/suit/roguetown/armor/manual/resting/barbarian
-	name = "hardened skin"
-	desc = "Toughened from abuse. My mettle remains. Resting will restore it's strength."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
+/obj/item/clothing/suit/roguetown/armor/manual/resting/body
+	body_parts_covered = COVERAGE_FULL //everything but head and it's subzones (neck, skull, ears, eyes, nose, mouth)
+	body_parts_inherent = COVERAGE_FULL
 	armor = ARMOR_PADDED
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //defaults to a gambeson
 
-/obj/item/clothing/suit/roguetown/armor/manual/resting/barbarian/chest
-	name = "hardened chest"
-	desc = "Toughened from abuse. My mettle remains. Resting will restore it's strength."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	blocksound = SOFTHIT
-	body_parts_covered = COVERAGE_VEST
-	body_parts_inherent = COVERAGE_VEST
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
-
-//Baseline barbarian skin is equivalent to a chest-only leather armor and a second chest-and-limbs gambeson.
-
-/obj/item/clothing/suit/roguetown/armor/manual/resting/gladiator
-	name = "pit-hardened skin"
-	desc = "Are you not entertained?!"
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	armor = ARMOR_PADDED
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
-
-/obj/item/clothing/suit/roguetown/armor/manual/resting/gladiator/chest
-	name = "pit-hardened chest"
-	desc = "Are you not entertained?!"
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	blocksound = SOFTHIT
-	body_parts_covered = COVERAGE_VEST
-	body_parts_inherent = COVERAGE_VEST
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
-
-//Gladiator skin is equivalent to a chest-only hardened leather armor and a second chest-and-limbs gambeson.
-
-/obj/item/clothing/suit/roguetown/armor/manual/resting/thug
+/obj/item/clothing/suit/roguetown/armor/manual/resting/body/thug
 	name = "calloused skin"
 	desc = "A brawler's hide, thickened by a hard life. A spell of rest is enough to knit it whole again."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	armor = ARMOR_PADDED
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE
 
-/obj/item/clothing/suit/roguetown/armor/manual/resting/thug/chest
-	name = "calloused chest"
-	desc = "A brawler's hide, thickened by a hard life. A spell of rest is enough to knit it whole again."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
-	blocksound = SOFTHIT
-	body_parts_covered = COVERAGE_VEST
-	body_parts_inherent = COVERAGE_VEST
-	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE
+/obj/item/clothing/suit/roguetown/armor/manual/resting/body/barbarian
+	name = "hardened skin"
+	desc = "Toughened from abuse. My mettle remains. Resting will restore it's strength."
 
-//Thug skin is equivalent to a chest-only hardened leather armor (2/3rds integ) and a second chest-and-limbs light gambeson.
+/obj/item/clothing/suit/roguetown/armor/manual/resting/body/gladiator
+	name = "pit-hardened skin"
+	desc = "Are you not entertained?!"
 
-/obj/item/clothing/suit/roguetown/armor/manual/resting/berzerker
+/obj/item/clothing/suit/roguetown/armor/manual/resting/body/berzerker
 	name = "unstoppable skin"
 	desc = "I've endured enough. The onslaught has lost its meaning."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	blocking_behavior = SAMEWEAR
 	armor = ARMOR_LEATHER
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //A full-body leather armor.
 
-/obj/item/clothing/suit/roguetown/armor/manual/resting/berzerker/chest
-	name = "unstoppable chest"
-	desc = "The callouses could stop arrows! But only so many."
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	resistance_flags = FLAMMABLE
-	blocksound = SOFTHIT
-	blocking_behavior = BLOCKSHIRT | BLOCKARMOR | SAMEWEAR // Unlayerable with outside armor, but pairs with the unstoppable skin.
+/obj/item/clothing/suit/roguetown/armor/manual/resting/chest
 	body_parts_covered = COVERAGE_VEST
 	body_parts_inherent = COVERAGE_VEST
-	armor = ARMOR_MAILLE
-	max_integrity = ARMOR_INT_CHEST_LIGHT_STEEL
+	blocksound = SOFTHIT
+	armor = ARMOR_LEATHER
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //defaults to a leather armor
 
-//Berzerker skin is equivalent to a chest-only light maille and a chest-and-limbs hardened leather armor (150% integ).
+/obj/item/clothing/suit/roguetown/armor/manual/resting/chest/thug
+	name = "calloused chest"
+	desc = "A brawler's hide, thickened by a hard life. A spell of rest is enough to knit it whole again."
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //A leather armor with gambeson integ (slightly weaker).
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/chest/monk
+	name = "tough chest"
+	desc = "Do you forsake protection for enlightenment, or in repentance for past transgressions?"
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //A leather armor with gambeson integ (slightly weaker).
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/chest/barbarian
+	name = "hardened chest"
+	desc = "Toughened from abuse. My mettle remains. Resting will restore it's strength."
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/chest/gladiator
+	name = "pit-hardened chest"
+	desc = "Are you not entertained?!"
+
+/obj/item/clothing/suit/roguetown/armor/manual/resting/chest/berzerker
+	name = "unstoppable chest"
+	desc = "The callouses could stop arrows! But only so many."
+	armor = ARMOR_MAILLE
+	max_integrity = ARMOR_INT_CHEST_LIGHT_STEEL //Light steel maille.

--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -123,7 +123,7 @@
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
 	armor = ARMOR_PADDED
-	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //125% of a heavy gambeson.
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //a heavy gambeson.
 
 /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats //Only for roles with Honorbound, as the restrictions offset the better head coverage.
 	icon_state = "easttats"
@@ -259,7 +259,6 @@
 	</br>I came here because I wanted purpose, something solid to believe in.\
 	</br>They tell me doubt is natural, and that understanding comes with time.\
 	</br>For now, I will listen, learn, and try to live in a way that does not waste what was given to us."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //a heavy gambeson.
 
 /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple
 	name = "enduring skin"
@@ -269,7 +268,7 @@
 	</br>To give into despair and hopelessness, however, is to rob all meaning from His sacrifice. \
 	</br>Heaven's gate closed to us long ago, yet His children persist; as as long as they do, so must I. \
 	</br>Happiness must be fought for."
-	max_integrity = ARMOR_INT_CHEST_LIGHT_ELITE //125% of a heavy gambeson.
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //a heavy gambeson.
 
 /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest
 	body_parts_covered = COVERAGE_VEST

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -77,7 +77,7 @@
 			if("Arbalist - Master Crossbows, +III STR / -III SPD")
 				head = /obj/item/clothing/head/roguetown/headband/bloodied
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fencer/psydon
-				shirt = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/confessor
+				shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/confessor
 				REMOVE_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 5, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/misc/swimming, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -83,7 +83,7 @@
 	id = /obj/item/clothing/ring/signet/psy
 
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/disciple //125% of a leather armor.
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/disciple //a leather armor.
 	shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple //a heavy gambeson.
 
 	backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -84,7 +84,7 @@
 
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
 	armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/disciple //125% of a leather armor.
-	shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple //125% of a heavy gambeson.
+	shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple //a heavy gambeson.
 
 	backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,
 	/obj/item/paper/inqslip/arrival/ortho = 1)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -7,9 +7,7 @@
 	subclass_languages = list(/datum/language/otavan)
 	category_tags = list(CTAG_ORTHODOXIST)
 	traits_applied = list(
-		TRAIT_CIVILIZEDBARBARIAN,
-		TRAIT_STEELHEARTED,
-		TRAIT_INQUISITION
+		TRAIT_CIVILIZEDBARBARIAN
 	)
 	subclass_stats = list(
 		STATKEY_STR = 3,
@@ -42,27 +40,26 @@
 /datum/outfit/job/roguetown/disciple/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
 	if(H.mind)
-		var/weapons = list("Abboteer - Master Pugilist, Weaponless Oath & No Malus", "Pugilist - Master Athletics, Pain Resistance", "Quarterstaff - Expert Staves, +I PER / +I INT", "Katar", "Knuckledusters")
+		var/weapons = list("Abboteer - Pugilist with Master Unarmed, Weaponless Oath & No Wrestling", "Pugilist - Master Athletics, Pain Resistance", "Quarterstaff - Expert Staves, +I PER", "Katar", "Knuckledusters")
 		var/weapon_choice = input(H,"Choose your WEAPON.", "TAKE UP PSYDON'S ARMS.") as anything in weapons
 		switch(weapon_choice)
-			if("Abboteer - Master Pugilist, Weaponless Oath & No Malus")
+			if("Abboteer - Pugilist with Master Unarmed, Weaponless Oath & No Wrestling")
 				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_MASTER, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/misc/swimming, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/magic/holy, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/pugilist
-				ADD_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_GENERIC)
+				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_WEAPONLESS, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_STRONGBITE, TRAIT_GENERIC)
 				H.change_stat(STATKEY_INT, 1)
 				H.change_stat(STATKEY_SPD, 1)
 			if("Pugilist - Master Athletics, Pain Resistance")
 				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_MASTER, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/pugilist
-				ADD_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_GENERIC)
-			if("Quarterstaff - Expert Staves, +I PER / +I INT")
+				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
+			if("Quarterstaff - Expert Staves, +I PER")
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/staves, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
@@ -86,8 +83,8 @@
 	id = /obj/item/clothing/ring/signet/psy
 
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/disciple //a slightly-better heavy gambeson.
-	shirt = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/disciple/chest //a heardened leather armor, chest-only.
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/disciple //125% of a leather armor.
+	shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple //125% of a heavy gambeson.
 
 	backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,
 	/obj/item/paper/inqslip/arrival/ortho = 1)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
@@ -13,9 +13,7 @@
 	traits_applied = list(
 		TRAIT_CIVILIZEDBARBARIAN,
 		TRAIT_ARCYNE,
-		TRAIT_NALEDI,
-		TRAIT_STEELHEARTED,
-		TRAIT_INQUISITION
+		TRAIT_NALEDI
 	)
 	subclass_stats = list(
 		STATKEY_STR = 2,
@@ -94,15 +92,16 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	backl = /obj/item/storage/backpack/rogue/satchel/black
 	cloak = /obj/item/clothing/cloak/tabard/psydontabard/alt
-	var/list/armor_choices = list("Light Armor", "Bare Skin")
+	var/list/armor_choices = list("Light Armor", "Bare Skin (Sewing repair)", "Bare Skin (Meditation repair)")
 	var/armor_choice = input(H,"Choose your DEFENSE.", "How will you ENDURE.") as anything in armor_choices
 	switch(armor_choice)
 		if("Light Armor")
 			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/pontifex
 			shirt = /obj/item/clothing/suit/roguetown/shirt/robe/pointfex //Yes, the item is spelled this way in the code.
-		if("Bare Skin")
-			armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/disciple //a slightly better heavy gambeson.
-			shirt = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/disciple/chest //hardened leather armor. Tougher to start than the armor loadout pick (but by less than you think, as that gets mage-ward layering with its gamby), but unable to upgrade to brigadine or have niche buffs like tailor fitting or enchantments.
+		if("Bare Skin (Sewing repair)") //does not get a chest-only skin layer, as ward layers there and is superior.
+			armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple //125% of a heavy gambeson. More integ than a light brig, far worse protection.
+		if("Bare Skin (Meditation repair)")
+			armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/disciple //Identical to other skin option aside from repair method.
 	var/naledi_book = pick(/obj/item/book/rogue/naledi1, /obj/item/book/rogue/naledi2, /obj/item/book/rogue/naledi3, /obj/item/book/rogue/naledi4)
 	backpack_contents = list(
 		/obj/item/roguekey/inquisitionmanor = 1,

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
@@ -99,7 +99,7 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/pontifex
 			shirt = /obj/item/clothing/suit/roguetown/shirt/robe/pointfex //Yes, the item is spelled this way in the code.
 		if("Bare Skin (Sewing repair)") //does not get a chest-only skin layer, as ward layers there and is superior.
-			armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple //125% of a heavy gambeson. More integ than a light brig, far worse protection.
+			armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/disciple //a heavy gambeson.
 		if("Bare Skin (Meditation repair)")
 			armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/disciple //Identical to other skin option aside from repair method.
 	var/naledi_book = pick(/obj/item/book/rogue/naledi1, /obj/item/book/rogue/naledi2, /obj/item/book/rogue/naledi3, /obj/item/book/rogue/naledi4)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -71,8 +71,8 @@
 				ADD_TRAIT(H, TRAIT_NOPAINSTUN, JOB_TRAIT)
 				H.change_stat(STATKEY_LCK, 1) // better pity bonus
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
-					armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/monke //a leather armor
-					shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/monke //a heavy gambeson. ape out, brothers. Bonus durability over other monks, but you have to stitch them up.
+					armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/monke //a leather armor. Bonus durability over other monks, but you have to stitch it up.
+					shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/monke //a gambeson.
 				else
 					armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/monk //leather armor with gambeson integ, this one needs resting.
 					shirt = /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk //a gambeson, repaired by praying.

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -74,8 +74,8 @@
 					armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/monke //a leather armor. Bonus durability over other monks, but you have to stitch it up.
 					shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/monke //a gambeson.
 				else
-					armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/monk //leather armor with gambeson integ, this one needs resting.
-					shirt = /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk //a gambeson, repaired by praying.
+					armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/monk //leather armor with light gambeson integ, this one needs resting.
+					shirt = /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk //a light gambeson, repaired by praying.
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -71,11 +71,11 @@
 				ADD_TRAIT(H, TRAIT_NOPAINSTUN, JOB_TRAIT)
 				H.change_stat(STATKEY_LCK, 1) // better pity bonus
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
-					armor = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/monke //gambeson. ape out, brothers. Bonus durability over other monks, but you have to stitch it up.
-					shirt = /obj/item/clothing/suit/roguetown/armor/manual/sewable/padded/monke/chest //leather armor.
+					armor = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/chest/monke //a leather armor
+					shirt = /obj/item/clothing/suit/roguetown/armor/manual/tool/needle/body/monke //a heavy gambeson. ape out, brothers. Bonus durability over other monks, but you have to stitch them up.
 				else
-					armor = /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk //light gambeson, repaired by praying.
-					shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/monk/chest //leather armor with light gambeson integ, this one needs resting.
+					armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/monk //leather armor with gambeson integ, this one needs resting.
+					shirt = /obj/item/clothing/suit/roguetown/armor/manual/emote/prayer/monk //a gambeson, repaired by praying.
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -623,10 +623,10 @@
 			if("A Bottle Of Medicinal Fish Vinegar.. ?")
 				beltl = /obj/item/reagent_containers/glass/bottle/rogue/healthpot/zarum
 				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_APPRENTICE, TRUE)
-		var/bronzediscipline = list("Thespian - Dodge Expert, -I CON / +I SPD","Gladiator - Skin-Armored & Immunity To Pain","Shieldbearer - Well-Armored & Maille Training","Bulwark - Fully-Armored & Plate Training")
+		var/bronzediscipline = list("Thespian - Dodge Expert, -III CON / +III SPD","Gladiator - Skin-Armored & Immunity To Pain","Shieldbearer - Well-Armored & Maille Training","Bulwark - Fully-Armored & Plate Training")
 		var/bronzediscipline_choice = input(H, "Choose your DISCIPLINE.", "EMBRACE GLORY AND DEATH.") as anything in bronzediscipline
 		switch(bronzediscipline_choice)
-			if("Thespian - Dodge Expert, -I CON / +I SPD")
+			if("Thespian - Dodge Expert, -III CON / +III SPD")
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				H.change_stat(STATKEY_SPD, 3)
 				H.change_stat(STATKEY_INT, 1)
@@ -641,8 +641,8 @@
 				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC) //Lite!Barbarian.
 				head = /obj/item/clothing/head/roguetown/helmet/bronzegladiator
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/cloth/gladiator
-				armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/gladiator
-				shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/gladiator/chest
+				armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/gladiator //a leather armor
+				shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/body/gladiator //a gambeson
 				pants = /obj/item/clothing/under/roguetown/loincloth/brown
 				belt = /obj/item/storage/belt/rogue/leather/battleskirt/breechcloth/red
 				//shirt = /obj/item/clothing/suit/roguetown/shirt/tribalrag/gladiator //no empty hands to put this in, and cannot seem to 'pre-load' the cosmetic slot of a skin armor. Can hang in limbo untill someone figures out how to grant it.

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -311,12 +311,12 @@
 			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 			head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm
 			gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted
-			armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/barbarian //gambeson.
-			shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/barbarian/chest //a leather armor, this one chest-only. The skin armor options start better protected, but cannot upgrade. A basic gamby + leather armor will match them, and heavy gamby + light brig will eclipse them significantly.
-		if ("Discipline - Bodybuilder") //its actually not that bad now. Better starting protection than the bronze sword option, but cannot upgrade to brigandine.
+			armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/barbarian //a leather armor.
+			shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/body/barbarian //a gambeson. The skin armor options start better protected, but cannot upgrade. A basic gamby + leather armor will match them, and heavy gamby + light brig will eclipse them significantly.
+		if ("Discipline - Bodybuilder") //Better starting protection than the bronze sword option, but cannot upgrade to brigandine.
 			H.adjust_skillrank_up_to(/datum/skill.combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/barbarian //a leather armor.
-			shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/barbarian/chest //chest-only leather armor.
+			armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/barbarian //a leather armor.
+			shirt = /obj/item/clothing/suit/roguetown/armor/manual/pushups/barbarian //a fullbody leather armor.
 			r_hand = /obj/item/rogueweapon/greatsword/iron
 			backr = /obj/item/rogueweapon/scabbard/gwstrap
 	belt = /obj/item/storage/belt/rogue/leather/battleskirt/barbarian

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -191,8 +191,8 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/thug //leather armor with gambeson integ.
-	shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/body/thug //a gambeson.
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/thug //leather armor with light gambeson integ.
+	shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/body/thug //a light gambeson.
 	backpack_contents = list(
 				/obj/item/rogueweapon/huntingknife = 1,
 				/obj/item/recipe_book/leatherworking = 1,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -191,8 +191,8 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/thug //light gambeson.
-	shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/thug/chest //leather armor with gambeson integ.
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/thug //leather armor with gambeson integ.
+	shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/body/thug //a gambeson.
 	backpack_contents = list(
 				/obj/item/rogueweapon/huntingknife = 1,
 				/obj/item/recipe_book/leatherworking = 1,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -67,8 +67,8 @@
 			if("Light Armor")
 				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 			if("Bare Skin")
-				armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/berzerker/chest
-				shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/berzerker
+				armor = /obj/item/clothing/suit/roguetown/armor/manual/resting/chest/berzerker //light steel maille
+				shirt = /obj/item/clothing/suit/roguetown/armor/manual/resting/body/berzerker //fullbody leather armor
 		var/list/main_choices = list("Unarmed Master", "Martial Expert") // Unarmed focuses on master punching and wrestling moves, Martial gives you two expert weapon skills to be flexible
 		var/category_choice = input(H, "Choose your MEANS OF VIOLENCE.", "SMASH OR SLASH!!") as anything in main_choices
 		switch(category_choice)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
@@ -81,8 +81,8 @@
 					shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced //dwarves like to blow up my patience
 			if("Enchanted Inks")
 				neck = /obj/item/clothing/neck/roguetown/leather
-				armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/mistwalker //a full-body leather armor.
-				shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/mistwalker/chest //another chest-only leather armor.
+				armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats/mistwalker //a full-body leather armor with 150% integ.
+				shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats/mistwalker //another chest-only leather armor.
 				l_hand = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 				ADD_TRAIT(H, TRAIT_HONORBOUND, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
@@ -38,8 +38,8 @@
 	beltl = /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench
 	l_hand = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
 	cloak = /obj/item/clothing/cloak/eastcloak1
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma //scalemail
-	shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma/chest //light brigadine.
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats/ruma //a heavy gambeson, but plate.
+	shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats/ruma //light brigadine.
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
 	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
@@ -91,8 +91,8 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	l_hand = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
 	cloak = /obj/item/clothing/cloak/eastcloak1
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma //scalemail
-	shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma/chest //light brigadine.
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats/ruma //a heavy gambeson, but plate.
+	shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats/ruma //light brigadine.
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
 	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/seonjang.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/seonjang.dm
@@ -33,8 +33,8 @@
 /datum/outfit/job/roguetown/mercenary/seonjang/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("You are a Captain of the Clan, second to none. The blades and bows of the Ruma look to you for guidance - rally your warriors and lead by example!"))
-	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma //scalemail
-	shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/easttats/ruma/chest //light brigadine.
+	armor = /obj/item/clothing/suit/roguetown/armor/manual/meditation/body/easttats/ruma //a heavy gambeson, but plate.
+	shirt = /obj/item/clothing/suit/roguetown/armor/manual/meditation/chest/easttats/ruma //light brigadine.
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
 	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan


### PR DESCRIPTION
## About The Pull Request

Follow-up PR to https://github.com/Azure-Peak/Azure-Peak/pull/8417. While integ values need more time to sit and gather feedback (adv monks likely need a nudge), there's a few things that can be fixed up while that happens.

Firstly, the manual file for all the skin armors got cleaned up for better inheritance and organization.

Secondly, some tweaks to skin-using roles:
- Sojourner lost its secondary chest layer. When it has the option of a crystalhide ward (300 integ of brig, better than any existing light armor) that it can put in its shirt layer (under real brig), slapping something equivalent to a leather armor in its shirt slot is too much of a downgrade

- Sojourner got a loadout variant to pick between sewing-based or meditation-based skin armor repair for it's remaining overlayer skin. The new meditation option is actually slightly slower, and has the exact same integ/protection. Its just for flavor alternatives (may add such variants to other roles in future where thematic).

- Disciple loadout options often lied, like the staff option listing +1 per/int when it only gave the per bonus (desc corrected), or the puglist option citing 'pain resistance' when it only gave a no-damage-slowdown trait that has been broken for over six months (see https://github.com/Azure-Peak/Azure-Peak/issues/8505). It got enduring swapped in there instead to be accurate to the statement, plus to combat pain slowdown that its usual psydonic mojo (that fights pain stuns) does not work on.

## Testing Evidence

Sojourner without secondary layer:
<img width="192" height="331" alt="image" src="https://github.com/user-attachments/assets/9878f84e-d859-4eee-9196-c85232a7db49" />

Meditation skin option for Sojourner:
<img width="312" height="161" alt="image" src="https://github.com/user-attachments/assets/33e547a0-db35-4653-8dc3-616a00a6278d" />
<img width="555" height="497" alt="image" src="https://github.com/user-attachments/assets/92c5b2f8-ea2f-4e52-b592-e0f0d096005c" />

Disciple Pugilist traits:
<img width="597" height="329" alt="image" src="https://github.com/user-attachments/assets/1fbbb4b4-bf31-4950-ae19-7091f6bd8f66" />


## Why It's Good For The Game

Neater code, functional traits, more aesthetic/flavor options for people.

## Changelog

:cl:
code: streamlined skin armor code to be neater and make better use of inheritance (~70 line delta yay).
del: Removed chest layer skin from sojourner, to allow layering vastly-superior ward there again.
add: Added alternative skin option to sojourner, using meditation repair. Same stats, just a flavor sidegrade.
fix: fixed disciple loadout options being misleading & it having nonfunctional slowdown-resist traits.
/:cl:
