### PR TITLE
weaponless trait allows surgical tool use

### DIFF
--- a/code/modules/surgery/surgery_tools_rogue.dm
+++ b/code/modules/surgery/surgery_tools_rogue.dm
@@ -21,6 +21,7 @@
 
 	grid_width = 32
 	grid_height = 64
+	is_tool = TRUE
 
 /obj/item/rogueweapon/surgery/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
surgical tools are rogueweapons but not flagged as tools so abboteer inq and such couldn't do surgery

## Testing Evidence
var change

## Why It's Good For The Game
consistency

## Changelog

:cl:
add: Surgical tools are now considered tools, not weapons, for the purposes of the weaponless and tinypaws traits
/:cl: