### PR TITLE
[FUCK] Skeleton lorefix

### DIFF
--- a/code/modules/spells/components/conjured_minion.dm
+++ b/code/modules/spells/components/conjured_minion.dm
@@ -168,7 +168,7 @@
 
 /datum/component/conjured_minion/proc/get_phantom_color()
 	if(istype(parent, /mob/living/carbon/human/species/skeleton))
-		var/list/palette = list("#9B59FF", "#FF3030")
+		var/list/palette = list("#a76cff", "#7718cf")
 		var/mob/living/summoner = summoner_ref?.resolve()
 		var/key = summoner ? "[summoner.real_name]" : "zizo"
 		var/hash = 0
@@ -189,7 +189,7 @@
 	var/mob/living/summoner = summoner_ref?.resolve()
 
 	if(istype(parent, /mob/living/carbon/human/species/skeleton))
-		examine_list += span_notice("An unnatural skeleton, its form seems bound by <font color='#ff0000'>Avantyne</font>, and the will of [summoner ? summoner.real_name : "an unknown magus"].")
+		examine_list += span_notice("An unnatural skeleton, its form seems bound and reanimated by <font color='#940000'>avantyne strings</font>, and the will of a nearby magus.")
 		return
 
 	examine_list += span_notice("A phantasmal servant, bound to the will of [summoner ? summoner.real_name : "an unknown magus"].")

--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -366,6 +366,7 @@
 	charge_slowdown = CHARGING_SLOWDOWN_SMALL
 	charge_sound = 'sound/magic/chargingold.ogg'
 	cooldown_time = 30 SECONDS
+	cast_range = SPELL_RANGE_GROUND
 
 	associated_skill = /datum/skill/magic/holy
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN


### PR DESCRIPTION
## About The Pull Request

- It just crossed me that Avantyne is the type of a perverted metal and not a term for 'zizo force', so fixing that flavortext. Yes, it means that skeletons have literal metal wires keeping them restrained to the summoner's will, that otherwise would make them feral and attack everyone.
- Made them glow different shades of purple instead of this inconsistent purple or red.
- Fixes the cast range being weirdly 2 squares, it should be ground target range.

## Testing Evidence

Compiles.

## Why It's Good For The Game

Lore consistency, ft. Fug Bixes.

## Changelog
:cl:
fix: Fixed Skeleton Swarm having the wrong range tag.
spellcheck: Adjusted the flavortext to adhere to the lore about what Avantyne truly is.
/:cl: