### PR TITLE
[QoL] Makes resident adventurers not hide their title

### DIFF
--- a/code/game/objects/items/rogueitems/skillbooks.dm
+++ b/code/game/objects/items/rogueitems/skillbooks.dm
@@ -44,7 +44,7 @@
 		return
 	var/author_job = H.advjob ? H.advjob : "Adventurer"
 	var/datum/job/J = SSjob.GetJob(H.job)
-	if (J.obsfuscated_job || J.wanderer_examine)
+	if (J.obsfuscated_job || (J.wanderer_examine && !(HAS_TRAIT(H, TRAIT_RESIDENT))))
 		author_job = "Adventurer"
 	if(!(H.real_name in authors))
 		authors[H.real_name] = author_job

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -790,7 +790,7 @@
 				display_as_wanderer = TRUE
 		else if(job)
 			var/datum/job/J = SSjob.GetJob(job)
-			if(!J || J.wanderer_examine)
+			if(!J || (J.wanderer_examine && !(HAS_TRAIT(src, TRAIT_RESIDENT))))
 				display_as_wanderer = TRUE
 		var/displayed_headshot
 		var/datum/antagonist/vampire/vampireplayer = src.mind?.has_antag_datum(/datum/antagonist/vampire)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Makes adventurers with residency no longer hide their job on examine and authoring books.

House job is still anonamized to adventurer, not because I did not wanted to change that, but because its used to protect antagonists. (I suspect this is unnesesary, as those that would get resident do have things that handle their job already, but I didnt want to handle the testing for all)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

resident:

<img width="429" height="240" alt="image" src="https://github.com/user-attachments/assets/b2831f0d-eaac-4e29-9cf6-776cd5460a34" />

<img width="626" height="273" alt="image" src="https://github.com/user-attachments/assets/706ed086-081e-4e8f-ab19-7d9129dbd5ae" />


not resident:

<img width="442" height="193" alt="image" src="https://github.com/user-attachments/assets/c0c8c5a6-b77b-457c-945e-5f81253f38b4" />

<img width="625" height="290" alt="image" src="https://github.com/user-attachments/assets/a2cb292a-0358-45f5-9c5b-06e0f0d3ec22" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

More making those that take the resident virtue part of the actual town and not an stadistic, integrating people better and letting others at a glance tell they are part of the town.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Resident adventurers now show their job title in examine and when autoring books (unless they use a pen name of course)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
