### PR TITLE
Broom now sweeps in a 3x3 AOE and scales inversely to Cooking skills

### DIFF
--- a/code/game/objects/items/rogueitems/broom.dm
+++ b/code/game/objects/items/rogueitems/broom.dm
@@ -1,6 +1,6 @@
 /obj/item/broom
 	name = "broom"
-	desc = "A robust-looking broom, made from a bundle of twigs. Sweep away debris, glass, blood, dirt, and time without a care in the world."
+	desc = "A robust-looking broom, made from a bundle of twigs. Sweep a wide swathe of floor clear of debris, glass, blood, dirt, and time without a care in the world."
 	icon = 'icons/roguetown/weapons/tools.dmi'
 	icon_state = "broom"
 	possible_item_intents = list(/datum/intent/use, /datum/intent/mace/strike/wood)
@@ -30,6 +30,13 @@
 				return list("shrink" = 0.6,"sx" = 4,"sy" = -2,"nx" = -3,"ny" = -2,"wx" = -5,"wy" = -1,"ex" = 3,"ey" = -2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 7,"sturn" = -7,"wturn" = 16,"eturn" = -22,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
 			if("onback")
 				return list("shrink" = 0.5,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
+
+/obj/item/broom/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("Sweeping time scales inversely to Cooking skill.")
+
+/obj/item/broom/proc/sweep_time(mob/living/user)
+	return max(20 - user.get_skill_level(/datum/skill/craft/cooking) * 2.5, 5)
 
 /obj/item/broom/proc/sweep_message(atom/A, mob/living/user)
 	user.visible_message(span_notice("[user] dutifully sweeps \the [A]."), span_notice("I dutifully sweep \the [A]."))
@@ -64,7 +71,7 @@
 		O.take_damage(200, BRUTE, "blunt", FALSE)
 		playsound(loc, "smashlimb", 50, FALSE)
 		return
-	if(!do_after(user, 15, target = O))
+	if(!do_after(user, sweep_time(user), target = O))
 		return
 	sweep_message(O, user)
 	playsound(user, "clothwipe", 100, TRUE)
@@ -75,14 +82,28 @@
 		return ..()
 	if(istype(T, /turf/open/lava) || istype(T, /turf/open/water))
 		return
-	if(!do_after(user, 20, target = T))
+	if(!do_after(user, sweep_time(user), target = T))
 		return
 	sweep_message(T, user)
 	playsound(user, 'sound/items/broom_sweep.ogg', 150, TRUE)
-	broom_fu(T)
 	gather_clutter(T, user)
-	for(var/obj/O in T)
-		broom_fu(O)
+	sweep_area(T)
+
+/obj/item/broom/proc/sweep_area(turf/center)
+	var/washed = 0
+	var/max_washes = 75
+	for(var/turf/T in range(1, center))
+		if(washed >= max_washes)
+			break
+		broom_fu(T)
+		wash_atom(T, CLEAN_MEDIUM)
+		washed++
+		for(var/atom/A in T)
+			if(washed >= max_washes)
+				break
+			if(istype(A, /obj/effect/decal/cleanable) || ismob(A) || (isobj(A) && !istype(A, /obj/effect)))
+				wash_atom(A, CLEAN_MEDIUM)
+				washed++
 
 /obj/item/broom/proc/broom_fu(atom/A)
 	var/turf/T = get_turf(A)


### PR DESCRIPTION
## About The Pull Request
The natural conclusion of the Greater Cleaning powercreep debate is that Broom, the dedicated cleaning tool, shouldn't be CBT for something that is aesthetics and roleplay oriented (cleaning). 

Broom now cleans in a 3x3 AOE and its cleaning time scales inversely to Cooking skills

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="661" height="518" alt="dreamseeker_1O9o1gl3lI" src="https://github.com/user-attachments/assets/007760f5-029e-4a50-a78c-1d1a26586199" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
yes

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Broom now cleans in a 3x3 AOE and its cleaning time scales inversely to Cooking skills
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
