### PR TITLE
Armour jak.

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
@@ -31,11 +31,6 @@
 	cost = 50
 	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine/heavy/iron)
 
-/datum/supply_pack/rogue/armor_iron/brigandine_light//It's made with iron and melts into iron it's not steel.
-	name = "Brigandine, Light"
-	cost = 55 //1 Iron, 1 Leather
-	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine/light)
-
 /datum/supply_pack/rogue/armor_iron/chaincoif_iron
 	name = "Chain Coif"
 	cost = 25
@@ -85,7 +80,7 @@
 	name = "Bracers, Plate"
 	cost = 25
 	contains = list(/obj/item/clothing/wrists/roguetown/bracers/iron)
-	
+
 /datum/supply_pack/rogue/armor_iron/bracers_chain
 	name = "Bracers, Chainmaille"
 	cost = 25
@@ -218,12 +213,12 @@
 
 /datum/supply_pack/rogue/armor_iron/helmet_nasal
 	name = "Helmet, Nasal"
-	cost = 50 
+	cost = 50
 	contains = list(/obj/item/clothing/head/roguetown/helmet/nasal/iron)
 
 /datum/supply_pack/rogue/armor_iron/helmet_winged
 	name = "Helmet, Winged"
-	cost = 50 
+	cost = 50
 	contains = list(/obj/item/clothing/head/roguetown/helmet/winged/iron)
 
 /datum/supply_pack/rogue/armor_iron/helmet_bucket_classic

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -88,22 +88,22 @@
 
 /datum/supply_pack/rogue/light_armor/hide_armor
 	name = "Hide Armor"
-	cost = 35 // Base sellprice of 20
+	cost = 30 // Base sellprice of 20
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/hide)
 
 /datum/supply_pack/rogue/light_armor/heavy_leather_armor
 	name = "Hardened Leather Armor"
-	cost = 40 // Base sellprice of 20
+	cost = 45 // Base sellprice of 20
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/heavy)
 
 /datum/supply_pack/rogue/light_armor/studded_leather_armor
 	name = "Studded Leather Armor"
-	cost = 45 // I added 5 to the base sellprice of 25 because it cost 1 ingot
+	cost = 35 // I added 5 to the base sellprice of 25 because it cost 1 ingot
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/studded)
 
-/datum/supply_pack/rogue/light_armor/studded_leather_armor
+/datum/supply_pack/rogue/light_armor/studded_leather_hood
 	name = "Studded Leather Hood"
-	cost = 45
+	cost = 35
 	contains = list(/obj/item/clothing/head/roguetown/roguehood/studded)
 
 /datum/supply_pack/rogue/light_armor/studded_leather_cuirass
@@ -113,12 +113,12 @@
 
 /datum/supply_pack/rogue/light_armor/heavy_leather_coat
 	name = "Hardened Leather Coat"
-	cost = 40 // Base sellprice of 25
+	cost = 55 // Base sellprice of 25
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/heavy/coat)
 
 /datum/supply_pack/rogue/light_armor/heavy_leather_jacket
 	name = "Hardened Leather Jacket"
-	cost = 40 // Base sellprice of 25
+	cost = 55 // Base sellprice of 25
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket)
 
 /datum/supply_pack/rogue/light_armor/heavy_leather_gloves

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
@@ -21,6 +21,11 @@
 	cost = 50 // 1 Ingots
 	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail)
 
+/datum/supply_pack/rogue/armor_steel/brigandine_light
+	name = "Brigandine, Light"
+	cost = 80 //1 Steel, 1 Leather, 1 Cloth
+	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine/light)
+
 /datum/supply_pack/rogue/armor_steel/hauberk_steel
 	name = "Hauberk"
 	cost = 90 // 2 Ingots
@@ -105,7 +110,7 @@
 	name = "Chausses, Chain"
 	cost = 50 // 1 Steel
 	contains = list(/obj/item/clothing/under/roguetown/chainlegs)
-	
+
 /datum/supply_pack/rogue/armor_steel/chainhose_steel
 	name = "Hosen, Chain"
 	cost = 50 // 1 Steel
@@ -115,7 +120,7 @@
 	name = "Chausses, Plate"
 	cost = 90 // 2 Steel
 	contains = list(/obj/item/clothing/under/roguetown/platelegs)
-	
+
 /datum/supply_pack/rogue/armor_steel/chainkilt
 	name = "Chain Kilt"
 	cost = 50 // 1 Steel
@@ -303,7 +308,7 @@
 
 /datum/supply_pack/rogue/armor_steel/helmet_aventailbascinet
 	name = "Helmet, Bascinet, Aventailed"
-	cost = 90 
+	cost = 90
 	contains = list(/obj/item/clothing/head/roguetown/helmet/bascinet/aventail)
 
 /datum/supply_pack/rogue/armor_steel/helmet_heavyaventailbascinet

--- a/code/modules/clothing/rogueclothes/armor/brigandine.dm
+++ b/code/modules/clothing/rogueclothes/armor/brigandine.dm
@@ -75,7 +75,6 @@
 	blocksound = SOFTHIT
 	body_parts_covered = COVERAGE_TORSO
 	max_integrity = ARMOR_INT_CHEST_PLATE_BRIGANDINE - ARMOR_INT_CHEST_PLATE_BRIGANDINE_WEIGHT_MODIFIER
-	smeltresult = /obj/item/ingot/iron
 	equip_delay_self = 40
 	armor_class = ARMOR_CLASS_LIGHT//steel version of the studded leather armor now
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/roguetown/roguecrafting/leather/reinforcement.dm
+++ b/code/modules/roguetown/roguecrafting/leather/reinforcement.dm
@@ -1,6 +1,7 @@
 /datum/crafting_recipe/roguetown/leather/reinforcement
 	abstract_type = /datum/crafting_recipe/roguetown/leather/reinforcement
 	category = "Reinforcement"
+	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/leather/reinforcement/crafteast
 	name = "decorated dobo robe"
@@ -12,10 +13,9 @@
 		/obj/item/clothing/suit/roguetown/armor/basiceast = 1,
 		)
 	tools = list(/obj/item/needle)
-	craftdiff = 3
+
 
 /datum/crafting_recipe/roguetown/leather/reinforcement/studded
-	craftdiff = 4
 	tools = list(/obj/item/needle, /obj/item/rogueweapon/hammer)
 
 /datum/crafting_recipe/roguetown/leather/reinforcement/studded/hood
@@ -56,6 +56,7 @@
 
 /datum/crafting_recipe/roguetown/leather/reinforcement/studded/forester
 	name = "forester's brigandine"
+	craftdiff = 4
 	result = list(/obj/item/clothing/suit/roguetown/armor/leather/studded/warden/upgraded)
 	reqs = list(
 		/obj/item/clothing/suit/roguetown/armor/leather/studded/warden = 1,

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -653,14 +653,6 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/iron
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 
-/datum/anvil_recipe/armor/iron/lbrigandine
-	name = "Light Brigandine, Iron (+1 Cloth)"
-	req_bar = /obj/item/ingot/iron
-	additional_items = list(/obj/item/natural/cloth)
-	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine/light
-	display_category = ITEM_CAT_ARMOR_CHESTPIECES
-	i_type = "Armor"
-
 /datum/anvil_recipe/armor/iron/halfplate
 	name = "Half-Plate, Iron (+2 Iron, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/iron
@@ -1099,6 +1091,14 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 
+/datum/anvil_recipe/armor/steel/lbrigandine
+	name = "Lightweight Brigandine, Steel (+1 Leather, +1 Cloth)"
+	req_bar = /obj/item/ingot/steel
+	additional_items = list(/obj/item/natural/hide/cured, /obj/item/natural/cloth)
+	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+	display_category = ITEM_CAT_ARMOR_CHESTPIECES
+	i_type = "Armor"
+
 /datum/anvil_recipe/armor/steel/halfplate
 	name = "Half-Plate, Steel (+2 Steel, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
@@ -1163,16 +1163,16 @@
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 
 /datum/anvil_recipe/armor/steel/coatplates
-	name = "Coat Of Plates, Steel (+1 Steel, +1 Cured Leather)"
+	name = "Coat Of Plates, Steel (+1 Steel, +1 Leather, +1 Cloth)"
 	req_bar = /obj/item/ingot/steel
-	additional_items = list(/obj/item/ingot/steel,/obj/item/natural/hide/cured)
+	additional_items = list(/obj/item/ingot/steel,/obj/item/natural/hide/cured,/obj/item/natural/cloth)
 	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine/heavy
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 
 /datum/anvil_recipe/armor/steel/steel/brigandine
-	name = "Brigandine, Steel (+1 Steel, +2 Cloth)"
+	name = "Brigandine, Steel (+1 Steel, +1 Leather, +2 Cloth)"
 	req_bar = /obj/item/ingot/steel
-	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/cloth, /obj/item/natural/cloth)
+	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/hide/cured, /obj/item/natural/cloth, /obj/item/natural/cloth)
 	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine
 	display_category = ITEM_CAT_ARMOR_CHESTPIECES
 


### PR DESCRIPTION
## About The Pull Request

Fixes pathing for studded armor in silverface so you can actually purchase it) and it has been reduced to Apprentice leatherworking requirement (except forester brigandine since that is an actual brigandine so it remains on expert)
Brigandines now require Steel Bar, Leather and Cloth to make (in different ratios depending on the type of it) - Lightweight is steel recipe now and with it has increased cost.
Hide Armor reduced to 30 mammon, Studded Armor and Hood down to 35 mammon price, Hardened Leather Armor increased to 45 from 40, Hardened Leather Coat/Jacket increased to 55 from 45 (it costs a lot of materials to make)

## Testing Evidence

Clearly

## Why It's Good For The Game

The bug has been around since I added a hood like half a year back (grim), the costs do not really represent the actual material costs still but this is closer to it. As for the rest - brigandines are cheaper than plate but more annoying to make that was the whole point - not exactly the case - hardened is superior to studded in practically every way and its severely underused as is between having to grind up to same leatherworking and material requirements so I'd like it to be used more.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Reinforcing has been reduced to Apprentice leatherworking requirement (except forester brigandine since that is an actual brigandine so it remains on expert)
balance: Brigandines now require Steel Bar, Leather and Cloth to make (in different ratios depending on the type of it) -Lightweight is steel recipe now and with it has increased cost in silverface.
balance: Hide Armor reduced to 30 mammon, Studded Armor and Hood down to 35 mammon price, Hardened Leather Armor increased to 45 from 40, Hardened Leather Coat/Jacket increased to 55 from 45 (it costs a lot of materials to make but this is bit closer to reality)
fix: Fixes pathing for studded armor in silverface so you can actually purchase it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
