### PR TITLE
bugfix: azurosa petals no longer dry into regular rosa petals

### DIFF
--- a/code/game/objects/items/donator_fluff_items.dm
+++ b/code/game/objects/items/donator_fluff_items.dm
@@ -133,6 +133,8 @@
 
 /datum/crafting_recipe/roguetown/dryazurrosa
 	name = "dry azurosa petals"
+	category = FOOD_CAT_DRYING
+	display_category = ITEM_CAT_FOODSTUFF_PRESERVED
 	result = /obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried/azure
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals/azure = 1)
 	structurecraft = /obj/machinery/tanningrack
@@ -140,7 +142,8 @@
 	verbage_simple = "dry"
 	verbage = "dries"
 	craftsound = null
-	skillcraft = null
+	skillcraft = /datum/skill/craft/cooking
+	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/survival/flowercrown_azurosa
 	name = "azurosa crown"

--- a/modular/Neu_Food/code/recipes/drying_recipes.dm
+++ b/modular/Neu_Food/code/recipes/drying_recipes.dm
@@ -231,6 +231,7 @@
 	verbage_simple = "dry"
 	verbage = "dries"
 	craftsound = null
+	subtype_reqs = FALSE
 
 /datum/crafting_recipe/roguetown/cooking/sigsweet/cheroot
 	name = "cheroot - swampweed"


### PR DESCRIPTION
## About The Pull Request
"um actually the blue pigmentation denatures when exposed to heat causing-" shut up this isn't psyenceville it's roguetown

also it's actually in the cooking drying recipes category now

## Testing Evidence
it's 1 var change

## Why It's Good For The Game
coherence

## Changelog

:cl:
fix: Azurosa petals can no longer be dried into normal rosa petals
/:cl:
