### PR TITLE
Astrata Beam

### DIFF
--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -170,7 +170,7 @@
 
 /obj/projectile/magic/sacred_flame
 	name = "bolt of holy fire"
-	tracer_type = /obj/effect/projectile/tracer/stun
+	tracer_type = /obj/effect/projectile/tracer/solar_beam
 	muzzle_type = null
 	impact_type = null
 	hitscan = TRUE
@@ -200,7 +200,6 @@
 			if(out_of_effective_range())
 				return
 			if(blocked < 100)
-				L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
 				if(HAS_TRAIT(L, TRAIT_SILVER_WEAK))
 					L.adjust_fire_stacks(4, /datum/status_effect/fire_handler/fire_stacks/sunder)
 					L.Immobilize(0.5 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Changes out Astratan tracer (the beam effect) for a correct one, removes electrocute act from it.

## Testing Evidence

No

## Why It's Good For The Game

Yes
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Removes electrocute act from Astratan Bolt.
image: Changes out Astratan tracer (the beam effect) for a correct one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
