### PR TITLE
[Bugfix] changes thin winter dress path, adds crafting recipe

### DIFF
--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -84,8 +84,8 @@
 	sort_category = "Triumphs"
 
 /datum/loadout_item/triumph_winterdress
-	name = "Winter Dress"
-	path = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/triumph
+	name = "Thin Winter Dress"
+	path = /obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress/triumph
 	triumph_cost = 3
 	sort_category = "Triumphs"
 

--- a/code/modules/clothing/rogueclothes/armor/armordress.dm
+++ b/code/modules/clothing/rogueclothes/armor/armordress.dm
@@ -51,20 +51,6 @@
 			pic.color = get_detail_color()
 		add_overlay(pic)
 
-/obj/item/clothing/suit/roguetown/armor/armordress/winterdress/triumph
-	name = "thin winter dress"
-	desc = "A thinner, well-frilled and cozy winter dress for the nobles."
-	armor = ARMOR_CLOTHING
-	grid_height = 64
-
-/obj/item/clothing/suit/roguetown/armor/armordress/winterdress/triumph/azure
-	detail_color = COLOR_WHITE
-	color = COLOR_WHITE
-
-/obj/item/clothing/suit/roguetown/armor/armordress/winterdress/triumph/raneshen
-	detail_color = COLOR_RED
-	color = COLOR_WHITE
-
 /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch //For the consort and apparently one migrant wave
 	desc = "A thick, padded, and comfortable dress to maintain both temperature and safety when leaving the keep."
 	armor = ARMOR_PADDED

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -1007,3 +1007,31 @@
 	color = CLOTHING_WHITE
 	detail_color = CLOTHING_WHITE
 
+/obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress
+	name = "winter dress"
+	icon = 'icons/roguetown/clothing/shirts_royalty.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts_royalty.dmi'
+	desc = "A thin and light version of a comfortable dress popular amongst nobility during winter."
+	body_parts_covered = COVERAGE_ALL_BUT_HANDFEET
+	icon_state = "winterdress"
+	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts_royalty.dmi'
+	boobed = TRUE
+	detail_tag = "_detail"
+	detail_color = CLOTHING_BLACK
+	r_sleeve_status = SLEEVE_NORMAL
+	l_sleeve_status = SLEEVE_NORMAL
+	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
+	salvage_result = /obj/item/natural/silk
+	salvage_amount = 2
+
+/obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress/triumph
+	detail_color = CLOTHING_BLACK
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress/azure
+	detail_color = CLOTHING_WHITE
+	color = CLOTHING_AZURE
+
+/obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress/raneshen
+	detail_color = CLOTHING_WHITE
+	color = CLOTHING_RED

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -1008,7 +1008,7 @@
 	detail_color = CLOTHING_WHITE
 
 /obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress
-	name = "winter dress"
+	name = "thin winter dress"
 	icon = 'icons/roguetown/clothing/shirts_royalty.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts_royalty.dmi'
 	desc = "A thin and light version of a comfortable dress popular amongst nobility during winter."

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -72,7 +72,7 @@
 					pants = /obj/item/clothing/under/roguetown/trou/beltpants
 					shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
 				if(should_wear_femme_clothes(H))
-					shirt = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/triumph/azure
+					shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress/azure
 					shoes = /obj/item/clothing/shoes/roguetown/boots
 				cloak = /obj/item/clothing/cloak/half/azure
 				head = /obj/item/clothing/head/roguetown/chaperon/noble
@@ -154,7 +154,7 @@
 				if(should_wear_masc_clothes(H))
 					armor = /obj/item/clothing/cloak/tabard/stabard/dungeon
 				if(should_wear_femme_clothes(H))
-					armor = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/triumph/raneshen
+					armor = /obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress/raneshen
 				shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/raneshen //Shittier version with regular gambeson protection levels
 				pants = /obj/item/clothing/under/roguetown/trou/leather/pontifex/raneshen

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -1573,6 +1573,16 @@
 	tools = list(/obj/item/needle)
 	craftdiff = 5
 
+/datum/crafting_recipe/roguetown/sewing/thinwinterdress
+	name = "thin winter dress"
+	category = "Dresses"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/tunic/thinwinterdress)
+	reqs = list(/obj/item/natural/cloth = 2, //cheaper because it is the unarmored clothing version
+				/obj/item/natural/fibers = 2,
+				/obj/item/natural/silk = 2)
+	tools = list(/obj/item/needle)
+	craftdiff = 5
+
 /datum/crafting_recipe/roguetown/sewing/skirt
 	name = "skirt"
 	category = "Misc"


### PR DESCRIPTION
## About The Pull Request

I noticed a weird interaction with the triumph winter dress and arcyne ward. Looking at the code, the winter dress was a type of armor but set to clothing. Rather than figure out that interaction I just repathed the non-armor version of the winter dress into shirt, and also added a crafting recipe for the thin variant.

## Testing Evidence

<img width="668" height="49" alt="image" src="https://github.com/user-attachments/assets/308f39e7-d2e1-4c84-8e0f-2843fecbbd9d" />


<img width="480" height="327" alt="image" src="https://github.com/user-attachments/assets/2fbbaa35-75d6-4b06-b764-3c385404db5f" />


<img width="518" height="376" alt="image" src="https://github.com/user-attachments/assets/94742d84-047a-460f-99d2-285778159072" />

Regular padded winter dress still works just fine

<img width="228" height="125" alt="image" src="https://github.com/user-attachments/assets/c8329cb2-5057-4ccb-949a-139b7e5dd1c0" />

Thin winter dress now no longer blocks arms from being protected by arcyne ward.

## Why It's Good For The Game

Fixes a bug and adds a crafting recipe

## Changelog

:cl: racobio
add: Adds a recipe to craft the thin winter dress
fix: fixes an arcyne ward interaction with the thin winter dress by repathing it
/:cl: