### PR TITLE
unarmed dualwield fix

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -38,6 +38,8 @@
 //			src.emote("attackgrunt")
 		if(used_intent.releasedrain)
 			stamina_add(ceil(used_intent.releasedrain * rmb_stam_penalty))
+		if(HAS_TRAIT(src, TRAIT_DUALWIELDER))
+			src.process_dualwield(L, null, null)
 		if(L.has_status_effect(/datum/status_effect/buff/clash) && L.get_active_held_item() && ishuman(L))
 			var/mob/living/carbon/human/H = L
 			var/obj/item/IM = L.get_active_held_item()

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -39,7 +39,7 @@
 		if(used_intent.releasedrain)
 			stamina_add(ceil(used_intent.releasedrain * rmb_stam_penalty))
 		if(HAS_TRAIT(src, TRAIT_DUALWIELDER))
-			src.process_dualwield(L, null, null)
+			process_dualwield(L, null, null)
 		if(L.has_status_effect(/datum/status_effect/buff/clash) && L.get_active_held_item() && ishuman(L))
 			var/mob/living/carbon/human/H = L
 			var/obj/item/IM = L.get_active_held_item()


### PR DESCRIPTION
## About The Pull Request

fixed dual wielder not working on unarmed attacks

## Testing Evidence

did tests on local server, trust me bro

## Why It's Good For The Game
Since knuckles became gloves there was no good way to play unarmed dualwielder anymore (except using things like katars but it's not unarmed anymore) and there is no actual reason for that, code even had checks for unarmed but was incomplete. I did complete it

## Changelog
added 2 whole lines to code, sheesh

:cl:
add: Added new mechanics or gameplay changes
/:cl:

