### PR TITLE
vicious mockery fixes

### DIFF
--- a/code/modules/spells/spell_types/bardic/vicious_mockery.dm
+++ b/code/modules/spells/spell_types/bardic/vicious_mockery.dm
@@ -81,8 +81,6 @@ GLOBAL_LIST_INIT(mockery_insults, list(
 			return BULLET_ACT_BLOCK
 		if(out_of_effective_range())
 			return
-		if(blocked >= 100)
-			return ..()
 		// Stack the debuff
 		var/datum/status_effect/debuff/mockery_stack/existing = M.has_status_effect(/datum/status_effect/debuff/mockery_stack)
 		if(existing)
@@ -115,12 +113,9 @@ GLOBAL_LIST_INIT(mockery_insults, list(
 		span_userdanger("The bard's words sting - I can't focus!"))
 
 /datum/status_effect/debuff/mockery_stack/proc/add_stack()
-	if(stacks >= MOCKERY_STACKS_MAX)
-		duration = MOCKERY_STACK_DURATION
-		return
 	remove_stack_effects()
 	stacks = min(stacks + 1, MOCKERY_STACKS_MAX)
-	duration = MOCKERY_STACK_DURATION
+	refresh()
 	apply_stack_effects()
 	owner.balloon_alert_to_viewers("mocked (x[stacks])")
 	if(stacks >= MOCKERY_STACKS_MAX)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
vicious mockery is blocked by armor right now, so it can't be used outside of when a fight is being concluded.
it's also clearing when you apply it twice/properly stack it, instead of refreshing the duration.

this pr makes it unblockable and also makes it refresh the duration properly if you land it

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="463" height="145" alt="image" src="https://github.com/user-attachments/assets/21496467-0e76-4cb0-bf92-3399a9f3578a" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
bugfix

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: vicious mockery is no longer blockable
fix: vicious mockery no longer removes itself when landing twice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
