### PR TITLE
f ix ! - corrects woodland brigandine's applicable armorsets, remove errant 'exact_type' from cackledaggers

### DIFF
--- a/code/game/objects/items/donator_fluff_items.dm
+++ b/code/game/objects/items/donator_fluff_items.dm
@@ -3278,6 +3278,78 @@ As Excaliber."
 			pic.color = get_detail_color()
 		add_overlay(pic)
 
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/woodland
+	name = "woodland brigandine"
+	desc = "A set of fitted brigandine armour featuring a hardened leather further reinforced with steel plates beneath, worn over a light \
+	maille shirt. Its similarity to the Azurian Warden's brigandine is no accident. Rosawood's Elven Rangers had shared its design with \
+	their fellows, who had adapted it further for their own needs. Armour such as this is oft worn by the Wardens that range Rosawood as well."
+	item_state = "woodwalkbrig"
+	icon_state = "woodwalkbrig"
+	icon = 'icons/clothing/donor_clothes.dmi'
+	mob_overlay_icon = 'icons/clothing/onmob/donor_clothes.dmi'
+	sleeved = 'icons/clothing/onmob/donor_sleeves_armor.dmi'
+
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/woodland/attack_right(mob/user)
+	if(detail_tag)
+		return
+	var/the_time = world.time
+	var/pickedcolor = input(user, "Select a color.","Brigandine Color") as null|anything in COLOR_MAP
+	if(!pickedcolor)
+		return
+	if(world.time > (the_time + 30 SECONDS))
+		return
+	detail_tag = "_detail"
+	detail_color = COLOR_MAP[pickedcolor]
+	update_icon()
+	if(ismob(loc))
+		var/mob/L = loc
+		L.update_inv_armor()
+
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/woodland/update_icon()
+	cut_overlays()
+	if(get_detail_tag())
+		var/mutable_appearance/pic = mutable_appearance(icon(icon, "[icon_state][detail_tag]"))
+		pic.appearance_flags = RESET_COLOR
+		if(get_detail_color())
+			pic.color = get_detail_color()
+		add_overlay(pic)
+
+/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/woodland
+	name = "woodland brigandine"
+	desc = "A set of fitted brigandine armour featuring a hardened leather further reinforced with steel plates beneath, worn over a light \
+	maille shirt. Its similarity to the Azurian Warden's brigandine is no accident. Rosawood's Elven Rangers had shared its design with \
+	their fellows, who had adapted it further for their own needs. Armour such as this is oft worn by the Wardens that range Rosawood as well."
+	item_state = "woodwalkbrig"
+	icon_state = "woodwalkbrig"
+	icon = 'icons/clothing/donor_clothes.dmi'
+	mob_overlay_icon = 'icons/clothing/onmob/donor_clothes.dmi'
+	sleeved = 'icons/clothing/onmob/donor_sleeves_armor.dmi'
+
+/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/woodland/attack_right(mob/user)
+	if(detail_tag)
+		return
+	var/the_time = world.time
+	var/pickedcolor = input(user, "Select a color.","Brigandine Color") as null|anything in COLOR_MAP
+	if(!pickedcolor)
+		return
+	if(world.time > (the_time + 30 SECONDS))
+		return
+	detail_tag = "_detail"
+	detail_color = COLOR_MAP[pickedcolor]
+	update_icon()
+	if(ismob(loc))
+		var/mob/L = loc
+		L.update_inv_armor()
+
+/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/woodland/update_icon()
+	cut_overlays()
+	if(get_detail_tag())
+		var/mutable_appearance/pic = mutable_appearance(icon(icon, "[icon_state][detail_tag]"))
+		pic.appearance_flags = RESET_COLOR
+		if(get_detail_color())
+			pic.color = get_detail_color()
+		add_overlay(pic)
+
 /obj/item/clothing/suit/roguetown/armor/brigandine/light/woodland/custom
 	item_state = "woodwalkerbrig"
 	icon_state = "woodwalkerbrig"
@@ -3294,6 +3366,16 @@ As Excaliber."
 	detail_color = "#7c6965"
 
 /obj/item/clothing/suit/roguetown/armor/leather/studded/woodland/custom
+	item_state = "woodwalkerbrig"
+	icon_state = "woodwalkerbrig"
+	detail_color = "#7c6965"
+
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/woodland
+	item_state = "woodwalkerbrig"
+	icon_state = "woodwalkerbrig"
+	detail_color = "#7c6965"
+
+/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/woodland
 	item_state = "woodwalkerbrig"
 	icon_state = "woodwalkerbrig"
 	detail_color = "#7c6965"

--- a/code/game/objects/items/donator_fluff_items.dm
+++ b/code/game/objects/items/donator_fluff_items.dm
@@ -3370,12 +3370,12 @@ As Excaliber."
 	icon_state = "woodwalkerbrig"
 	detail_color = "#7c6965"
 
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/woodland
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/woodland/custom
 	item_state = "woodwalkerbrig"
 	icon_state = "woodwalkerbrig"
 	detail_color = "#7c6965"
 
-/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/woodland
+/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/woodland/custom
 	item_state = "woodwalkerbrig"
 	icon_state = "woodwalkerbrig"
 	detail_color = "#7c6965"

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -1232,20 +1232,10 @@
 /obj/item/enchantingkit/nero_woodlandbrig
 	name = "'Woodland Brigandine' morphing elixir"
 	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of a Light Brigandine vest, \
-	a set of Studded Leather Armor, a Steel Cuirass, or a Haubergeon."
+	a set of Studded Leather Armor, a Steel Cuirass, a Fluted Cuirass, a Haubergeon, or a Hauberk."
 	target_items = list(
-		/obj/item/clothing/suit/roguetown/armor/brigandine/light			= /obj/item/clothing/suit/roguetown/armor/brigandine/light/woodland,
-		/obj/item/clothing/suit/roguetown/armor/leather/studded				= /obj/item/clothing/suit/roguetown/armor/leather/studded/woodland,
-		/obj/item/clothing/suit/roguetown/armor/plate/cuirass				= /obj/item/clothing/suit/roguetown/armor/plate/cuirass/woodland,
-		/obj/item/clothing/suit/roguetown/armor/chainmail					= /obj/item/clothing/suit/roguetown/armor/chainmail/woodland
-	)
-	result_item = null
-
-/obj/item/enchantingkit/nero_woodlandbrig_dye
-	name = "'Woodland Brigandine' morphing elixir"
-	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of a Light Brigandine vest, \
-	a set of Studded Leather Armor, a Steel Cuirass, or a Haubergeon."
-	target_items = list(
+		/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted		= /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/woodland/custom,
+		/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk			= /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/woodland/custom,
 		/obj/item/clothing/suit/roguetown/armor/brigandine/light			= /obj/item/clothing/suit/roguetown/armor/brigandine/light/woodland/custom,
 		/obj/item/clothing/suit/roguetown/armor/leather/studded				= /obj/item/clothing/suit/roguetown/armor/leather/studded/woodland/custom,
 		/obj/item/clothing/suit/roguetown/armor/plate/cuirass				= /obj/item/clothing/suit/roguetown/armor/plate/cuirass/woodland/custom,

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -266,7 +266,6 @@
 		/obj/item/rogueweapon/huntingknife/idagger/steel/decorated			= /obj/item/rogueweapon/huntingknife/idagger/steel/decorated/donator
 	)
 	result_item = null
-	exact_type = TRUE
 
 /obj/item/enchantingkit/beltleather
 	name = "'Belt of Caped Leather' morphing elixir"


### PR DESCRIPTION
## About The Pull Request

yea

## Testing Evidence

mm

## Why It's Good For The Game

yea

## Changelog

:cl:
fix: Resolved edge cases where the Cackledagger skin couldn't properly be applied to certain steel-tier daggers.
add: Hauberk and fluted cuirass's compatibility with the Woodland Brigandine.
/:cl:
