### PR TITLE
Fixing a past fix that kinda worked but also kinda didn't

### DIFF
--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -273,6 +273,11 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 		affected.death()
 	if(shatter_wound && HAS_TRAIT(affected, TRAIT_SHATTER_KILL))
 		affected.death()
+	// wounds bad enough to have 0 sleepheal kill way faster than you can sleep them off anyway... for everyone BUT
+	// deathless/deadite-immune players, who also have a good chance of being RRd by them if they die in a random cave
+	// so we let them sleepheal over a really long time to prevent that kind of softlock
+	if(!sleep_healing && (HAS_TRAIT(affected, TRAIT_ZOMBIE_IMMUNE) || HAS_TRAIT(affected, TRAIT_DEATHLESS)))
+		sleep_healing = 0.5
 
 /// Removes this wound from a given, simpler than adding to a bodypart - No extra effects
 /datum/wound/proc/remove_from_mob()

--- a/code/datums/wounds/types/arteries.dm
+++ b/code/datums/wounds/types/arteries.dm
@@ -17,7 +17,7 @@
 	can_sew = TRUE
 	can_cauterize = TRUE
 	critical = TRUE
-	sleep_healing = 0.5
+	sleep_healing = 0.5 // this needs to not be zero so that getting arteried in a cave isn't an RR for deadite-immune players; arteries still kill way faster than you can sleepheal them for everyone else
 	embed_chance = 75
 
 	werewolf_infection_probability = 100

--- a/code/datums/wounds/types/arteries.dm
+++ b/code/datums/wounds/types/arteries.dm
@@ -17,7 +17,7 @@
 	can_sew = TRUE
 	can_cauterize = TRUE
 	critical = TRUE
-	sleep_healing = 0.5 // this needs to not be zero so that getting arteried in a cave isn't an RR for deadite-immune players; arteries still kill way faster than you can sleepheal them for everyone else
+	sleep_healing = 0
 	embed_chance = 75
 
 	werewolf_infection_probability = 100

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -614,7 +614,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 				blood_volume = min(blood_volume + (4 * sleepy_mod), BLOOD_VOLUME_NORMAL)
 			for(var/obj/item/bodypart/affecting as anything in bodyparts)
 				//for context, it takes 5 small cuts (0.2 x 5) or 3 normal cuts (0.4 x 3) for a bodypart to not be able to heal itself
-				if(affecting.get_bleed_rate() >= 1)
+				if(affecting.get_bleed_rate() >= 1 && !HAS_TRAIT(src, TRAIT_ZOMBIE_IMMUNE)) // however, if you're undead - and therefore won't deadite - we let you get back up after a VERY long time, bcs otherwise any artery can be an RR
 					continue
 				if(affecting.heal_damage(sleepy_mod, sleepy_mod, required_status = BODYPART_ORGANIC))
 					src.update_damage_overlays()


### PR DESCRIPTION
## About The Pull Request
In #7703 , we caused artery wounds to be sleephealable - this is because for deadite immune players, being arteried in a cave could effectively just be an RR. if you get arteried, and have NOBLOOD and deadite immune, you could sleep it off over a period of like, an hour or two - theoretically. however, i've just discovered that that fix was actually not working because of another mechanic: limbs that are bleeding too much skip healing their wounds entirely. i've just added a check for deadite immunity to disable that mechanic (as pointed out in the last pr, bleeding wounds kill so fast and heal so slowly that this won't significantly impact people's ability to get back in a fight - it genuinely takes _forever_ to sleepheal off bleeds), as well as added comments explaining why as suggested by free last time

i've also changed it to be a more futureproof impl - instead of changing sleepheal values globally, i just added a sleepheal floor of 0.5 when wounds are applied to folks with deathless/deadite immunity 

## Testing Evidence
it's. pretty hard to test this because i would have to sit in deathcrit for like an hour.

## Why It's Good For The Game
same as last time; deaditing is our anti-RR feature for if you die somewhere nobody will find you. deadite immune potentially nukes that, so i feel it's a pretty safe shot to say you should be able to sleep for an hour or two and get back up so it's only half an RR if you eat shit and die in a random cave

## Changelog

:cl:
fix: Deadite immune players can now sleepheal even the most severe of wounds, over a long period of time, preventing them from being effectively RRd by dying in a random cave
/:cl:
