### PR TITLE
Devotion Bugfix Package 5 Addendum 1

### DIFF
--- a/code/modules/roguetown/roguemachine/stockpile/withdraw_tab.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/withdraw_tab.dm
@@ -41,6 +41,8 @@
 /datum/withdraw_tab/proc/do_withdraw(datum/roguestock/D, mob/user)
 	if(!D || !parent_structure)
 		return FALSE
+	if(get_dist(parent_structure, user) > 1)
+		return FALSE
 	D.refresh_auto_price()
 	var/total_price = D.withdraw_price
 	if(D.withdraw_disabled && !has_fiscal_authority(user))


### PR DESCRIPTION
## About The Pull Request
(oh gods it's becoming homestuck)
Fixes another issue disguised under one of the bigger ones. You can no longer withdraw items from a vomitorium/stockpile from _anywhere_ so long as you keep the window open. You could before.

## Testing Evidence
pretend there's a screenshot of... me clicking a button that does nothing. i promise i tested this it's just impossible to screenshot

## Why It's Good For The Game
Me when I leave 200 mammon in the abandoned hot springs vomitorium and become the azure peak materials summoner- actually that'd be hilarious, once

## Changelog

:cl:
fix: You can no longer withdraw from stockpiles and vomitoriums at range.
/:cl:
