### PR TITLE
Just makes slayers slightly average as opposed to weakest you can get

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
@@ -29,7 +29,6 @@
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, // Sew up the countless holes you will be receiving
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE, //bare minimum so they can use silverfaces and the like
 	)
-	adv_stat_ceiling = list(STAT_STRENGTH = 12) // I'm sorry but you're not grabbing muscular and aiming chest with 12 speed 17 strength swift intent spam.
 
 /datum/outfit/job/roguetown/mercenary/trollslayer
 	allowed_patrons = ALL_SLAYER_PATRONS
@@ -165,7 +164,7 @@
 	var/outline_colour = "#EB4445"
 	id = "axedance"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/axedance
-	duration = 30 SECONDS // should be enough to balance it out
+	duration = 20 SECONDS // should be enough to balance it out
 	effectedstats = list("speed" = 3, "strength" = 3)
 
 /datum/status_effect/buff/axedance/on_apply()

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
@@ -164,7 +164,7 @@
 	var/outline_colour = "#EB4445"
 	id = "axedance"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/axedance
-	duration = 20 SECONDS // should be enough to balance it out
+	duration = 30 SECONDS // should be enough to balance it out
 	effectedstats = list("speed" = 3, "strength" = 3)
 
 /datum/status_effect/buff/axedance/on_apply()


### PR DESCRIPTION
## About The Pull Request

The slayers are always kind of on the weak side, the 12 strength cap especially harming any sort of build with them so in exchange for a shorter axe dance they have regained their ability to have strength uncapped

## Testing Evidence

It runs and compiles with intended use

## Why It's Good For The Game

I tested the axe dance against a dragon broodmother and the broodmother won, best I could do solo, even with infinite stamina swift intent is not that good for 20 seconds

## Changelog

removes the trollslayer strength cap

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
Make troll slayer more viable by removing strength cap
/:cl:


