### PR TITLE
devout follower prayers now tagged as such

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -67,8 +67,16 @@
 		return
 	follower.sate_addiction(/datum/charflaw/addiction/godfearing)
 
+	var/devout = FALSE
+	if(ishuman(follower))
+		var/mob/living/carbon/human/hfollower = follower
+		for(var/datum/charflaw/cf in hfollower.charflaws)
+			if(istype(cf, /datum/charflaw/addiction/godfearing))
+				devout = TRUE
+				break
+
 	/* admin stuff - tells you the followers name, key, and what patron they follow */
-	var/follower_ident = "[follower.key]/([follower.real_name]) (follower of [patron])"
+	var/follower_ident = "[follower.key]/([follower.real_name]) ([devout ? "devout " : ""]follower of [patron])"
 	message_admins("[follower_ident] [ADMIN_SM(follower)] [ADMIN_FLW(follower)] prays: [span_info(prayer)]")
 	user.log_message("(follower of [patron]) prays: [prayer]", LOG_GAME)
 


### PR DESCRIPTION
## About The Pull Request
Title

## Testing Evidence
<img width="519" height="74" alt="image" src="https://github.com/user-attachments/assets/fc1bc99e-4731-4ba5-bc5f-8df6dfcde03b" />
<img width="520" height="70" alt="image" src="https://github.com/user-attachments/assets/8224a998-7caa-4211-b324-dd1a1df88324" />


## Why It's Good For The Game
Admin request

## Changelog

:cl:
admin: Prayers from players with the devout follower vice are now tagged as "devout follower of (patron)" instead of "follower of (patron)", making it easier to distinguish them at a glance.
/:cl: