### PR TITLE
READ OMEN WHIMSYMAXXING - Read Omen Maintenance and additions.

### DIFF
--- a/code/modules/spells/spell_types/wizard/augmentation/readomen.dm
+++ b/code/modules/spells/spell_types/wizard/augmentation/readomen.dm
@@ -133,7 +133,7 @@
 
 /obj/item/orbofwisdom
 	name = "orb of wisdom"
-	desc = "Said to house the essence of the condemed Wizard 'Mineester the Omnipotent', whomst was punished for his hubris and arrogance. His grand punishment is to serve as a simple tool for answering any and all the questions that may be posed by all the Magos of Psydonia. (CLICK WITH THE ORB TO ANSWER YOUR QUESTION)"
+	desc = "Said to house the essence of the condemned Wizard 'Mineester the Omnipotent', whomst was punished for his hubris and arrogance. His grand punishment is to serve as a simple tool for answering any and all the questions that may be posed by all the Magos of Psydonia. (CLICK WITH THE ORB TO ANSWER YOUR QUESTION)"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 10
 	icon = 'icons/roguetown/rav/obj/cult.dmi'

--- a/code/modules/spells/spell_types/wizard/augmentation/readomen.dm
+++ b/code/modules/spells/spell_types/wizard/augmentation/readomen.dm
@@ -44,7 +44,7 @@
 	var/list/reign_messages = list(
 		/datum/faith/divine = list(
 			/datum/faith/divine = "The Leylines feel still, and ready to be molded.",
-			/datum/faith/inhumen = "They Leylines feel controlled, like it's potential is being surpressed.",
+			/datum/faith/inhumen = "They Leylines feel controlled, like it's potential is being suppressed.",
 			/datum/faith/old_god = "They Leylines feel average, they could always be more controlled.",
 		),
 		/datum/faith/inhumen = list(

--- a/code/modules/spells/spell_types/wizard/augmentation/readomen.dm
+++ b/code/modules/spells/spell_types/wizard/augmentation/readomen.dm
@@ -106,8 +106,14 @@
 /datum/action/cooldown/spell/readomen/proc/cast_omen(mob/living/user)
 	var/dominant_faith = GLOB.dominant_faith_tracker.dominant_faith
 	user.visible_message(span_info("The eyes of [user] roll back into their head for a moment!"), span_info("Your eyes roll into the back of your head!"))
-	if(!istype(user) || !user.patron || ispath(user.patron.associated_faith, /datum/faith/mossmother) || ispath(user.patron.associated_faith, /datum/faith/godless))
+	if(!istype(user) || !user.patron || ispath(user.patron.associated_faith, /datum/faith/godless))
 		to_chat(user, "<span class='warning'>For some reason, I cannot get a good grasp of the Leylines.</span>")
+		return FALSE
+	if(ispath(user.patron.associated_faith, /datum/faith/accelerationism))
+		to_chat(user, "<span class='warningbig'>FUCK THE LEYLINES, THEY ARE A TOOL, I DON'T CARE HOW THEY FEEL. I'LL BLOW THEM THE FUCK UP TOO WHEN I'M DONE.</span>")
+		return FALSE
+	if(ispath(user.patron.associated_faith, /datum/faith/mossmother))
+		to_chat(user, "<span class='blue'>The Leylines moods are of no concern to me.</span>")
 		return FALSE
 	if(ispath(dominant_faith, /datum/faith/old_god))
 		to_chat(user, span_blue(replacetext(reign_messages[user.patron.associated_faith][dominant_faith], "$patron", get_god_name(user.patron))))

--- a/code/modules/spells/spell_types/wizard/augmentation/readomen.dm
+++ b/code/modules/spells/spell_types/wizard/augmentation/readomen.dm
@@ -1,14 +1,16 @@
 /datum/action/cooldown/spell/readomen
 	name = "Read Omen"
-	desc = "Casting this spell, you draw upon the leylines themselves to reveal secrets of fate itself. \n\
-	(Casting it gives you a vague explanation of which god currently holds sway over the land. If they are your patron, the explanation is less vague.)"
+	desc = "A spell used to read the secrets of the world. This spell has two modes, OMEN, and ORB. \n\
+	While in OMEN mode, casting the spell will give you a vague reading of the leylines indicating which pantheon is dominant currently. \n\
+	While in Orb Mode, casting the spell summons an ORB OF WISDOM. \n\
+	clicking with it will cause the orb to answer one of your deepest questions."
 	button_icon = 'icons/mob/actions/mage_augmentation.dmi'
 	button_icon_state = "readomen"
 	sound = 'sound/magic/whiteflame.ogg'
 	spell_color = GLOW_COLOR_ARCANE
 	glow_intensity = GLOW_INTENSITY_LOW
 
-	click_to_activate = FALSE
+	click_to_activate = TRUE
 	self_cast_possible = TRUE
 
 	primary_resource_type = SPELL_COST_STAMINA
@@ -19,11 +21,11 @@
 
 	charge_required = TRUE
 	charge_swingdelay_type = SWINGDELAY_PENALTY
-	charge_time = 2 SECONDS
+	charge_time = 1 SECONDS
 	hold_drain = 0
 	charge_slowdown = CHARGING_SLOWDOWN_SMALL
 	charge_sound = 'sound/magic/charging.ogg'
-	cooldown_time = 2 MINUTES
+	cooldown_time = 1 MINUTES
 
 	associated_skill = /datum/skill/magic/arcane
 	spell_tier = 1
@@ -33,115 +35,140 @@
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
-/datum/action/cooldown/spell/readomen/cast(mob/living/user)
+	var/current_mode = 1
+	var/list/modes = list(
+		list("name" = "Read Omen", "tag" = "OMEN", "icon" = "readomen", "invocation" = "Caelum Feri!"),
+		list("name" = "Orb of Wisdom", "tag" = "ORB", "icon" = "readomen", "invocation" = "Feri Fulmine Hostem!"),
+	)
+
+	var/list/reign_messages = list(
+		/datum/faith/divine = list(
+			/datum/faith/divine = "The Leylines feel still, and ready to be molded.",
+			/datum/faith/inhumen = "They Leylines feel controlled, like it's potential is being surpressed.",
+			/datum/faith/old_god = "They Leylines feel average, they could always be more controlled.",
+		),
+		/datum/faith/inhumen = list(
+			/datum/faith/inhumen = "The Leylines feel ripe for change, excitement fills your Lux as you behold it.",
+			/datum/faith/divine = "The Leylines feel unstable, something is causing the mana in them to fluxuate.",
+			/datum/faith/old_god = "The Leylines are being leeched, something is manipulating Psydonia.",
+		),
+		/datum/faith/old_god = list(
+			/datum/faith/divine = "The Leylines feel dull, perhaps they are healing.",
+			/datum/faith/inhumen = "The Leylines power is being dulled, an insult to the Arcyne.",
+			/datum/faith/old_god = "The Leylines are as they should be, a perfect balance of calm.",
+		)
+	)
+
+	var/obj/item/rogueweapon/conjured_orb = null
+
+/datum/action/cooldown/spell/readomen/Grant(mob/grant_to)
+	. = ..()
+	apply_mode(current_mode)
+
+/datum/action/cooldown/spell/readomen/proc/apply_mode(index)
+	var/list/mode = modes[index]
+	name = mode["name"]
+	button_icon_state = mode["icon"]
+	invocations = list(mode["invocation"])
+	build_all_button_icons()
+	update_mode_maptext(mode["tag"])
+
+/datum/action/cooldown/spell/readomen/toggle_alt_mode(mob/user)
+	current_mode = (current_mode % length(modes)) + 1
+	apply_mode(current_mode)
+	to_chat(user, span_notice("[name]: [modes[current_mode]["name"]] mode."))
+	return TRUE
+
+/datum/action/cooldown/spell/readomen/proc/update_mode_maptext(tag)
+	for(var/datum/hud/hud as anything in viewers)
+		var/atom/movable/screen/movable/action_button/B = viewers[hud]
+		var/atom/movable/screen/arc_maptext_holder/holder
+		for(var/atom/movable/screen/arc_maptext_holder/existing in B.vis_contents)
+			holder = existing
+			break
+		if(!holder)
+			holder = new(B)
+			B.vis_contents.Add(holder)
+		holder.maptext = MAPTEXT(tag)
+		holder.maptext_x = 5
+		holder.color = GLOW_COLOR_LIGHTNING
+
+/datum/action/cooldown/spell/readomen/cast()
 	. = ..()
 
+	var/mob/living/carbon/human/H = owner
+	if(current_mode == 1)
+		cast_omen(H)
+	else
+		cast_orb(H)
+	return TRUE
+
+/datum/action/cooldown/spell/readomen/proc/cast_omen(mob/living/user)
+	var/dominant_faith = GLOB.dominant_faith_tracker.dominant_faith
 	user.visible_message(span_info("The eyes of [user] roll back into their head for a moment!"), span_info("Your eyes roll into the back of your head!"))
+	if(!istype(user) || !user.patron || ispath(user.patron.associated_faith, /datum/faith/mossmother) || ispath(user.patron.associated_faith, /datum/faith/godless))
+		to_chat(user, "<span class='warning'>For some reason, I cannot get a good grasp of the Leylines.</span>")
+		return FALSE
+	if(ispath(dominant_faith, /datum/faith/old_god))
+		to_chat(user, span_blue(replacetext(reign_messages[user.patron.associated_faith][dominant_faith], "$patron", get_god_name(user.patron))))
+	else if(ispath(user.patron.associated_faith, dominant_faith))
+		to_chat(user, span_boldgreen(replacetext(reign_messages[user.patron.associated_faith][dominant_faith], "$patron", get_god_name(user.patron))))
+	else
+		to_chat(user, span_warningbig(replacetext(reign_messages[user.patron.associated_faith][dominant_faith], "$patron", get_god_name(user.patron))))
 
-	var/datum/storyteller/current_god = SSgamemode.storytellers[SSgamemode.ruling_god]
-	
-	if(istype(current_god, /datum/storyteller/astrata))
-		if(istype(user.patron, /datum/patron/divine/astrata))
-			to_chat(user, "<span class='warning'>You know this feeling well. That is the warmth of the sun on your cheeks. Astrata light beams upon you in this moment.</span>")
-		else
-			to_chat(user, "<span class='warning'>You feel warm for a moment, like you are beginning to get flush from a fever, and then it fades.</span>")
-			
-	if(istype(current_god, /datum/storyteller/noc))
-		if(istype(user.patron, /datum/patron/divine/noc))
-			to_chat(user, "<span class='warning'>With your eyes rolled into the back of you head, a feeling you are familiar with comes to mind. Darkness, the comforting darkness of night.</span>")
-		else
-			to_chat(user, "<span class='warning'>With your eyes rolled into the back of your head, you don't quite feel anything other than the opressive darkness that is the inside of your skull.</span>")
-			
-	if(istype(current_god, /datum/storyteller/abyssor))
-		if(istype(user.patron, /datum/patron/divine/abyssor))
-			to_chat(user, "<span class='warning'>You concentrate on the spell, and are immediately hit with the familiar feeling of a lucid dream, you know this feeling well.</span>")
-		else
-			to_chat(user, "<span class='warning'>In your concentration of the spell, you feel yourself drift for a moment, like the feeling right before you are about to fall asleep.</span>")
-			
-	if(istype(current_god, /datum/storyteller/dendor))
-		if(istype(user.patron, /datum/patron/divine/dendor))
-			to_chat(user, "<span class='warning'>The spell takes effect, and you hear it immediately. You hear peaceful nature in your ears, winds billowing through trees, a distant volf bark. It is comforting.</span>")
-		else
-			to_chat(user, "<span class='warning'>You feel the spell take effect, but cannot notice anything quite different. Though, you swear you hear the sound of a nearby rustling tree.</span>")
-			
-	if(istype(current_god, /datum/storyteller/ravox))
-		if(istype(user.patron, /datum/patron/divine/ravox))
-			to_chat(user, "<span class='warning'>It hits you quickly, this is the feeling you get right before a fight. You feel your body tense for a moment, excitement, duty, honor- before, it fades, that adrenaline quickly draining.</span>")
-		else
-			to_chat(user, "<span class='warning'>The spell takes effect, but all you feel is that feeling you get right before a fight. That brief jump in adrenaline before nothing once more.</span>")
-			
-	if(istype(current_god, /datum/storyteller/eora))
-		if(istype(user.patron, /datum/patron/divine/eora))
-			to_chat(user, "<span class='warning'>This is the feeling of love, I know it well. Those butterflies in your stomach before you're about to confess, the excitement, the small amount of fear.</span>")
-		else
-			to_chat(user, "<span class='warning'>You feel something in your stomach, you aren't quite sure how to put it but it's a feeling akin to butterflies.</span>")
-			
-	if(istype(current_god, /datum/storyteller/necra))
-		if(istype(user.patron, /datum/patron/divine/necra))
-			to_chat(user, "<span class='warning'>There is a deathly stillness in the air. You know this feeling and find comfort in it. You stand there and bask in the peacefulness of it for a moment before reality returns.</span>")
-		else
-			to_chat(user, "<span class='warning'>You swear for a moment you heard something whisper in your ear, perhaps it was the wind?</span>")
-			
-	if(istype(current_god, /datum/storyteller/pestra))
-		if(istype(user.patron, /datum/patron/divine/pestra))
-			to_chat(user, "<span class='warning'>You finish the incantation of the spell and instantly notice the distinct smell of decay, a smell you know oh so well. It fills your mind with all sorts of machinations before the spell finishes.</span>")
-		else
-			to_chat(user, "<span class='warning'>You struggle for a moment in the silence, trying to concentrate on the spell, but the sound of a damned fly keeps distracting you before you lose concentration entirely.</span>")
-			
-	if(istype(current_god, /datum/storyteller/malum))
-		if(istype(user.patron, /datum/patron/divine/malum))
-			to_chat(user, "<span class='warning'>You enter a state of meditation while you concentrate on the spell. You feel the familiar warmth on your cheeks for a moment, like you just stuck your head infront of a forge or oven.</span>")
-		else
-			to_chat(user, "<span class='warning'>You sit in silence, not knowing if the spell has actually taken effect, but you can swear you hear the sound of a distant ting from a blacksmith working away.</span>")
-			
-	if(istype(current_god, /datum/storyteller/zizo))
-		if(istype(user.patron, /datum/patron/inhumen/zizo))
-			to_chat(user, "<span class='warning'>You finish the incantations of the spell, but you know the answer already.</span>")
-		else
-			to_chat(user, "<span class='warning'>As you finish the spell, you are met with a feeling. You can't quite put your thumb on it but, something does not feel right.</span>")
-			
-	if(istype(current_god, /datum/storyteller/matthios))
-		if(istype(user.patron, /datum/patron/inhumen/matthios))
-			to_chat(user, "<span class='warning'>The spell takes effect, and as your eyes are rolled back into your head, you swear you feel someone brush up against you, and instinctively reach for your coin pouch, only to realize that it never happened.</span>")
-		else
-			to_chat(user, "<span class='warning'>You feel your eyes roll into the back of your head, and begin to question if this was really worth casting. Before you have a chance to focus it's all over, what a ripoff.</span>")
-			
-	if(istype(current_god, /datum/storyteller/baotha))
-		if(istype(user.patron, /datum/patron/inhumen/baotha))
-			to_chat(user, "<span class='warning'>Once you finish the spell, you are hit with absolutely nothing, the same feeling you get after a line of Ozium. Dull and numb.</span>")
-		else
-			to_chat(user, "<span class='warning'>Your stomach immediately churns, you aren't quite sure if it's guilt, or if it's too much drink. It feels horrible.</span>")
 
-	if(istype(current_god, /datum/storyteller/graggar))
-		if(istype(user.patron, /datum/patron/inhumen/graggar))
-			to_chat(user, "<span class='warning'>You finish the incantation and feel something well up inside you. Rage, excitement, the thirst you know so well. You snap back to reality, heart beating fast.</span>")
-		else
-			to_chat(user, "<span class='warning'>You finish the spell, however after a few moments you don't feel much difference, it leaves you frustrated and angry.</span>")
-			
-	if(istype(current_god, /datum/storyteller/psydon))
-		if(istype(user.patron, /datum/patron/old_god))
-			to_chat(user, "<span class='warning'>You finish the incantation of the spell, but nothing happens. It is a nice moment of peace.</span>")
-		else
-			to_chat(user, "<span class='warning'>You finish the incantation of the spell, but nothing happens.</span>")
-			
-	if(istype(current_god, /datum/storyteller/xylix))
-		if(istype(user.patron, /datum/patron/divine/xylix))
-			to_chat(user, "<span class='warning'>The spell incantation finishes and you feel a s- no. No that isn't right. That was a trick! Heehee, you can't trick me that easily.</span>")
-		else
-			var/list/possible_messages = list(
-				"<span class='warning'>You feel warm for a moment, like you are beginning to get flush from a fever, and then it fades.</span>",
-				"<span class='warning'>With your eyes rolled into the back of your head, you don't quite feel anything other than the opressive darkness that is the inside of your skull.</span>",
-				"<span class='warning'>In your concentration of the spell, you feel yourself drift for a moment, like the feeling right before you are about to fall asleep.</span>",
-				"<span class='warning'>You feel the spell take effect, but cannot notice anything quite different. Though, you swear you hear the sound of a nearby rustling tree.</span>",
-				"<span class='warning'>The spell takes effect, but all you feel is that feeling you get right before a fight. That brief jump in adrenaline before nothing once more.</span>",
-				"<span class='warning'>You feel something in your stomach, you aren't quite sure how to put it but it's a feeling akin to butterflies.</span>",
-				"<span class='warning'>You swear for a moment you heard something whisper in your ear, perhaps it was the wind?</span>",
-				"<span class='warning'>You struggle for a moment in the silence, trying to concentrate on the spell, but the sound of a damned fly keeps distracting you before you lose concentration entirely.</span>",
-				"<span class='warning'>You sit in silence, not knowing if the spell has actually taken effect, but you can swear you hear the sound of a distant ting from a blacksmith working away.</span>",
-				"<span class='warning'>As you finish the spell, you are met with a feeling. You can't quite put your thumb on it but, something does not feel right.</span>",
-				"<span class='warning'>You feel your eyes roll into the back of your head, and begin to question if this was really worth casting. Before you have a chance to focus it's all over, what a ripoff.</span>",
-				"<span class='warning'>Your stomach immediately churns, you aren't quite sure if it's guilt, or if it's too much drink. It feels horrible.</span>",
-				"<span class='warning'>You finish the spell, however after a few moments you don't feel much difference, it leaves you frustrated and angry.</span>",
-				"<span class='warning'>You finish the incantation of the spell, but nothing happens.</span>"
-			)
-			to_chat(user, pick(possible_messages))
+
+/datum/action/cooldown/spell/readomen/proc/cast_orb(atom/cast_on)
+	var/mob/living/user = owner
+	if(!istype(user))
+		return FALSE
+
+	if(src.conjured_orb)
+		qdel(conjured_orb)
+	var/obj/item/R = new /obj/item/orbofwisdom(user.drop_location())
+	R.AddComponent(/datum/component/conjured_item, null, FALSE, user, src)
+	user.put_in_hands(R)
+	src.conjured_orb = R
+	return TRUE
+
+/obj/item/orbofwisdom
+	name = "orb of wisdom"
+	desc = "Said to house the essence of the condemed Wizard 'Mineester the Omnipotent', whomst was punished for his hubris and arrogance. His grand punishment is to serve as a simple tool for answering any and all the questions that may be posed by all the Magos of Psydonia. (CLICK WITH THE ORB TO ANSWER YOUR QUESTION)"
+	w_class = WEIGHT_CLASS_NORMAL
+	force = 10
+	icon = 'icons/roguetown/rav/obj/cult.dmi'
+	color = "#72cbff"
+	icon_state = "sphere0"
+	item_state = "sphere0"
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	possible_item_intents = list(/datum/intent/use)
+
+/obj/item/orbofwisdom/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	. = ..()
+
+	var/turf/T = get_turf(src)
+	var/list/florish_message = list("A brilliant question, truelee...", "Hrm... allow me to PONDER this question...", "BAH, to thynk my wisdom is wasted on such a question...", "I SUPPOSE I can contemplate this...", "You know I used to be a GRANDMASTER?", "I miss my wyfe...", "Hrm! Allow me to ponder... WOOOSHH WHHSHWOOOSH, WHOOSSSHH...", "Whatte? MUST I ponder this? Fyne...", "TO THINK my ABILITIES could be used for FAR BETTER THINGS THAN SUCH a SIMPLE QUESTION... alas...", "Yeeees, Yeeeeees. I will answer your question you fool...")
+	var/list/arcyne_wisdom = list("THE ANSWER IS YES.", "Maybe? It is uncertain.", "Yeeeeeeees.", "Absolutely not, now unhand me.", "No.", "I am so tired, ask me later.", "I COULD HAVE BEEN A LYCH AT THIS POINT BUT NO, I HAVE TO ANSWER YOUR FOOLISH QUESTI- sure whatever.", "Perhaps another Magos should ask.", "No, you weerdoe.", "PERHAPS. Perhaps...")
+
+	if(!HAS_TRAIT(user, TRAIT_ARCYNE))
+		visible_message(span_warningbig("FOOL, you are no Wyzard, I'm not LEGALLY BOUND to answer to your QUESTIONS, unhand me at this instant."))
+		user.dropItemToGround(src)
+		playsound(src, 'sound/combat/hits/onglass/glassbreak (2).ogg', 100)
+		qdel(src)
+		return
+	else
+		visible_message(span_say("[src] bellows \"[pick(florish_message)]\""))
+		sleep(rand(1 SECONDS, 5 SECONDS))
+		visible_message(span_say("[src] answers \"[pick(arcyne_wisdom)]\""))
+		sleep(2 SECONDS)
+		visible_message(span_say("[src] says \"NOW, I must AWAY. Other Wyzards need my wisdom.\""))
+		sleep(1 SECONDS)
+		playsound(src, 'sound/combat/tempo_loss.ogg', 100)
+		visible_message(span_emote("[src] poofs in a puff of smoke."))
+		if(T)
+			var/mutable_appearance/poof = mutable_appearance('icons/effects/effects.dmi', "mist", layer = 10)
+			T.add_overlay(poof)
+			addtimer(CALLBACK(T, TYPE_PROC_REF(/atom, cut_overlay), poof), 1 SECONDS)
+		qdel(src)
+		return


### PR DESCRIPTION
## About The Pull Request
What's up gang, remember Read Omen which was HARDLY EVER USED? I do to... THEN WE ALSO GOT RID OF STORYTELLERS which made it EXTRA USELESS...

WELL NO LONGER. Read Omen has been IMPROVED!!!

I have moved it over to work with the new Dominant FAITH system instead. Magos can now listen to the leylines to get good/bad/neutral feelings based on their chosen pantheon/patron and the current dominant faith.

<img width="475" height="149" alt="dreamseeker_CfsPV9rBhC" src="https://github.com/user-attachments/assets/5897ebd5-41b9-4e9f-8abe-77d3ff2d5d85" />

"But Strudel I don't need to use that that often why is it worth one spell point" I hear you ask.

INTRODUCING THE NEW ALT MODE VERSION OF READ OMEN. The ORB OF WISDOM.
<img width="57" height="62" alt="dreamseeker_M6eSBLKsI6" src="https://github.com/user-attachments/assets/e46ae945-f6b2-496f-bed5-af5753f5c3a6" />
<img width="551" height="238" alt="dreamseeker_mhn3NKsTUn" src="https://github.com/user-attachments/assets/a2c0d024-cd82-45c4-88be-541ca9f6e4b1" />

The ORB of WISDOM is simple, casting it summons an ORB of the bound essence of "Mineester the Omnipotent", whom as dictated by his magical punishment must answer all the random questions of EVERY MAGOS in PSYDONIA. Truely horrific TORTURE.
(Disclaimer he is an unreliable answerer)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1920" height="790" alt="rWXAvmtiLP" src="https://github.com/user-attachments/assets/19b8cd71-6b1d-40e8-97d6-f906b2f1c714" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Maintenance for a neglected spell. More whimsy

(Also I think current read omen causes a runtime)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adds a NEW AND IMPROVED ALT MODE to READ OMEN - The ORB of WISDOM
refactor: Has the normal version of read omen use the new dominant pantheon system instead of the deprecated storyteller system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
