### PR TITLE
fixes a wrench bug i missed whilst testing

### DIFF
--- a/code/game/objects/items/contraption.dm
+++ b/code/game/objects/items/contraption.dm
@@ -184,9 +184,9 @@
 	playsound(src, 'sound/misc/clockloop.ogg', 25, TRUE)
 
 /obj/item/rogueweapon/contraption/attack_obj(obj/O, mob/living/user)
+	if(brute_attack && (user.used_intent.type != /datum/intent/use))
+		return ..()
 	if(!current_charge)
-		if(brute_attack && (user.used_intent.type != /datum/intent/use))
-			return ..()
 		flick(off_icon, src)
 		to_chat(user, span_info("The contraption beeps! It requires \a [initial(accepted_power_source.name)]!"))
 		playsound(src, 'sound/magic/magic_nulled.ogg', 100, TRUE)

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -1279,7 +1279,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 32
 	grid_height = 64
-	possible_item_intents = list(/datum/intent/use, /datum/intent/mace/strike, /datum/intent/mace/strike/dislocate)
+	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/use, /datum/intent/mace/strike/dislocate)
 	force = 20
 	max_integrity = 200
 	dropshrink = 0.8
@@ -1308,7 +1308,7 @@
 	force = 13
 	force_wielded = 25
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/bash/ranged)
-	gripped_intents = list(/datum/intent/use, /datum/intent/mace/strike, /datum/intent/mace/strike/dislocate, /datum/intent/mace/lesserdemolish)
+	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/use, /datum/intent/mace/strike/dislocate, /datum/intent/mace/lesserdemolish)
 	minstr = 8
 	max_integrity = 350
 	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
## About The Pull Request
during testing, i tested wrenches with and without charges on attacking mobs, and without charges on attacking objects. I failed to test them with charges on attacking objects. This fixes a bug where wrenches with charges cannot attack objects
also re-orders intents, so default intent on weapon-wrenches is STRIKE, instead of USE

## Testing Evidence
<img width="302" height="175" alt="{ED3B10E0-1E0B-4D73-B79B-F4606B0BA3FD}" src="https://github.com/user-attachments/assets/06156ab9-603c-4e16-831d-33316dbf7f21" />
## Why It's Good For The Game
bugfix
## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: wrenches with charges can now attack objects
qol: battle-wrenches default to STRIKE instead of USE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
