### PR TITLE
Azurean Pilum Frost Fix

### DIFF
--- a/code/modules/spells/spell_types/classunique/spellblade/azurean_pilum.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/azurean_pilum.dm
@@ -89,20 +89,33 @@
 
 /obj/projectile/magic/azurean_pilum/on_hit(target, blocked = FALSE)
 	. = ..()
-	if(isliving(target))
-		var/mob/living/L = target
-		if(L.anti_magic_check())
-			visible_message(span_warning("[src] disperses on contact with [L]!"))
-			playsound(get_turf(L), 'sound/magic/magic_nulled.ogg', 100)
+	if(ismob(target))
+		var/mob/M = target
+		if(M.anti_magic_check())
+			visible_message(span_warning("[src] fizzles on contact with \the [target]!"))
+			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
+			qdel(src)
 			return BULLET_ACT_BLOCK
-		if(out_of_effective_range())
-			return
-		if(blocked >= 100)
-			return
-		apply_frost_stack(L, frost_stacks)
-		to_chat(L, span_danger("An icy pilum strikes true - the cold seeps into my bones!"))
-		if(firer)
-			log_combat(firer, L, "pilum-struck", zone=def_zone)
+		if(isliving(target) && !out_of_effective_range())
+			var/mob/living/L = target
+			if(L.on_fire)
+				L.adjust_fire_stacks(-1)
+				L.visible_message(span_warning("The frost dampens the flames on [L]!"))
+			apply_frost_stack(L, frost_stacks)
+			playsound(get_turf(L), pick('sound/combat/fracture/fracturedry (1).ogg', 'sound/combat/fracture/fracturedry (2).ogg', 'sound/combat/fracture/fracturedry (3).ogg'), 80, TRUE)
+			new /obj/effect/temp_visual/snap_freeze(get_turf(L))
+			to_chat(L, span_danger("An icy pilum strikes true - the cold seeps into my bones!"))
+			if(firer)
+				log_combat(firer, L, "pilum-struck", zone=def_zone)
+	else if(isobj(target))
+		var/obj/O = target
+		O.extinguish()
+		var/turf/target_turf = get_turf(target)
+		var/obj/effect/hotspot/hotspot = (locate(/obj/effect/hotspot) in target_turf)
+		if(hotspot)
+			new /obj/effect/temp_visual/small_smoke(target_turf)
+			qdel(hotspot)
+	qdel(src)
 
 /obj/projectile/magic/azurean_pilum/empowered
 	name = "Empowered Azurean Pilum"


### PR DESCRIPTION
## About The Pull Request

azurean pilum now applies frost properly when absorbed by armor

## Testing Evidence

<img width="259" height="341" alt="image" src="https://github.com/user-attachments/assets/ce207a3d-77d1-41e3-ace3-203d96ca31aa" />

## Why It's Good For The Game

i THINK the armor rework broke it? it has pierce instead of frostbolt damage so that's probably the culprit, so i'm doing the unga bunga solution instead of changing the damage type

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Azurean Pilum's frost application no longer prevented by armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
