### PR TITLE
[BUGFIX?] Arcyne Katar Correction

### DIFF
--- a/code/modules/spells/spell_types/classunique/spellfist/blade_of_psydon.dm
+++ b/code/modules/spells/spell_types/classunique/spellfist/blade_of_psydon.dm
@@ -81,7 +81,7 @@
 	associated_skill = /datum/skill/combat/unarmed
 	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'
 	wdefense = 0
-	wbalance = WBALANCE_SWIFT
+	wbalance = WBALANCE_NORMAL
 	can_parry = TRUE
 
 /obj/item/melee/touch_attack/rogueweapon/bladeofpsydon/attack_self()


### PR DESCRIPTION
## About The Pull Request
SWIFT balance was removed from katars from the main katar item pathway.

However, Arcyne Katars do not use "/obj/item/rogueweapon/katar" as part of their hierarchy, so this change never reached the Arcyne Katar. 

I cannot find any documentation about the Arcyne Katar keeping SWIFT balance for any reason. This seems like a clear oversight. It's just odd how this one and only katar is different from the rest.

This oversight is similar to my last bugfix, where item hierarchy is not considered or overlooked. I'll keep an eye out for more of these.

## Testing Evidence
Compiled.

This is a one-line code change. If proof is needed, I will post in-game screenshots.

## Why It's Good For The Game
Makes katars consistent and fixes a bug since Arcane Katar code has not been touched in 14 months. This is a clear oversight.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Arcyne Katars have been given more arcyne weight, making them no longer swift. The mage university thought this was a good idea.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
