### PR TITLE
Players and NPCs can no longer resist or guard while paralyzed.

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -110,7 +110,7 @@
 			changeNext_move(CLICK_CD_MELEE)
 
 /mob/living/rmb_on(atom/A, params)
-	if(stat)
+	if(incapacitated(ignore_restraints = TRUE))
 		return
 
 	if(!has_active_hand()) //can't attack without a hand.

--- a/code/game/objects/items/rogueweapons/mmb/jump.dm
+++ b/code/game/objects/items/rogueweapons/mmb/jump.dm
@@ -24,6 +24,9 @@
 	if(src.get_num_legs() < 2)
 		return FALSE
 
+	if(incapacitated(ignore_restraints = TRUE))
+		return FALSE
+
 	if(pulledby && pulledby != src)
 		to_chat(src, span_warning("I'm being grabbed."))
 		changeNext_move(mmb_intent.clickcd)
@@ -184,6 +187,8 @@
 	if(A == src || A == src.loc)
 		return FALSE
 	if(get_num_legs() < 2)
+		return FALSE
+	if(incapacitated(ignore_restraints = TRUE))
 		return FALSE
 	if(pulledby && pulledby != src)
 		to_chat(src, span_warning("I'm being grabbed."))

--- a/code/game/objects/items/rogueweapons/mmb/kick.dm
+++ b/code/game/objects/items/rogueweapons/mmb/kick.dm
@@ -68,6 +68,8 @@
 /mob/living/proc/can_kick(atom/A, do_message = TRUE)
 	if(get_num_legs() < 2)
 		return FALSE
+	if(incapacitated(ignore_restraints = TRUE))
+		return FALSE
 	if(!A.Adjacent(src))
 		return FALSE
 	if(A == src)

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -315,6 +315,8 @@
 /datum/rmb_intent/weak/special_attack(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(!istype(target) || !istype(user) || !target.Adjacent(user))
 		return
+	if(user.incapacitated())
+		return
 
 	user.attempt_steal(user, target)
 	return ..()

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -3,8 +3,8 @@
 //eye_blind, eye_blurry, druggy, TRAIT_BLIND trait, TRAIT_NEARSIGHT trait, and TRAIT_HUSK trait.
 
 
-/mob/living/carbon/IsParalyzed(include_stamcrit = TRUE)
-	return ..() || (include_stamcrit && stam_paralyzed)
+/mob/living/carbon/IsParalyzed()
+	return ..() || stam_paralyzed
 
 /mob/living/carbon/proc/enter_stamcrit()
 	if(!(status_flags & CANKNOCKDOWN) || HAS_TRAIT(src, TRAIT_STUNIMMUNE))

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -251,7 +251,7 @@
 			return FALSE
 	if(r_grab || l_grab || length(grabbedby))
 		return FALSE
-	if(IsImmobilized() || IsOffBalanced())
+	if(IsImmobilized() || IsOffBalanced() || incapacitated(ignore_restraints = TRUE))
 		return FALSE
 	if(m_intent == MOVE_INTENT_RUN)
 		to_chat(src, span_warning("I can't focus on this while running."))

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -181,10 +181,10 @@
 
 ///////////////////////////////// PARALYZED //////////////////////////////////
 /mob/living/proc/IsParalyzed() //If we're immobilized
-	return has_status_effect(STATUS_EFFECT_PARALYZED)
+	return has_status_effect(STATUS_EFFECT_PARALYZED) || HAS_TRAIT(src, TRAIT_PARALYSIS)
 
 /mob/living/proc/AmountParalyzed() //How many deciseconds remain in our Paralyzed status effect
-	var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
+	var/datum/status_effect/incapacitating/paralyzed/P = has_status_effect(STATUS_EFFECT_PARALYZED)
 	if(P)
 		return P.duration - world.time
 	return 0
@@ -195,7 +195,7 @@
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		if(absorb_stun(amount, ignore_canstun))
 			return
-		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
+		var/datum/status_effect/incapacitating/paralyzed/P = has_status_effect(STATUS_EFFECT_PARALYZED)
 		if(P)
 			P.duration = max(world.time + amount, P.duration)
 		else if(amount > 0)
@@ -206,7 +206,7 @@
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
+		var/datum/status_effect/incapacitating/paralyzed/P = has_status_effect(STATUS_EFFECT_PARALYZED)
 		if(amount <= 0)
 			if(P)
 				qdel(P)
@@ -225,7 +225,7 @@
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		if(absorb_stun(amount, ignore_canstun))
 			return
-		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
+		var/datum/status_effect/incapacitating/paralyzed/P = has_status_effect(STATUS_EFFECT_PARALYZED)
 		if(P)
 			P.duration += amount
 		else if(amount > 0)


### PR DESCRIPTION
## About The Pull Request
So, I got a bug report that NPC were resisting out of grabs while paralyzed. I investigated. It turns out skull crack gives TRAIT_PARALYSIS and also disable your limbs, which immobilize you. 

However, NPCs check for IsParalyzed(), which does not in fact, cover TRAIT_PARALYSIS. This also in turn means you can GUARD or resist grabs while paralyzed, **as a player**. 

This PR fixes *both* instances by expanding the checks to cover both cases and also guard various other actions (like jump) from being doable while paralyzed.

Pulled some changes over to my GMTK-1 branch (For gating AI actions) because I want to avoid self conflict.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="193" height="134" alt="dreamseeker_YpP1ncBBvb" src="https://github.com/user-attachments/assets/ed2178ce-10f1-4518-9677-89d9e73714d0" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Never made much sense

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Players and NPCs should no longer be able to resist out of a grab or guard while paralyzed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
