### PR TITLE
[TM] Character preference snapshot datum

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -17,6 +17,59 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 	if(special.req_text)
 		to_chat(user, span_boldwarning("Requirements: [special.req_text]"))
 
+/**
+ * A frozen copy of the character-setup preferences a mob was spawned from.
+ *
+ * There is only one /datum/preferences per client and switching character slot overwrites its
+ * fields in place, so client.prefs stops describing the mob you are playing the moment the player
+ * opens the setup menu and picks another slot. This is fine in most cases but in the case of
+ * apply_character_post_equipment(), we need a static copy of the character's pref for edge cases
+ * where the player changes their slot until the player finishes class and loadout selection.
+ *
+ * Taken in /datum/preferences/proc/copy_to()
+ */
+
+/datum/pref_snapshot
+	var/datum/virtue/virtue
+	var/datum/virtue/virtuetwo
+	var/datum/virtue/virtue_origin
+	var/extra_language
+	var/datum/patron/selected_patron
+	var/datum/statpack/statpack
+	var/race_bonus
+	var/voice_pack
+	var/dnr_pref = FALSE
+	var/qsr_pref = FALSE
+	var/next_special_trait
+	var/list/gear_list
+	var/averse_chosen_faction
+	var/lastclass
+
+/datum/pref_snapshot/New(datum/preferences/prefs)
+	. = ..()
+	if(!prefs)
+		return
+	virtue = prefs.virtue
+	virtuetwo = prefs.virtuetwo
+	virtue_origin = prefs.virtue_origin
+	extra_language = prefs.extra_language
+	selected_patron = prefs.selected_patron
+	statpack = prefs.statpack
+	race_bonus = prefs.race_bonus
+	voice_pack = prefs.voice_pack
+	dnr_pref = prefs.dnr_pref
+	qsr_pref = prefs.qsr_pref
+	next_special_trait = prefs.next_special_trait
+	gear_list = prefs.gear_list?.Copy()
+	averse_chosen_faction = prefs.averse_chosen_faction
+	lastclass = prefs.lastclass
+
+/// Returns the preferences this mob spawned with. Has a failsafe for NPCs or admin mobs.
+/mob/living/carbon/human/proc/get_pref_snapshot()
+	if(!pref_snapshot && client?.prefs)
+		pref_snapshot = new /datum/pref_snapshot(client.prefs)
+	return pref_snapshot
+
 /proc/try_apply_character_post_equipment(mob/living/carbon/human/character, client/player)
 	var/datum/job/job
 	if(character.job)
@@ -34,18 +87,22 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 /proc/apply_character_post_equipment(mob/living/carbon/human/character, client/player)
 	if(!player)
 		player = character.client
-	apply_charflaw_equipment(character, player)
-	apply_prefs_special(character, player)
-	apply_prefs_virtue(character, player)
-	apply_prefs_race_bonus(character, player)
+	// Everything preference-derived below comes from the spawn-time snapshot, never client.prefs -
+	// for adv class jobs this proc runs after class and loadout selection, by which point the
+	// player may have switched character slot and overwritten their prefs with another character.
+	var/datum/pref_snapshot/snapshot = character.get_pref_snapshot()
+	apply_charflaw_equipment(character)
+	apply_prefs_special(character, snapshot)
+	apply_prefs_virtue(character, snapshot)
+	apply_prefs_race_bonus(character, snapshot)
 	if(!HAS_TRAIT(character, TRAIT_NO_VOICEPACK_OVERRIDE)) //Only roundstart roles that jobload in, should use this. Prevents prefloaded voicepacks overriding yours.
-		apply_voicepacks(character, player)
-	if(player.prefs.dnr_pref)
-		apply_dnr_trait(character, player)
-	if(player.prefs.qsr_pref)
-		apply_qsr_trait(character, player)
-	character.mind.triumph_discount_remaining = is_donator(player.ckey) ? 3 : 0 // donators get first 3 triumph points free, spent on retrieval
-	for(var/item_name in player.prefs.gear_list)
+		apply_voicepacks(character, snapshot?.voice_pack)
+	if(snapshot?.dnr_pref)
+		apply_dnr_trait(character)
+	if(snapshot?.qsr_pref)
+		apply_qsr_trait(character)
+	character.mind.triumph_discount_remaining = is_donator(player?.ckey) ? 3 : 0 // donators get first 3 triumph points free, spent on retrieval
+	for(var/item_name in snapshot?.gear_list)
 		var/datum/loadout_item/LI = GLOB.loadout_items_by_name[item_name]
 		if(!LI)
 			continue
@@ -54,7 +111,7 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 			character.mind.special_items["[LI.name][TRIUMPH_STASH_SUFFIX]"] = LI.path
 		else
 			character.mind.special_items[LI.name] = LI.path
-		character.mind.special_items_metadata[LI.name] = player.prefs.gear_list[item_name]
+		character.mind.special_items_metadata[LI.name] = snapshot.gear_list[item_name]
 	var/datum/job/assigned_job = SSjob.GetJob(character.mind?.assigned_role)
 	if(assigned_job)
 		assigned_job.clamp_stats(character)
@@ -77,35 +134,34 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	return TRUE
 
-/proc/apply_voicepacks(mob/living/carbon/human/character, client/player)
-	if(player.prefs.voice_pack != "Default")
-		var/datum/voicepack/VP = GLOB.voice_packs[GLOB.voice_packs_list[player.prefs.voice_pack]]
-		character.dna.species.soundpack_m = VP
-		character.dna.species.soundpack_f = VP
-
-
-/proc/apply_prefs_virtue(mob/living/carbon/human/character, client/player)
-	if (!player)
-		player = character.client
-	if (!player)
+/proc/apply_voicepacks(mob/living/carbon/human/character, voice_pack)
+	if(!voice_pack || voice_pack == "Default")
 		return
-	if (!player.prefs)
+	var/datum/voicepack/VP = GLOB.voice_packs[GLOB.voice_packs_list[voice_pack]]
+	character.dna.species.soundpack_m = VP
+	character.dna.species.soundpack_f = VP
+
+
+/proc/apply_prefs_virtue(mob/living/carbon/human/character, datum/pref_snapshot/snapshot)
+	if (!snapshot)
+		snapshot = character.get_pref_snapshot()
+	if (!snapshot)
 		return
 
 	var/virtuous = FALSE
 	var/heretic = FALSE
 	var/species = character.dna.species
 
-	if(istype(player.prefs.selected_patron, /datum/patron/inhumen))
+	if(istype(snapshot.selected_patron, /datum/patron/inhumen))
 		heretic = TRUE
 
-	if(player.prefs.statpack.virtuous)
+	if(snapshot.statpack?.virtuous)
 		virtuous = TRUE
 
-	var/datum/virtue/virtue_type = player.prefs.virtue
-	var/datum/virtue/virtuetwo_type = player.prefs.virtuetwo
-	var/datum/virtue/origin_type = player.prefs.virtue_origin
-	var/language_type = player.prefs.extra_language
+	var/datum/virtue/virtue_type = snapshot.virtue
+	var/datum/virtue/virtuetwo_type = snapshot.virtuetwo
+	var/datum/virtue/origin_type = snapshot.virtue_origin
+	var/language_type = snapshot.extra_language
 	if(virtue_type)
 		if(virtue_check(virtue_type, heretic, species))
 			apply_virtue(character, virtue_type)
@@ -121,7 +177,7 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 			character.grant_language(language_type)
 		if(origin_type.job_origin == TRUE)
 			apply_virtue(character, origin_type)
-			player.prefs.virtue_origin = origin_type.last_origin
+			snapshot.virtue_origin = origin_type.last_origin
 		else
 			if(origin_check(origin_type, species))
 				apply_virtue(character, origin_type)
@@ -145,18 +201,16 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		return TRUE
 	return FALSE
 
-/proc/apply_prefs_race_bonus(mob/living/carbon/human/character, client/player)
-	if (!player)
-		player = character.client
-	if (!player)
+/proc/apply_prefs_race_bonus(mob/living/carbon/human/character, datum/pref_snapshot/snapshot)
+	if (!snapshot)
+		snapshot = character.get_pref_snapshot()
+	if (!snapshot)
 		return
-	if (!player.prefs)
-		return
-	if (!player.prefs.race_bonus || player.prefs.race_bonus == "None")
+	if (!snapshot.race_bonus || snapshot.race_bonus == "None")
 		return
 	if(!length(character.dna.species.custom_selection))
 		return
-	var/bonus = player.prefs.race_bonus
+	var/bonus = snapshot.race_bonus
 	if(!(bonus in character.dna.species.custom_selection))
 		return
 	var/full_bonus
@@ -195,7 +249,7 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		return TRUE
 	return FALSE
 
-/proc/apply_charflaw_equipment(mob/living/carbon/human/character, client/player)
+/proc/apply_charflaw_equipment(mob/living/carbon/human/character)
 	var/has_extra_vice = FALSE
 	var/needs_extra_vice = FALSE
 	for(var/datum/charflaw/cf in character.charflaws) // difficulty flaws don't count as each other's extra vice
@@ -211,27 +265,29 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		character.charflaws.Add(rf)
 		rf.apply_post_equipment(character)
 
-/proc/apply_dnr_trait(mob/living/carbon/human/character, client/player)
-	ADD_TRAIT(player.mob, TRAIT_DNR, TRAIT_GENERIC)
+/proc/apply_dnr_trait(mob/living/carbon/human/character)
+	ADD_TRAIT(character, TRAIT_DNR, TRAIT_GENERIC)
 
-/proc/apply_qsr_trait(mob/living/carbon/human/character, client/player)
-	ADD_TRAIT(player.mob, TRAIT_QUICKSILVERRESISTANT, TRAIT_GENERIC)
+/proc/apply_qsr_trait(mob/living/carbon/human/character)
+	ADD_TRAIT(character, TRAIT_QUICKSILVERRESISTANT, TRAIT_GENERIC)
 
-/proc/apply_prefs_special(mob/living/carbon/human/character, client/player)
-	if(!player)
-		player = character.client
-	if(!player)
+/proc/apply_prefs_special(mob/living/carbon/human/character, datum/pref_snapshot/snapshot)
+	if(!snapshot)
+		snapshot = character.get_pref_snapshot()
+	if(!snapshot)
 		return
-	if(!player.prefs)
-		return
-	var/trait_type = player.prefs.next_special_trait
+	var/trait_type = snapshot.next_special_trait
 	if(!trait_type)
 		return
-	apply_special_trait_if_able(character, player, trait_type)
-	player.prefs.next_special_trait = null
+	apply_special_trait_if_able(character, trait_type)
+	snapshot.next_special_trait = null
+	// The pref is a one-shot token, so clear it on the live prefs too - but only if the player is
+	// still on the slot we spawned from, otherwise we'd be consuming another character's token.
+	if(character.client?.prefs?.next_special_trait == trait_type)
+		character.client.prefs.next_special_trait = null
 
-/proc/apply_special_trait_if_able(mob/living/carbon/human/character, client/player, trait_type)
-	if(!charactet_eligible_for_trait(character, player, trait_type))
+/proc/apply_special_trait_if_able(mob/living/carbon/human/character, trait_type)
+	if(!charactet_eligible_for_trait(character, trait_type))
 		log_game("SPECIALS: Failed to apply [trait_type] for [key_name(character)]")
 		return FALSE
 	log_game("SPECIALS: Applied [trait_type] for [key_name(character)] ([character.get_role_title()])")
@@ -239,17 +295,13 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 	return TRUE
 
 /// Applies random special trait IF the client has specials enabled in prefs
-/proc/apply_random_special_trait(mob/living/carbon/human/character, client/player)
-	if(!player)
-		player = character.client
-	if(!player)
-		return
-	var/special_type = get_random_special_for_char(character, player)
+/proc/apply_random_special_trait(mob/living/carbon/human/character)
+	var/special_type = get_random_special_for_char(character)
 	if(!special_type) // Ineligible for all of them, somehow
 		return
 	apply_special_trait(character, special_type)
 
-/proc/charactet_eligible_for_trait(mob/living/carbon/human/character, client/player, trait_type)
+/proc/charactet_eligible_for_trait(mob/living/carbon/human/character, trait_type)
 	var/datum/special_trait/special = SPECIAL_TRAIT(trait_type)
 	var/datum/job/job
 	if(character.job)
@@ -290,11 +342,11 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		return FALSE
 	return TRUE
 
-/proc/get_random_special_for_char(mob/living/carbon/human/character, client/player)
+/proc/get_random_special_for_char(mob/living/carbon/human/character)
 	var/list/eligible_weight = list()
 	for(var/trait_type in GLOB.special_traits)
 		var/datum/special_trait/special = SPECIAL_TRAIT(trait_type)
-		if(!charactet_eligible_for_trait(character, player, trait_type))
+		if(!charactet_eligible_for_trait(character, trait_type))
 			continue
 		eligible_weight[trait_type] = special.weight
 

--- a/code/controllers/subsystem/rogue/merchant_trade_kinship.dm
+++ b/code/controllers/subsystem/rogue/merchant_trade_kinship.dm
@@ -31,10 +31,11 @@
 	return null
 
 /datum/controller/subsystem/merchant_trade/proc/try_claim_kinship_for(mob/living/carbon/human/H, client/source)
-	var/datum/preferences/prefs = source?.prefs || H?.client?.prefs
-	if(!prefs)
+	var/mob/living/carbon/human/claimant = ishuman(source?.mob) ? source.mob : H
+	var/datum/pref_snapshot/snapshot = claimant?.get_pref_snapshot()
+	if(!snapshot)
 		return
-	var/datum/virtue/origin/O = prefs.virtue_origin
+	var/datum/virtue/origin/O = snapshot.virtue_origin
 	if(!istype(O))
 		return
 	var/new_realm = origin_name_to_realm_id(O.origin_name)
@@ -79,9 +80,10 @@
 	if(!realm_id || !ishuman(H))
 		return 1
 	var/is_agent = (H.job == "Shophand") || HAS_TRAIT(H, TRAIT_AGENT_MERCHANT)
-	if(!is_agent || !H.client?.prefs)
+	if(!is_agent)
 		return 1
-	var/datum/virtue/origin/O = H.client.prefs.virtue_origin
+	var/datum/pref_snapshot/snapshot = H.get_pref_snapshot()
+	var/datum/virtue/origin/O = snapshot?.virtue_origin
 	if(!istype(O))
 		return 1
 	var/agent_realm = origin_name_to_realm_id(O.origin_name)
@@ -93,12 +95,13 @@
 	return min(get_kinship_buy_mult(realm_id), get_agent_kinship_buy_mult(realm_id, user))
 
 /datum/controller/subsystem/merchant_trade/proc/get_agent_personal_kinship_realm(mob/living/carbon/human/H)
-	if(!ishuman(H) || !H.client?.prefs)
+	if(!ishuman(H))
 		return null
 	var/is_agent = (H.job == "Shophand") || HAS_TRAIT(H, TRAIT_AGENT_MERCHANT)
 	if(!is_agent)
 		return null
-	var/datum/virtue/origin/O = H.client.prefs.virtue_origin
+	var/datum/pref_snapshot/snapshot = H.get_pref_snapshot()
+	var/datum/virtue/origin/O = snapshot?.virtue_origin
 	if(!istype(O))
 		return null
 	return origin_name_to_realm_id(O.origin_name)

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -80,15 +80,10 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	if(!flaw)
 		return FALSE
 
-	if(charflaws && charflaws.len)
-		for(var/datum/charflaw/cf in charflaws)
-			if(istype(cf, flaw))
-				return TRUE
-
-	if(client?.prefs?.charflaws && client.prefs.charflaws.len)
-		for(var/datum/charflaw/cf in client.prefs.charflaws)
-			if(istype(cf, flaw))
-				return TRUE
+	// Only ever read the mob's own vices.
+	for(var/datum/charflaw/cf in charflaws)
+		if(istype(cf, flaw))
+			return TRUE
 
 	return FALSE
 
@@ -134,8 +129,10 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	var/datum/job/mob_job = null
 	if(target.mind?.assigned_role)
 		mob_job = SSjob.GetJob(target.mind.assigned_role)
-	else if(target.client?.prefs?.lastclass)
-		mob_job = SSjob.GetJob(target.client.prefs.lastclass)
+	else
+		var/datum/pref_snapshot/snapshot = target.get_pref_snapshot()
+		if(snapshot?.lastclass)
+			mob_job = SSjob.GetJob(snapshot.lastclass)
 
 	if(mob_job && mob_job.vice_restrictions)
 		for(var/key in cf_list)
@@ -877,8 +874,10 @@ GLOBAL_LIST_INIT(averse_factions, list(
 
 /datum/charflaw/averse/apply_post_equipment(mob/user)
 	if(user.mind)
-		if(user.client.prefs?.averse_chosen_faction)
-			set_jobflag(user.client.prefs?.averse_chosen_faction)
+		var/mob/living/carbon/human/H = user
+		var/datum/pref_snapshot/snapshot = ishuman(H) ? H.get_pref_snapshot() : null
+		if(snapshot?.averse_chosen_faction)
+			set_jobflag(snapshot.averse_chosen_faction)
 			is_active = TRUE
 			active_since = world.time
 	if(is_active && user && !QDELETED(user))

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -488,19 +488,20 @@
 	return preload
 
 /datum/outfit/proc/change_origin(mob/living/carbon/human/H, new_origin = /datum/virtue/none, wording = "Custom")
-	var/client/player = H?.client
-	if(player?.prefs)
-		var/origin_memory = player.prefs.virtue_origin
-		player.prefs.virtue_origin = new new_origin
+	// Overrides the origin on the mob's snapshot rather than on client.prefs
+	var/datum/pref_snapshot/snapshot = H?.get_pref_snapshot()
+	if(snapshot)
+		var/origin_memory = snapshot.virtue_origin
+		snapshot.virtue_origin = new new_origin
 		H.dna.species.skin_tone_wording = wording
-		player.prefs.virtue_origin.job_origin = TRUE
-		player.prefs.virtue_origin.last_origin = origin_memory
-		player.prefs.virtue_origin.apply_to_human(H)
-		if(length(player.prefs.virtue_origin.added_languages))
-			for(var/L in player.prefs.virtue_origin.added_languages)
+		snapshot.virtue_origin.job_origin = TRUE
+		snapshot.virtue_origin.last_origin = origin_memory
+		snapshot.virtue_origin.apply_to_human(H)
+		if(length(snapshot.virtue_origin.added_languages))
+			for(var/L in snapshot.virtue_origin.added_languages)
 				H.grant_language(L)
-		if(length(player.prefs.virtue_origin.last_origin.added_languages))
-			for(var/L in player.prefs.virtue_origin.last_origin.added_languages)
-				if(L != player.prefs.extra_language)
+		if(length(snapshot.virtue_origin.last_origin?.added_languages))
+			for(var/L in snapshot.virtue_origin.last_origin.added_languages)
+				if(L != snapshot.extra_language)
 					H.remove_language(L)
-		H.grant_language(player.prefs.extra_language)
+		H.grant_language(snapshot.extra_language)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3181,6 +3181,11 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 		for(var/datum/charflaw/cf in character.charflaws)
 			cf.on_mob_creation(character)
 
+	// Static copy of the player's preferences that cannot change once
+	// they have spawned in. This is to prevent weird edge cases where
+	// reading client preferences might return a difference slot.
+	character.pref_snapshot = new /datum/pref_snapshot(src)
+
 	character.dna.real_name = character.real_name
 
 	character.headshot_link = headshot_link

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -251,9 +251,10 @@
 	if(length(allowed_patrons) && !(H.patron.type in allowed_patrons))
 		return FALSE
 
-	if(length(virtue_limits) && H.client)
+	var/datum/pref_snapshot/snapshot = H.get_pref_snapshot()
+	if(length(virtue_limits) && snapshot)
 		for(var/virtuetype in virtue_limits)
-			if(istype(H.client.prefs?.virtue, virtuetype) || istype(H.client.prefs?.virtuetwo, virtuetype))
+			if(istype(snapshot.virtue, virtuetype) || istype(snapshot.virtuetwo, virtuetype))
 				return FALSE
 
 	var/list/current_vice_limits = get_vice_limits(H)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -165,8 +165,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
 	var/client/player = H?.client
-	if(player.prefs)
-		if(!istype(player.prefs.virtue_origin, /datum/virtue/origin/azuria) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/grenzelhoft) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/otava) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/etrusca))
+	var/datum/pref_snapshot/snapshot = H?.get_pref_snapshot()
+	if(snapshot)
+		if(!istype(snapshot.virtue_origin, /datum/virtue/origin/azuria) && !istype(snapshot.virtue_origin, /datum/virtue/origin/grenzelhoft) && !istype(snapshot.virtue_origin, /datum/virtue/origin/otava) && !istype(snapshot.virtue_origin, /datum/virtue/origin/etrusca))
 			var/list/new_origins = list("Azuria" = /datum/virtue/origin/azuria,
 			"Grenzelhoft" = /datum/virtue/origin/grenzelhoft,
 			"Otava" = /datum/virtue/origin/otava,

--- a/code/modules/jobs/job_types/roguetown/nobility/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/prince.dm
@@ -41,8 +41,9 @@
 /datum/outfit/job/roguetown/heir/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
 	var/client/player = H?.client
-	if(player.prefs)
-		if(!istype(player.prefs.virtue_origin, /datum/virtue/origin/azuria) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/grenzelhoft) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/otava) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/etrusca))
+	var/datum/pref_snapshot/snapshot = H?.get_pref_snapshot()
+	if(snapshot)
+		if(!istype(snapshot.virtue_origin, /datum/virtue/origin/azuria) && !istype(snapshot.virtue_origin, /datum/virtue/origin/grenzelhoft) && !istype(snapshot.virtue_origin, /datum/virtue/origin/otava) && !istype(snapshot.virtue_origin, /datum/virtue/origin/etrusca))
 			var/list/new_origins = list("Azuria" = /datum/virtue/origin/azuria,
 			"Grenzelhoft" = /datum/virtue/origin/grenzelhoft,
 			"Otava" = /datum/virtue/origin/otava,

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1142,5 +1142,5 @@
 	vocal_speed = client.prefs.bark_speed
 	vocal_pitch = client.prefs.bark_pitch
 	vocal_pitch_range = client.prefs.bark_variance
-	apply_voicepacks(src, client)
+	apply_voicepacks(src, client.prefs.voice_pack)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -204,6 +204,9 @@
 
 	var/list/charflaws = list()
 
+	/// Spawn-time copy of the character-setup preferences this mob was built from. See /datum/pref_snapshot.
+	var/datum/pref_snapshot/pref_snapshot
+
 	var/list/feint_list = list()
 
 	/// curse list and cooldown

--- a/code/modules/roguetown/roguemachine/merchant/trade/merchant_catalog.dm
+++ b/code/modules/roguetown/roguemachine/merchant/trade/merchant_catalog.dm
@@ -92,9 +92,10 @@
 	return TRUE
 
 /datum/controller/subsystem/merchant_trade/proc/catalog_origin_access(datum/merchant_catalog/C, mob/living/carbon/human/H)
-	if(!istype(C) || !C.home_origin_name || !ishuman(H) || !H.client?.prefs)
+	if(!istype(C) || !C.home_origin_name || !ishuman(H))
 		return FALSE
-	var/datum/virtue/origin/O = H.client.prefs.virtue_origin
+	var/datum/pref_snapshot/snapshot = H.get_pref_snapshot()
+	var/datum/virtue/origin/O = snapshot?.virtue_origin
 	if(!istype(O))
 		return FALSE
 	return O.origin_name == C.home_origin_name

--- a/code/modules/virtues/_virtue.dm
+++ b/code/modules/virtues/_virtue.dm
@@ -196,7 +196,8 @@ GLOBAL_LIST_EMPTY(virtues)
 		record_featured_object_stat(FEATURED_STATS_ORIGINS, virtue_type.name)
 	else
 		var/stacked = FALSE
-		if(istype(recipient.client?.prefs?.virtue, recipient.client?.prefs?.virtuetwo))
+		var/datum/pref_snapshot/snapshot = recipient.get_pref_snapshot()
+		if(snapshot?.virtuetwo && istype(snapshot.virtue, snapshot.virtuetwo))
 			stacked = TRUE
 		record_featured_object_stat(FEATURED_STATS_VIRTUES, (stacked ? "[virtue_type.name] (Stacked)" : virtue_type.name), stacked ? 0.5 : 1)
 /datum/virtue/none


### PR DESCRIPTION


## About The Pull Request

Not really any user facing changes.

Adds a frozen copy of char preferences from setup to be used in place of a client's current active preferences. This touches a lot of things to do with client preferences so this may need to be TM to be entirely safe.

## Testing Evidence

It's sort of difficult to really record what this is doing, but, I joined as a Knight and change my slot before choosing my weapons. It still applies the traits from my previous slot.

Changing your vice midround also no longer allows you to switch to be able to suddenly see lovesick/alcoholic people on the fly either.

## Why It's Good For The Game

Weird edge case bugs that most people probably haven't noticed. Fixes #8518 

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adds /datum/pref_snapshot to be used in place of a client's live preferences.
fix: Fixes being able to switch your character's vices/virtues by changing your slot while spawning in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
