### PR TITLE
[Fix] Biting broken armor applies full recoil

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -339,7 +339,7 @@
 				recoil_mult = 0.05
 
 		// if armor broke, your toof dont broke, ya git
-		var/obj/item/clothing/armor = C.get_item_by_slot(def_zone)
+		var/obj/item/clothing/armor = C.get_item_by_slot(sublimb_grabbed)
 		if(armor?.obj_broken)
 			recoil_mult = 0.05
 

--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -156,6 +156,11 @@
 				else
 					recoil_mult = 0.05
 
+			// if armor broke, your toof dont broke, ya git
+			var/obj/item/clothing/armor = src.get_item_by_slot(def_zone)
+			if(armor?.obj_broken)
+				recoil_mult = 0.05
+
 			var/recoil = round(dam2do * recoil_mult)
 			user.apply_damage(recoil, BRUTE, BODY_ZONE_PRECISE_MOUTH)// cleaner, basically! this will recoil 25% damage to your mouth if you bite flesh, and 50% if you bite armor
 		if(prob(25)) // 1/4 of the time you'll overextend and be exposed, giving your opponent a room to strike back hard
@@ -332,6 +337,11 @@
 				recoil_mult = 0.50
 			else
 				recoil_mult = 0.05
+
+		// if armor broke, your toof dont broke, ya git
+		var/obj/item/clothing/armor = src.get_item_by_slot(def_zone)
+		if(armor?.obj_broken)
+			recoil_mult = 0.05
 
 		var/recoil = round(damage * recoil_mult)
 		user.apply_damage(recoil, BRUTE, BODY_ZONE_PRECISE_MOUTH) // cleaner, basically! this will recoil 25% damage to your mouth if you bite flesh, and 50% if you bite armor

--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -339,7 +339,7 @@
 				recoil_mult = 0.05
 
 		// if armor broke, your toof dont broke, ya git
-		var/obj/item/clothing/armor = src.get_item_by_slot(def_zone)
+		var/obj/item/clothing/armor = C.get_item_by_slot(def_zone)
 		if(armor?.obj_broken)
 			recoil_mult = 0.05
 


### PR DESCRIPTION
## About The Pull Request

- Recoil didn't have a condition for when and if armor is broken, only if armor is of a certain AC. Oops.

## Testing Evidence

Works and compiles just fine, da

## Why It's Good For The Game

Fug Bixes

## Changelog
:cl:
fix: Recoil is set to minimal if armor is broken.
/:cl: