### PR TITLE
Fixes Tremor's Casting While Moving

### DIFF
--- a/code/modules/spells/spell_types/classunique/spellblade/tremor.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/tremor.dm
@@ -7,6 +7,7 @@
 	invocations = list("Tremor!")
 	damage = 30
 	empowered_mult = 2
+	sweep_step = 0
 	push_dist = 1
 	detonate_sound = null
 	momentum_on_hit = 1


### PR DESCRIPTION
## About The Pull Request

Tremor's ring now sweeps instantenously, instead of being staggered when done mid-movement.

## Testing Evidence

it needs a video to demonstrate

## Why It's Good For The Game

makes spell behave as it is advertised. it had no "sweep_step = 0" like shatter, which made it so when you tried walking into someone with it, it'd get staggered and the front row of it would be delayed for another second, mostly just taking more time to hit your intended target. now it's consistent with the rest of the ring

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Mace Chant's Tremor no longer gets staggered when you walk into someone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
