### PR TITLE
Charred no longer chain on Pyromancy. Adaptation is now 6 seconds instead of 3 seconds.

### DIFF
--- a/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
@@ -1,4 +1,4 @@
-#define SCORCH_ADAPTATION_DURATION (3 SECONDS)
+#define SCORCH_ADAPTATION_DURATION (6 SECONDS)
 #define SCORCH_ADAPTATION_KEY "scorch_adaptation"
 #define SCORCH_OVERLAY_COLOR rgb(255, 138, 61)
 #define SCORCH_BURN_DAMAGE 60
@@ -16,13 +16,15 @@
 	var/final_tier = 0
 	for(var/i in 1 to stacks)
 		if(target.has_status_effect(/datum/status_effect/debuff/scorched4))
-			apply_scorch_burn(target, zone_override)
+			if(apply_scorch_burn(target, zone_override))
+				remove_all_scorch_stacks(target)
 			final_tier = 4
 			break
 		if(target.has_status_effect(/datum/status_effect/debuff/scorched3))
 			target.remove_status_effect(/datum/status_effect/debuff/scorched3)
 			target.apply_status_effect(/datum/status_effect/debuff/scorched4)
-			apply_scorch_burn(target, zone_override)
+			if(apply_scorch_burn(target, zone_override))
+				remove_all_scorch_stacks(target)
 			final_tier = 4
 			break
 		if(target.has_status_effect(/datum/status_effect/debuff/scorched2))


### PR DESCRIPTION
## About The Pull Request
Charred can no longer stacks, you must rebuild the scorch stacks after it procs. Adaptation is now 6 seconds instead of 3 seconds.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested locally

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
NOT INTENDED.

Thank you for reporting this.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Charred can no longer stacks, you must rebuild the scorch stacks after it procs. Adaptation is now 6 seconds instead of 3 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
