### PR TITLE
Fixes swingdelays applying incorrect defense penalties

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -441,7 +441,7 @@
 
 /mob/living/proc/is_swinging(disrupt_only = FALSE)
 	if(!disrupt_only)
-		return (has_status_effect(/datum/status_effect/swingdelay) || has_status_effect(/datum/status_effect/swingdelay/disrupt))
+		return (has_status_effect(/datum/status_effect/swingdelay) || has_status_effect(/datum/status_effect/swingdelay/disrupt) || has_status_effect(/datum/status_effect/swingdelay/penalty))
 	else
 		return (has_status_effect(/datum/status_effect/swingdelay/disrupt))
 

--- a/code/datums/status_effects/rogue/roguestatus.dm
+++ b/code/datums/status_effects/rogue/roguestatus.dm
@@ -57,7 +57,7 @@
 	if(newdur)
 		duration = newdur
 	. = ..()
-	
+
 /datum/status_effect/swingdelay/on_apply()
 	. = ..()
 	owner.swing_state = TRUE
@@ -69,6 +69,7 @@
 	icon_state = "swingdelay"
 
 /datum/status_effect/swingdelay/penalty
+	id = "swingdelay_penalty"
 	alert_type = /atom/movable/screen/alert/status_effect/swingdelay/penalty
 	mob_effect_icon_state = "eff_swingdelay_penalty"
 


### PR DESCRIPTION
## About The Pull Request
The standard 'white' swing delay was being recognised as the penalty (yellow) swingdelay in-code due to overlapping IDs. Bad micro optimization moment.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Why It's Good For The Game
Fixes swingdelays applying incorrect defense penalties
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed standard swingdelays applying incorrect defense penalties.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
