### PR TITLE
restores arcana levelling

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
+++ b/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
@@ -1,8 +1,3 @@
-// No Arcana recipes gives XP, to prevent grinding a combat skills
-// Through crafting. However, all of them are gated at only Craft Diff 2 
-// Aka Apprentice, so high int novice can gate it. And every magic 
-// Role can engage competently, thus removing the need to legitimately
-// Grind crafting recipes for XP / crafting purpose.
 /datum/crafting_recipe/roguetown/arcana
 	req_table = TRUE
 	tools = list()
@@ -11,7 +6,6 @@
 	skillcraft = /datum/skill/magic/arcane
 	subtype_reqs = TRUE
 	display_category = ITEM_CAT_ARCYNE_GEARS
-	xp_modifier = 0
 	craftdiff = SKILL_LEVEL_APPRENTICE
 
 /datum/crafting_recipe/roguetown/arcana/amethyst
@@ -200,7 +194,7 @@
 	result = /obj/item/magic/elemental/relic
 	reqs = list(/obj/item/magic/elemental/fragment = 2)
 
-// Runed Artifacts are only found in bog and run out soon so this is a 
+// Runed Artifacts are only found in bog and run out soon so this is a
 // Loreful way of "replicating" it but requires you to go out at least once
 
 /datum/crafting_recipe/roguetown/arcana/runed_artifact_replication


### PR DESCRIPTION
## About The Pull Request
Arcana recipes had their xp gain disabled to prevent people from grinding a combat skill, back when arcana skill affected spells. It no longer does, and has been fully supplanted by arcyne armament in terms of "mage combat skill"; therefore, there's no reason it shouldn't be grindable. There's, admittedly, not much reason to do so, it's mostly for vanity, but the primary benefit is that if you take arcpot and end up fighting mage summons on a contract, you can actually level to apprentice instead of suffering with 4% crafting checks for an ungodly length of time to try to condense the drops.

## Testing Evidence
single var edit

## Why It's Good For The Game
lets people learn magic skill at the magic academy, tiny qol for advents that want to sell the planarmob drops ansari maid sellable, etc. no combat balance impact

## Changelog

:cl:
add: Arcana crafting recipes now grant xp again like all other recipes. It's no longer a combat skill, in fact it's nigh-useless, so there's no particular reason to gate it.
/:cl: