### PR TITLE
nerfs demolition intent on easier to acquire weapons

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -73,8 +73,19 @@
 	clickcd = CLICK_CD_HEAVY
 	swingdelay = 10
 
-/datum/intent/mace/demolish/lesser
-	demolition_mod = 2.5
+/datum/intent/mace/lesserdemolish
+	name = "break"
+	desc = "A deliberate structure-breaking blow. Deals triple the damage to structures"
+	icon_state = "incrush"
+	blade_class = BCLASS_SMASH
+	attack_verb = list("demolishes", "crushes", "wrecks")
+	animname = "strike"
+	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
+	item_d_type = "blunt"
+	penfactor = PEN_NONE
+	demolition_mod = 3
+	clickcd = CLICK_CD_HEAVY
+	swingdelay = 10
 
 /datum/intent/mace/rangedthrust
 	name = "thrust"
@@ -1297,7 +1308,7 @@
 	force = 13
 	force_wielded = 25
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/bash/ranged)
-	gripped_intents = list(/datum/intent/use, /datum/intent/mace/strike, /datum/intent/mace/strike/dislocate, /datum/intent/mace/demolish/lesser)
+	gripped_intents = list(/datum/intent/use, /datum/intent/mace/strike, /datum/intent/mace/strike/dislocate, /datum/intent/mace/lesserdemolish)
 	minstr = 8
 	max_integrity = 350
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -339,7 +339,7 @@
 	name = "bogbark club"
 	desc = "A primitive cudgel carved of a stout piece of treefall, from the deepest parts of the Terrorbog. An unmistakable aura of power surrounds it. This thing looks dangerously strong."
 	aura_color = "#00ff00"
-	gripped_intents = list(/datum/intent/mace/strike/wood/, /datum/intent/mace/smash/wood, /datum/intent/effect/daze, /datum/intent/mace/demolish)
+	gripped_intents = list(/datum/intent/mace/strike/wood/, /datum/intent/mace/smash/wood, /datum/intent/effect/daze, /datum/intent/mace/lesserdemolish)
 	w_class = WEIGHT_CLASS_NORMAL // it's just a stick, can put it in your backpack
 
 /obj/item/rogueweapon/mace/woodclub


### PR DESCRIPTION
## About The Pull Request
Large wrench demolish intent now deals about 75 damage (from 62) to objects, without a 15% flat damage to structures
Militia wood club (Levy's bogstick) now deals 54 damage (from 63) to objects, without a 15% flat damage to structures

this is in comparison to the recently nerfed Psydonic Maul, which deals 135 damage to objects, with a flat 15% bonus to structures


## Testing Evidence

<img width="303" height="190" alt="{CA5ADF23-E3CF-44F3-AD31-F6DA00E02E86}" src="https://github.com/user-attachments/assets/2b5924ab-a642-47c6-9353-1d457c1fcd05" />

## Why It's Good For The Game
I balanced wrenches with downstream sensibilities in mind. https://github.com/Azure-Peak/Azure-Peak/pull/8649 alerted me to the fact that Demolish intent may be the cause of some issues upstream.

This PR nerfs both instances of demolish intent on easy acquire weapons- removing the 15% integrity scaling, and scaling the damage mult down to 3x. This covers big battle-wrenches and Bogbark Clubs

I don't necessarily think it's good for the game- feel free to close this if you don't think it's a good option. I prefer this not be merged, but believe it's prudent to put forwards regardless, if demolition intent has been an issue
## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: nerfs bogbark club and battle-wrench demolition intent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
