### PR TITLE
renamed 'vial of Reanimation Elixir' to 'bottle of Reanimation Elixir'

### DIFF
--- a/code/modules/surgery/revive_chair.dm
+++ b/code/modules/surgery/revive_chair.dm
@@ -165,7 +165,7 @@
 	taste_description = "lightning and regret"
 
 /obj/item/reagent_containers/glass/bottle/frankenbrew
-	name = "vial of Reanimation Elixir"
+	name = "bottle of Reanimation Elixir"
 	desc = "A volatile chemical mixture that helps the deceased conduct electricity. Looks expensive..."
 	list_reagents = list(/datum/reagent/frankenbrew = 50)
 


### PR DESCRIPTION
## About The Pull Request

Renamed 'vial of Reanimation Elixir' to 'bottle of Reanimation Elixir' Why?
It's called a "vial of reanimation elixir". But it's not a vial(30dr), it's a bottle(50dr).

## Testing Evidence

do i have to when i changed one line?

## Why It's Good For The Game

Naming consistency.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: renamed 'vial of Reanimation Elixir' to 'bottle of Reanimation Elixir'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
