### PR TITLE
[Fluff] Skill check messages

### DIFF
--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -390,6 +390,21 @@ GLOBAL_LIST_EMPTY(miracle_tiers)
 			holder.mind.AddSpell(new_paint_spell, holder)
 			LAZYADD(granted_spells, new_paint_spell)
 
+/**
+ * Formats a skill or patron check text string with custom status prefixing.
+ *
+ * Output format: "[Check Name: Success/Failure] Content"
+ *
+ * * check_name - The display name of the check (e.g., "Abyssor", "Medical", "Half-Light").
+ * * success - Whether the check succeeded (TRUE = greentext "Success", FALSE = redtext "Failure").
+ * * content - The body text/flavor text to display inside the notice span.
+ */
+/proc/skill_check_text(check_name, success = TRUE, content = "")
+	var/status_text = success ? "Success" : "Failure"
+	var/bracket_text = "\[[check_name]: [status_text]\]"
+	var/prefix = success ? span_greentext(bracket_text) : span_redtext(bracket_text)
+	return "[prefix] [span_notice(content)]"
+
 #undef PRAYER_DEVOTION_TIME_MULT
 #undef PRAYER_DEVOTION_BASE
 #undef PRAYER_DEVOTION_SKILL

--- a/code/game/objects/effects/gods/unassuming_fluff.dm
+++ b/code/game/objects/effects/gods/unassuming_fluff.dm
@@ -17,7 +17,9 @@ GLOBAL_LIST_EMPTY(players_in_dream)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.patron.type == /datum/patron/divine/abyssor)
-			. += span_danger("One of the greatest and eldest of the dreamfiends. It's said creatures of the dream take ages to grow in size... And this one is a true leviathan.")
+			. += skill_check_text("Abyssor", TRUE, "One of the greatest and eldest of the dreamfiends. It's said creatures of the dream take ages to grow in size... And this one is a true leviathan.")
+		else
+			. += skill_check_text("Abyssor", FALSE, "My devotion to Abyssor is too weak, the whispers of the void remain silent.")
 
 /datum/stressevent/dream_horror
 	timer = 999 MINUTES

--- a/code/modules/roguetown/roguemachine/heartbeast/heart_beast.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_beast.dm
@@ -21,13 +21,15 @@
 
 /obj/structure/roguemachine/chimeric_heart_beast/examine(mob/user)
 	. = ..()
-	if(iscarbon(user))
-		var/mob/living/carbon/c = user
-		if(c.patron.type == /datum/patron/divine/pestra)
-			. += span_info("The divine beast of Pestra. For untold ages, these beasts remained behind locked doors, allowing the sect of Pestra to lengthen their lifespan.")
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.patron.type == /datum/patron/divine/pestra)
+			. += skill_check_text("Pestra", TRUE, "The divine beast of Pestra. For untold ages, these beasts remained behind locked doors, allowing the sect of Pestra to lengthen their lifespan.")
 			. += span_infection("Yet the others grew restless, desiring pure lux for their own...")
-			. += span_info("Now, they are employed in most regions of the world where the light of the ten shines. Decreasing suffering.")
+			. += span_infection("Now, they are employed in most regions of the world where the light of the ten shines. Decreasing suffering.")
 			. += span_infection("For the great beast of Pestra, made through the ingenuity of humenkind influences all divine magic within a region.")
+		else
+			. += skill_check_text("Pestra", FALSE, "My devotion to Pestra is too weak, the whispers of the void remain silent.")
 
 /obj/structure/roguemachine/chimeric_heart_beast/proc/initialize_personality()
 	// Pick random archetype

--- a/code/modules/spells/roguetown/acolyte/eora/eora_arils.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_arils.dm
@@ -30,7 +30,9 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/c = user
 		if(c.patron.type == /datum/patron/divine/eora)
-			. += span_info(effect_desc)
+			. += skill_check_text("Eora", TRUE, effect_desc)
+		else
+			. += skill_check_text("Eora", FALSE, "My devotion to Eora is too weak, the whispers of the void remain silent.")
 
 /obj/item/reagent_containers/food/snacks/eoran_aril/proc/apply_effects(mob/living/carbon/eater)
 	return


### PR DESCRIPTION
## About The Pull Request
Adds a simple proc to quickly add skill check messages.
Merely used for a handful of examines that only show when you have a certain patron.

## Testing Evidence
<img width="575" height="46" alt="image" src="https://github.com/user-attachments/assets/45c09d59-66f4-412a-9ca9-dceca9be2172" />

## Why It's Good For The Game
Should make it more obvious when an examine check is broken.
It's cute, hints at players why they receive certain information, whilst hinting at others that they shouldn't know certain things.

## Changelog

:cl:
add: Skill check messages for certain patron based examine blurbs.
fix: Fix heartbeast lore blurb
/:cl:
