### PR TITLE
Hefty swing for silver one-handed axes

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -267,7 +267,7 @@
 	thrown_damage_flag = "piercing"
 	minstr = 8
 	smeltresult = /obj/item/ingot/silver
-	special = /datum/special_intent/axe_swing //Cannot be wielded, otherwise.
+	special = /datum/special_intent/axe_swing/graggarite //Cannot be wielded, otherwise.
 	is_tool = FALSE
 	is_silver = TRUE
 	resistance_flags = FIRE_PROOF
@@ -295,7 +295,7 @@
 	thrown_damage_flag = "piercing"
 	minstr = 8
 	smeltresult = /obj/item/ingot/silverblessed
-	special = /datum/special_intent/axe_swing //Cannot be wielded, otherwise.
+	special = /datum/special_intent/axe_swing/graggarite //Cannot be wielded, otherwise.
 	is_tool = FALSE
 	is_silver = TRUE
 	resistance_flags = FIRE_PROOF
@@ -466,7 +466,7 @@
 	wdefense = 5
 	is_silver = TRUE
 	blade_dulling = DULLING_SHAFT_METAL
-	special = /datum/special_intent/axe_swing //Cannot be wielded, otherwise.
+	special = /datum/special_intent/axe_swing/graggarite //Cannot be wielded, otherwise.
 	resistance_flags = FIRE_PROOF
 
 /obj/item/rogueweapon/stoneaxe/woodcut/silver/ComponentInitialize()
@@ -492,7 +492,7 @@
 	blade_dulling = DULLING_SHAFT_METAL
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
-	special = /datum/special_intent/axe_swing //Cannot be wielded, otherwise.
+	special = /datum/special_intent/axe_swing/graggarite //Cannot be wielded, otherwise.
 	resistance_flags = FIRE_PROOF
 
 /obj/item/rogueweapon/stoneaxe/battle/psyaxe/ComponentInitialize()


### PR DESCRIPTION
## About The Pull Request

You can now use hefty swing on silver one-handed axes

## Testing Evidence

tested on local trust pls

## Why It's Good For The Game
You can now use axe special on silver one-handed axes. I don't really know was it intended or not in the first place, you do have special in description, you do get message to contact coders when trying to use it, but you also can't do it on any other one-handed axe. Comment "Cannot be wielded, otherwise." sounds like a riddle im not willing to solve today
## Changelog
replaced default axe_swing for axe_swing/graggarite on silver one-handed axes (except tomahawk)
:cl:
balance: rebalanced something
fix: fixed a few things
code: changed some code
/:cl:

