### PR TITLE
Pyromancy can no longer proc the true damage explosion multiple time. Scorched no longer debuff CON. Spitfire + DB damage buffs

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -743,7 +743,7 @@
 					ignited = TRUE
 			if(isliving(target))
 				var/mob/living/M = target
-				apply_scorch_stack(M, 4, BODY_ZONE_CHEST)
+				apply_scorch_stack(M, 3, BODY_ZONE_CHEST)
 				ignited = TRUE
 			if(ignited && single_use)
 				is_active = FALSE

--- a/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
@@ -473,7 +473,7 @@
 	if(!ismob(target) || blocked >= 100)
 		return
 	var/mob/living/M = target
-	apply_scorch_stack(M, 4, def_zone)
+	apply_scorch_stack(M, 3, def_zone)
 
 /obj/item/ammo_casing/caseless/rogue/bolt/water
 	name = "water bolt"

--- a/code/game/objects/structures/rune_ward_structure.dm
+++ b/code/game/objects/structures/rune_ward_structure.dm
@@ -96,7 +96,7 @@
 	playsound(src, pick('sound/misc/explode/incendiary (1).ogg', 'sound/misc/explode/incendiary (2).ogg'), 80, TRUE)
 	new /obj/effect/hotspot(get_turf(src))
 	L.Slowdown(4)
-	apply_scorch_stack(L, 4, BODY_ZONE_CHEST)
+	apply_scorch_stack(L, 3, BODY_ZONE_CHEST)
 
 /obj/structure/rune_ward/chill
 	name = "frost rune"

--- a/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
@@ -44,9 +44,9 @@
 		if(1)
 			target.balloon_alert_to_viewers("<font color='#ff8a3d'>scorched I</font>")
 		if(2)
-			target.balloon_alert_to_viewers("<font color='#ff8a3d'>scorched II (-1 con)</font>")
+			target.balloon_alert_to_viewers("<font color='#ff8a3d'>scorched II</font>")
 		if(3)
-			target.balloon_alert_to_viewers("<font color='#ff8a3d'>scorched III (-2 con)</font>")
+			target.balloon_alert_to_viewers("<font color='#ff8a3d'>scorched III</font>")
 
 /proc/apply_scorch_burn(mob/living/target, zone_override = null)
 	if(!isliving(target))
@@ -151,7 +151,6 @@
 	id = "scorched2"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/scorched2
 	duration = 25 SECONDS
-	effectedstats = list(STATKEY_CON = -1)
 
 /atom/movable/screen/alert/status_effect/debuff/scorched2
 	name = "Scorched II"
@@ -170,7 +169,6 @@
 	id = "scorched3"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/scorched3
 	duration = 25 SECONDS
-	effectedstats = list(STATKEY_CON = -2)
 
 /atom/movable/screen/alert/status_effect/debuff/scorched3
 	name = "Scorched III"
@@ -189,7 +187,6 @@
 	id = "scorched4"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/scorched4
 	duration = 25 SECONDS
-	effectedstats = list(STATKEY_CON = -2)
 
 /atom/movable/screen/alert/status_effect/debuff/scorched4
 	name = "Scorched IV"

--- a/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
@@ -1,4 +1,4 @@
-#define SCORCH_ADAPTATION_DURATION (3 SECONDS)
+#define SCORCH_ADAPTATION_DURATION (6 SECONDS)
 #define SCORCH_ADAPTATION_KEY "scorch_adaptation"
 #define SCORCH_OVERLAY_COLOR rgb(255, 138, 61)
 #define SCORCH_BURN_DAMAGE 60
@@ -17,12 +17,15 @@
 	for(var/i in 1 to stacks)
 		if(target.has_status_effect(/datum/status_effect/debuff/scorched4))
 			apply_scorch_burn(target, zone_override)
-			final_tier = 4
+			if(apply_scorch_burn(target, zone_override))
+				remove_all_scorch_stacks(target)
 			break
 		if(target.has_status_effect(/datum/status_effect/debuff/scorched3))
 			target.remove_status_effect(/datum/status_effect/debuff/scorched3)
 			target.apply_status_effect(/datum/status_effect/debuff/scorched4)
 			apply_scorch_burn(target, zone_override)
+			if(apply_scorch_burn(target, zone_override))
+				remove_all_scorch_stacks(target)
 			final_tier = 4
 			break
 		if(target.has_status_effect(/datum/status_effect/debuff/scorched2))

--- a/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
@@ -1,5 +1,3 @@
-#define SCORCH_ADAPTATION_DURATION (6 SECONDS)
-#define SCORCH_ADAPTATION_KEY "scorch_adaptation"
 #define SCORCH_OVERLAY_COLOR rgb(255, 138, 61)
 #define SCORCH_BURN_DAMAGE 60
 
@@ -16,14 +14,12 @@
 	var/final_tier = 0
 	for(var/i in 1 to stacks)
 		if(target.has_status_effect(/datum/status_effect/debuff/scorched4))
-			apply_scorch_burn(target, zone_override)
 			if(apply_scorch_burn(target, zone_override))
 				remove_all_scorch_stacks(target)
 			break
 		if(target.has_status_effect(/datum/status_effect/debuff/scorched3))
 			target.remove_status_effect(/datum/status_effect/debuff/scorched3)
 			target.apply_status_effect(/datum/status_effect/debuff/scorched4)
-			apply_scorch_burn(target, zone_override)
 			if(apply_scorch_burn(target, zone_override))
 				remove_all_scorch_stacks(target)
 			final_tier = 4
@@ -51,10 +47,6 @@
 /proc/apply_scorch_burn(mob/living/target, zone_override = null)
 	if(!isliving(target))
 		return FALSE
-	if(target.mob_timers[SCORCH_ADAPTATION_KEY] && world.time < target.mob_timers[SCORCH_ADAPTATION_KEY])
-		var/remaining = round((target.mob_timers[SCORCH_ADAPTATION_KEY] - world.time) / 10)
-		target.balloon_alert_to_viewers("<font color='#ff8a3d'>fire adapted ([remaining]s)</font>")
-		return FALSE
 	var/target_zone = prob(50) ? BODY_ZONE_HEAD : BODY_ZONE_CHEST
 	var/aimed_zone = zone_override ? check_zone(zone_override) : null
 	if(aimed_zone == BODY_ZONE_HEAD || aimed_zone == BODY_ZONE_CHEST)
@@ -72,7 +64,6 @@
 			if(!burn_wound)
 				burn_wound = affecting.add_wound(/datum/wound/dynamic/burn)
 			burn_wound?.upgrade(SCORCH_BURN_DAMAGE, 0, FALSE)
-	target.mob_timers[SCORCH_ADAPTATION_KEY] = world.time + SCORCH_ADAPTATION_DURATION
 	var/hit_zone_name = parse_zone(target_zone)
 	target.balloon_alert_to_viewers("<font color='#ff4a2a'>CHARRED!</font>")
 	target.visible_message(
@@ -150,7 +141,7 @@
 /datum/status_effect/debuff/scorched2
 	id = "scorched2"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/scorched2
-	duration = 25 SECONDS
+	duration = 15 SECONDS
 
 /atom/movable/screen/alert/status_effect/debuff/scorched2
 	name = "Scorched II"
@@ -168,7 +159,7 @@
 /datum/status_effect/debuff/scorched3
 	id = "scorched3"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/scorched3
-	duration = 25 SECONDS
+	duration = 15 SECONDS
 
 /atom/movable/screen/alert/status_effect/debuff/scorched3
 	name = "Scorched III"
@@ -186,7 +177,7 @@
 /datum/status_effect/debuff/scorched4
 	id = "scorched4"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/scorched4
-	duration = 25 SECONDS
+	duration = 15 SECONDS
 
 /atom/movable/screen/alert/status_effect/debuff/scorched4
 	name = "Scorched IV"
@@ -201,7 +192,5 @@
 	owner.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, SCORCH_OVERLAY_COLOR)
 	. = ..()
 
-#undef SCORCH_ADAPTATION_DURATION
-#undef SCORCH_ADAPTATION_KEY
 #undef SCORCH_OVERLAY_COLOR
 #undef SCORCH_BURN_DAMAGE

--- a/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/_pyromancy_shared.dm
@@ -132,7 +132,7 @@
 /datum/status_effect/debuff/scorched1
 	id = "scorched1"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/scorched1
-	duration = 25 SECONDS
+	duration = 15 SECONDS
 
 /atom/movable/screen/alert/status_effect/debuff/scorched1
 	name = "Scorched"

--- a/code/modules/spells/spell_types/wizard/pyromancy/dragons_breath.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/dragons_breath.dm
@@ -21,7 +21,7 @@
 	spell_impact_intensity = SPELL_IMPACT_HIGH
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
-	damage = 60
+	damage = 65
 	strike_damage_type = BURN
 	blade_class = BCLASS_BURN
 	committed_strike = TRUE

--- a/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
@@ -1,4 +1,4 @@
-#define SPITFIRE_DAMAGE 40
+#define SPITFIRE_DAMAGE 50
 /datum/action/cooldown/spell/projectile/spitfire
 	button_icon = 'icons/mob/actions/mage_pyromancy.dmi'
 	name = "Spitfire"
@@ -51,7 +51,7 @@
 
 /obj/projectile/magic/spitfire/arc
 	name = "arced spitfire"
-	damage = 27
+	damage = 38
 	arcshot = TRUE
 
 /obj/projectile/magic/spitfire/on_hit(target, blocked = FALSE)

--- a/code/modules/spells/spell_types/wizard/pyromancy/wyrmfire.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/wyrmfire.dm
@@ -460,7 +460,7 @@
 				arcyne_strike(caster, L, null, blast_damage, BODY_ZONE_CHEST, BCLASS_BURN, spell_name = "Pyroclasm", damage_type = BURN, skip_animation = TRUE)
 			else
 				L.adjustFireLoss(blast_damage)
-			apply_scorch_stack(L, 4)
+			apply_scorch_stack(L, 3)
 		for(var/obj/structure/damaged in T)
 			if(!istype(damaged, /obj/structure/flora/newbranch))
 				damaged.take_damage(blast_structural, BRUTE, "blunt", TRUE)


### PR DESCRIPTION
## About The Pull Request
Move budget away from the true damage explosion that was a bit problematic in favor of just plain raw damage. 

- When the CHARRED explosion procs, it will clear all scorched stack. No more exploding multiple time through armor.
- Adaptation is 6 seconds instead of 3 seconds. 
- Scorched no longer debuff CON.
- Spitfire damage 40 -> 50 
- Dragon's Breath 60 -> 65
- Reduced scorched duration to 15s from 25s.
- Remove fire adaptation. 
- Source that gave 4 stacks scorch -> now gives 3

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Proccing multiple true damage explosion through armor on a status effect that lasts is in fact, not healthy for the state of the game. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: When the CHARRED explosion procs from Pyromancy, it will clear all scorched stack. No more exploding multiple time through armor.
balance: Remove fire adaptation
balance: Scorched no longer debuff CON.
balance: Spitfire damage 40 -> 50 
balance: Dragon's Breath 60 -> 65
balance: Reduced scorched duration to 15s from 25s.
balance: Source that gave 4 stacks scorch -> now gives 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
