### PR TITLE
drakkyn lore fix again sisyphus edition

### DIFF
--- a/code/game/objects/items/rogueitems/natural/heads.dm
+++ b/code/game/objects/items/rogueitems/natural/heads.dm
@@ -164,8 +164,8 @@
 	sellprice = 50
 
 /obj/item/natural/head/dragon/
-	name = "dragon head"
-	desc = "The head of a dragon."
+	name = "drake head"
+	desc = "The head of a drake."
 	w_class = WEIGHT_CLASS_NORMAL // We want them to be placeable in headhook
 	grid_height = 96
 	grid_width = 96

--- a/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
@@ -9,7 +9,7 @@
 	origin = "Lirvas"
 	base_name = "Zard"
 	desc_title = "Drakian"
-	desc = "Mighty scaled individuals who claim to be descendants of the dragons of yore."
+	desc = "Hailing from Lirvas, Drakians are winged relatives of the Zardmen, results of Matthios's doomed attempts to mimic the forms of drakkyn. Though they may share visual similarities, and their pride tends to befit such, no Drakian would ever claim to be a descendent of the drakkyn, as to do so is to invite a terrible wasting curse."
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT


### PR DESCRIPTION
## About The Pull Request
people keep putting in lore that is not our lore or it just hasn't been updated or w/e. updates the drake heads to not be erroneously called dragon heads, and fixes the drakian lore blurb to not be the exact opposite of our lore (any drakian that says they're related drakkyn Fucking Dies actually wdym they "claim to be descendents of the dragons of yore")

## Testing Evidence
text changes

## Why It's Good For The Game
nepotism

## Changelog

:cl:
fix: Fixed the description of the drakian race, which was the exact opposite of our lore. Also renamed "dragon heads" because, once more, those are not drakkyn those are drakes.
/:cl:
