### PR TITLE
[hotfix] announce edgecase fix

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -23,7 +23,7 @@
 			return
 
 		to_chat(M, announcement)
-		if (M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
+		if (M.client?.prefs?.toggles & SOUND_ANNOUNCEMENTS)
 			if (!sound)
 				return
 			M.playsound_local(M, s, 100)
@@ -35,7 +35,7 @@
 	for(var/mob/M in GLOB.player_list)
 		if(M.can_hear())
 			to_chat(M, "<span class='big bold'><font color = purple>[html_encode(title)]</font color><BR>[html_encode(message)]</span><BR>")
-			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
+			if(M.client?.prefs?.toggles & SOUND_ANNOUNCEMENTS)
 				if(alert)
 					M.playsound_local(M, 'sound/misc/alert.ogg', 100)
 				else


### PR DESCRIPTION
## About The Pull Request
Apparently in some circumstances i could not reproduce GLOB.player_list could contain uncliented mobs. This would break announcements with a runtime as they assumed the list of cliented mobs would in fact contain, cliented mobs. How naïve. Couldn't actually figure out what was causing that assumption to break but we have the ?. operator we don't need to make it in the first place.

## Testing Evidence
you're going to just have to trust the ?. operator to do its job here i can't repro the initial bug and therefore can't test the fix

## Why It's Good For The Game
announcements randomly breaking is probably bad

## Changelog

:cl:
fix: Fixed a runtime relating to throne announcements.
/:cl:
