### PR TITLE
[Cl*ss Addition] Adds the alchemist as adventurer

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -39,7 +39,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/mage
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/reagent_containers/glass/bottle/rogue/manapot
+	beltr = /obj/item/storage/magebag
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/satchel
@@ -48,7 +48,8 @@
 		backr = choose_implement(H, "lesser")
 		backpack_contents = list(
 			/obj/item/rogueweapon/spellbook = 1,
-			/obj/item/chalk = 1
+			/obj/item/chalk = 1,
+			/obj/item/reagent_containers/glass/bottle/rogue/manapot = 1
 			)
 	backpack_contents |= list(
 		/obj/item/flashlight/flare/torch = 1,
@@ -58,6 +59,64 @@
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'
+
+/datum/advclass/mage/alchemist
+	name = "Alchemist"
+	tutorial = "You are an alchemist of the road, traveling the world in search of rare reagents, forgotten recipes, \
+	and opportunities to put your craft to the test. You trade in potions, powders, and peculiar concoctions, turning \
+	the spoils of your adventures into something useful. Every monster, ruin, and strange plant might be the key \
+	ingredient to your next creation. Just be careful what you mix together. Some things have a tendency to explode."
+	outfit = /datum/outfit/job/roguetown/adventurer/alchemist
+	traits_applied = list(TRAIT_ALCHEMY_EXPERT,TRAIT_SEEDKNOW, TRAIT_ARCYNE)
+	subclass_stats = list(
+		STATKEY_INT = 3,
+		STATKEY_PER = 3,
+		STATKEY_WIL = 1
+	)
+	age_mod = /datum/class_age_mod/apprentice_alchemist
+	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 1, "utilities" = 6, "ward" = TRUE)
+	subclass_skills = list(
+		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/arcyne = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
+		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/farming = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/cooking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/mining = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/fishing = SKILL_LEVEL_NOVICE,
+	)
+
+/datum/outfit/job/roguetown/adventurer/alchemist/pre_equip(mob/living/carbon/human/H)
+	..()
+	to_chat(H, span_warning("You are an alchemist traveling the world in search of rare reagents and new discoveries. You turn the spoils of your adventures into strange and useful concoctions."))
+	head = /obj/item/clothing/head/roguetown/roguehood/black
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	pants = /obj/item/clothing/under/roguetown/tights/black
+	shirt = /obj/item/clothing/suit/roguetown/shirt/robe/mageyellow
+	belt = /obj/item/storage/belt/rogue/leather/black
+	backl = /obj/item/storage/backpack/rogue/satchel
+	backr = /obj/item/storage/backpack/rogue/satchel
+	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+	beltl = /obj/item/storage/magebag
+	beltr = /obj/item/flashlight/flare/torch/lantern
+	backpack_contents = list(
+		/obj/item/paper/scroll = 3,
+		/obj/item/natural/feather = 1,
+		/obj/item/roguegem/amethyst = 1,
+		/obj/item/rogueweapon/spellbook = 1,
+		/obj/item/chalk = 1,
+		/obj/item/rogueweapon/huntingknife/idagger = 1,
+		/obj/item/rogueweapon/scabbard/sheath = 1,
+		)
+
 
 /datum/advclass/mage/spellblade
 	name = "Azurcaephan"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Adds the Alchemist, based on the alchemist associate, to the adventurer mage.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="837" height="865" alt="image" src="https://github.com/user-attachments/assets/ed8225e6-d907-4d31-a081-0e6aaf9fcfca" />

<img width="694" height="837" alt="image" src="https://github.com/user-attachments/assets/8564c22d-2732-42aa-a3f4-5465d66a9a66" />

<img width="879" height="981" alt="image" src="https://github.com/user-attachments/assets/722a380a-d48f-485b-a9fc-f0c70a3f35f2" />

<img width="1122" height="741" alt="image" src="https://github.com/user-attachments/assets/294160f5-1360-4861-a574-5cff02cb2410" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

With the witch new ruling, we have a pletora of characters that must be on the university, a role already limited and generally used to learn about magic. This proposal would allow to revive an underused role with an already tried and true balance that the alchemy associate has, albeit, without the resources usually needed to mount a laboratory, something the university alchemy already has outfited, as well as a base, salary and other protections, such basics will be needed to be taken as virtues by the players that desire it, or work some other way to get them.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adds the Alchemist, based on the alchemist associate, to the adventurer mage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
