### PR TITLE
yet another devotion exploit fix

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1560,6 +1560,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 				charflaws.Add(C)
 				if(C.desc)
 					to_chat(user, span_info(C.desc))
+			else
+				charflaws.Add(new /datum/charflaw/noflaw())
 
 		else if(task == "remove")
 			var/index = text2num(href_list["index"])

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -423,6 +423,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			var/datum/charflaw/cf = new charflaw_type()
 			if(cf)
 				charflaws.Add(cf)
+	// fix saves maid during the period where there was an exploit allowing "true flawless" i.e. no charflaws
+	if(!length(charflaws))
+		charflaws.Add(new /datum/charflaw/noflaw())
 	if(needs_resave)
 		var/list/cleaned_types = list()
 		for(var/datum/charflaw/cf in charflaws)


### PR DESCRIPTION
## About The Pull Request
Fixes a longstanding exploit that allowed you to end up with no charflaws, not even flawless. Also applies to existing character slots as soon as they're loaded, so there should be no further ways for this to slip through the cracks.

## Testing Evidence
can't really screenshot it but i just tested it by performing the exploit n the exploit didn't work i got flawless as intended

## Why It's Good For The Game
pick a vice, powergamer

## Changelog

:cl:
fix: Fixed an exploit allowing a character to have no vices at all, not even the Flawless vice that blocks passive triumph gain.
/:cl:
