### PR TITLE
Fix Ravox sharpness loss target

### DIFF
--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -596,7 +596,7 @@
 			var/obj/item/rogueweapon/RW = user.get_active_held_item()
 			if(RW)
 				RW.take_damage(RW.sharpness ? (INTEG_PARRY_DECAY) : (INTEG_PARRY_DECAY_NOSHARP), BRUTE, used_weapon.d_type)
-				RW.remove_bintegrity((SHARPNESS_ONHIT_DECAY), src)
+				RW.remove_bintegrity((SHARPNESS_ONHIT_DECAY), user)
 
 			//if(used_weapon)
 			//	used_weapon.take_damage((used_weapon.sharpness ? (INTEG_PARRY_DECAY) : (INTEG_PARRY_DECAY_NOSHARP)), BRUTE, used_weapon.d_type)

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -331,7 +331,7 @@
 
 					if(!has_status_effect(/datum/status_effect/buff/weapon_binded))
 						used_weapon.take_damage(intdam, BRUTE, used_weapon.d_type)
-						used_weapon.remove_bintegrity(sharp_loss, user)
+						used_weapon.remove_bintegrity(sharp_loss, defender)
 			else
 				// Unarmed attacker
 				var/intdam = INTEG_PARRY_DECAY_UNARMED
@@ -344,7 +344,7 @@
 				if(istype(used_weapon, /obj/item/rogueweapon/shield) && attack_intent)
 					intdam *= attack_intent.intent_intdamage_factor
 				used_weapon.take_damage(intdam, BRUTE, used_weapon.d_type)
-				used_weapon.remove_bintegrity(sharp_loss, user)
+				used_weapon.remove_bintegrity(sharp_loss, defender)
 			if(mind)
 				dodgetime = CLAMP(dodgetime - 2, 0, CLICK_CD_DODGE)
 				changeMaxDodge(2)


### PR DESCRIPTION

## About The Pull Request
Fixes Ravox's sharpness protection being checked against the wrong participant.
The effect now applies to the Ravox worshipper's weapon instead of reducing sharpness loss for their opponent.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
One parry was performed in each case.

### Before the fix

1. **Ravox defender parries an attack**

Starting sharpness: `150`  
Sharpness after parry: `147.90`  
Sharpness loss: `2.10`
<img width="277" height="288" alt="image" src="https://github.com/user-attachments/assets/8f00e01c-bb08-44db-a86d-eb99dedefe30" />

2. **Non-Ravox defender parries an attack from a Ravox worshipper**

Starting sharpness: `150`  
Sharpness after parry: `148.53`  
Sharpness loss: `1.47`

The opponent incorrectly received Ravox's reduced sharpness loss.

<img width="299" height="310" alt="image2" src="https://github.com/user-attachments/assets/27bf2e3a-5e2b-491b-b864-7053127874b9" />

### After the fix

1. **Ravox defender parries an attack**

Starting sharpness: `200`  
Sharpness after parry: `198.53`  
Sharpness loss: `1.47`

Ravox's reduced sharpness loss now applies to the worshipper.
<img width="319" height="262" alt="Screenshot_1" src="https://github.com/user-attachments/assets/85c502ac-6d9f-4a2b-a427-d75d5a1ce613" />

2. **Non-Ravox defender parries an attack from a Ravox worshipper**

Starting sharpness: `200`  
Sharpness after parry: `197.90`  
Sharpness loss: `2.10`

The opponent no longer receives Ravox's protection.
<img width="329" height="265" alt="Screenshot_2" src="https://github.com/user-attachments/assets/4186e072-8f8e-4b49-931a-ad3a9e843fe2" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Ravox's patron benefit should help the worshipper rather than their opponent.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Ravox's sharpness protection now benefits the worshipper instead of their opponent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

