### PR TITLE
Choose Your Gnoll Organs

### DIFF
--- a/code/datums/mob_descriptors/descriptors/other.dm
+++ b/code/datums/mob_descriptors/descriptors/other.dm
@@ -90,8 +90,7 @@
 		return FALSE
 	if(!get_location_accessible(H, BODY_ZONE_PRECISE_GROIN))
 		return FALSE
-	var/obj/item/organ/penis/penis = H.getorganslot(ORGAN_SLOT_PENIS)
-	if(penis && penis.sheath_type == SHEATH_TYPE_SLIT) //If our penis hides in a slit, dont describe testicles
+	if(testes.visible_organ == FALSE) //If we can't normally see the testes, dont describe em
 		return FALSE
 	return TRUE
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -95,7 +95,7 @@
 			if("sac")
 				H.internal_organs_slot[ORGAN_SLOT_TESTICLES] = new /obj/item/organ/testicles/internal
 			if("cryptorchid")
-				H.internal_organs_slot[ORGAN_SLOT_TESTICLES] = new /obj/item/organ/testicles/internal
+				H.internal_organs_slot[ORGAN_SLOT_TESTICLES] = new /obj/item/organ/testicles
 
 		var/gnoll_genitals = list("pintle", "gudgeon", "both", "naught")
 		var/genital_choice = input(H, "What's between your legs?", "FUCK THE WORLD.") as anything in gnoll_genitals

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -74,7 +74,7 @@
 /datum/outfit/job/roguetown/gnoll/proc/don_pelt(mob/living/carbon/human/H)
 	if(H.mind)
 		var/pelts = list("firepelt", "rotpelt", "whitepelt", "bloodpelt", "nightpelt", "darkpelt")
-		var/pelt_choice = input(H, "Choose your pelt.", "SPILL THEIR ENTRAILS.") as anything in pelts
+		var/pelt_choice = input(H, "Choose your pelt.", "WITNESS FURY.") as anything in pelts
 		H.set_blindness(0)
 		H.icon_state = "[pelt_choice]"
 		H.dna?.species?.custom_base_icon = "[pelt_choice]"
@@ -83,6 +83,30 @@
 		H.AddSpell(new /obj/effect/proc_holder/spell/self/howl/gnoll)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/gnoll/consume)
 		H.AddComponent(/datum/component/gnoll_combat_tracker)
+
+		var/gnoll_chest = list("breasts", "nothing")
+		var/breast_choice = input(H, "What's on your chest?", "NURSE RESENTMENT.") as anything in gnoll_chest
+		if(breast_choice == "breasts")
+			H.internal_organs_slot[ORGAN_SLOT_BREASTS] = new /obj/item/organ/breasts
+
+		var/gnoll_balls = list("sac", "cryptorchid", "no")
+		var/ball_choice = input(H, "Do you have testes?", "BREED HATRED.") as anything in gnoll_balls
+		switch(ball_choice)
+			if("sac")
+				H.internal_organs_slot[ORGAN_SLOT_TESTICLES] = new /obj/item/organ/testicles/internal
+			if("cryptorchid")
+				H.internal_organs_slot[ORGAN_SLOT_TESTICLES] = new /obj/item/organ/testicles/internal
+
+		var/gnoll_genitals = list("pintle", "gudgeon", "both", "naught")
+		var/genital_choice = input(H, "What's between your legs?", "FUCK THE WORLD.") as anything in gnoll_genitals
+		switch(genital_choice)
+			if("pintle")
+				H.internal_organs_slot[ORGAN_SLOT_PENIS] = new /obj/item/organ/penis/knotted
+			if("gudgeon")
+				H.internal_organs_slot[ORGAN_SLOT_VAGINA] = new /obj/item/organ/vagina
+			if("both")
+				H.internal_organs_slot[ORGAN_SLOT_PENIS] = new /obj/item/organ/penis/knotted
+				H.internal_organs_slot[ORGAN_SLOT_VAGINA] = new /obj/item/organ/vagina
 
 		var/obj/effect/proc_holder/spell/invoked/gnoll_sniff/F = new()
 		var/obj/effect/proc_holder/spell/invoked/invisibility/gnoll/I = new()


### PR DESCRIPTION
## About The Pull Request
at the intersection of simple enough for me to code, people would use it, and no one wants to do it: alert menus at round start to choose your gnoll's genitals after their pelt

- Adds a spawn prompt for gnoll genitalia, alters the pelt menu title to flow with it.
- Makes it so you can't see internal testicles in Details regardless of sheath type.

## Testing Evidence
it works
<img width="531" height="416" alt="gnoll organs 1" src="https://github.com/user-attachments/assets/5e35b21e-1744-44f6-9bd2-10835ba53e33" />
<img width="590" height="405" alt="gnoll organs 2" src="https://github.com/user-attachments/assets/76b9bb52-8bfb-443f-8fae-dcfc83101552" />


## Why It's Good For The Game
- Allows gnolls to customize and use the menu. This is something that people assume is the case but isn't.
- A minuscule bugfix(?).
- In the future I'd like to put gnoll subclasses and pelt choice into the job preferences system and this would fit there, could be altered/cleaned/expanded.

## Changelog
:cl:
add: Added organ selector 
fix: fixed internal testicles being visible in details when they wouldn't
/:cl: