### PR TITLE
Devotion Bugfix Package 5 Addendum 2

### DIFF
--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -188,7 +188,11 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 	owner = bodypart_owner.owner
 	var/initial_bleed = bleed_rate
 	bleed_rate = 0
-	if(initial_bleed)
+	var/mob/living/carbon/human/H = owner
+	// this is needed because rib/skull fractures will bleed even non-blooded mobs otherwise - and they override the "no bleeding wounds can apply to skeletons"
+	// check. note that player skeletons, like ancient deathknight/azurcaephan, don't actually get the skeleton species and therefore the NOBLOOD check will not
+	// catch them - so we need to check bodypart skeletonization instead as it's literally the only way to tell
+	if(initial_bleed && !bodypart_owner.skeletonized && !(ishuman(H) && (NOBLOOD in H.dna?.species?.species_traits)))
 		set_bleed_rate(initial_bleed)
 	on_bodypart_gain(affected)
 	INVOKE_ASYNC(src, PROC_REF(on_mob_gain), affected.owner) //this is literally a fucking lint error like new species cannot possible spawn with wounds until after its ass

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -1281,6 +1281,9 @@
 	if(L.stat == DEAD)
 		return
 
+	if(HAS_TRAIT(L, TRAIT_NOBREATH))
+		return
+
 	to_chat(L, span_danger("You breathe in the spiky spores!"))
 	L.apply_damage(damage_amount, BRUTE)
 

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_INIT(skeleton_aggro, list(
 	d_intent = INTENT_PARRY
 	possible_mmb_intents = list(INTENT_SPECIAL, INTENT_JUMP, INTENT_KICK, INTENT_BITE)
 	cmode_music = 'sound/music/combat_weird.ogg'
+	taints_loot = TRUE
 
 /mob/living/carbon/human/species/skeleton/npc
 	ambush_faction = "undead"

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -50,9 +50,11 @@ GLOBAL_LIST_INIT(skeleton_aggro, list(
 	SEND_SIGNAL(src, COMSIG_MOB_MODIFY_AGGRO_LINES, GLOB.skeleton_aggro, TRUE)
 	src.regenerate_icons() //Fixes the weird body with random genders for NPCs.
 	for(var/obj/item/equipped_item in get_equipped_items() + held_items)
-		equipped_item.AddComponent(/datum/component/item_on_drop/dust)
+		if(equipped_item.smeltresult && (equipped_item.smeltresult != /obj/item/ingot/aaslag))
+			equipped_item.AddComponent(/datum/component/item_on_drop/dust)
 	for(var/obj/item/held_item in held_items)
-		ADD_TRAIT(held_item, TRAIT_NODROP, TRAIT_GENERIC)
+		if(held_item.smeltresult != /obj/item/ingot/aaslag)
+			ADD_TRAIT(held_item, TRAIT_NODROP, TRAIT_GENERIC)
 
 /mob/living/carbon/human/species/skeleton/npc/ambush
 	threat_point = THREAT_MODERATE

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -49,12 +49,6 @@ GLOBAL_LIST_INIT(skeleton_aggro, list(
 	src.grant_language(/datum/language/undead)
 	SEND_SIGNAL(src, COMSIG_MOB_MODIFY_AGGRO_LINES, GLOB.skeleton_aggro, TRUE)
 	src.regenerate_icons() //Fixes the weird body with random genders for NPCs.
-	for(var/obj/item/equipped_item in get_equipped_items() + held_items)
-		if(equipped_item.smeltresult && (equipped_item.smeltresult != /obj/item/ingot/aaslag))
-			equipped_item.AddComponent(/datum/component/item_on_drop/dust)
-	for(var/obj/item/held_item in held_items)
-		if(held_item.smeltresult != /obj/item/ingot/aaslag)
-			ADD_TRAIT(held_item, TRAIT_NODROP, TRAIT_GENERIC)
 
 /mob/living/carbon/human/species/skeleton/npc/ambush
 	threat_point = THREAT_MODERATE

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton.dm
@@ -49,6 +49,10 @@ GLOBAL_LIST_INIT(skeleton_aggro, list(
 	src.grant_language(/datum/language/undead)
 	SEND_SIGNAL(src, COMSIG_MOB_MODIFY_AGGRO_LINES, GLOB.skeleton_aggro, TRUE)
 	src.regenerate_icons() //Fixes the weird body with random genders for NPCs.
+	for(var/obj/item/equipped_item in get_equipped_items() + held_items)
+		equipped_item.AddComponent(/datum/component/item_on_drop/dust)
+	for(var/obj/item/held_item in held_items)
+		ADD_TRAIT(held_item, TRAIT_NODROP, TRAIT_GENERIC)
 
 /mob/living/carbon/human/species/skeleton/npc/ambush
 	threat_point = THREAT_MODERATE

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_summons.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_summons.dm
@@ -1,6 +1,13 @@
 /mob/living/carbon/human/species/skeleton/npc/summon //Unique skilled NPC summons exclusive to necromancers, these guys are a menace to fight.
 	skel_outfit = /datum/outfit/job/roguetown/npc/skeleton/npc/summon
 
+/mob/living/carbon/human/species/skeleton/npc/summon/after_creation()
+	. = ..()
+	for(var/obj/item/equipped_item in get_equipped_items() + held_items)
+		equipped_item.AddComponent(/datum/component/item_on_drop/dust)
+	for(var/obj/item/held_item in held_items)
+		ADD_TRAIT(held_item, TRAIT_NODROP, TRAIT_GENERIC)
+
 /datum/outfit/job/roguetown/npc/skeleton/npc/summon //On par getup almost with greater summons, because sovl.
 
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather

--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -310,7 +310,8 @@
 
 	if (method == TOUCH)
 		if (M.mob_biotypes & MOB_UNDEAD)
-			M.adjustFireLoss(2*reac_volume, 0)
+			var/effective_volume = min(reac_volume, 10) // realistically the entire pot isn't going to be metabolized if you throw it at someone. also you could basically instakill with this so
+			M.adjustFireLoss(2*effective_volume, 0)
 			M.visible_message(span_warning("[M] erupts into angry fizzling and hissing!"), span_warning("DAMNATION, BLESSED WATER! IT BUUUURNS!"))
 			M.emote("scream")
 

--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -310,7 +310,7 @@
 
 	if (method == TOUCH)
 		if (M.mob_biotypes & MOB_UNDEAD)
-			var/effective_volume = min(reac_volume, 10) // realistically the entire pot isn't going to be metabolized if you throw it at someone. also you could basically instakill with this so
+			var/effective_volume = min(reac_volume, 30) // realistically the entire pot isn't going to be metabolized if you throw it at someone. also you could basically instakill with this so
 			M.adjustFireLoss(2*effective_volume, 0)
 			M.visible_message(span_warning("[M] erupts into angry fizzling and hissing!"), span_warning("DAMNATION, BLESSED WATER! IT BUUUURNS!"))
 			M.emote("scream")

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -368,7 +368,7 @@
 
 /datum/action/cooldown/spell/earthen_forge
 	name = "Earthen Forge"
-	desc = "Shape your earthen form into a tool or weapon. When the item breaks, you will revert to your original form. Cast again to manually revert."
+	desc = "Shape your earthen form into a tool or weapon. When the item breaks, you will revert to your original form. Resist to manually revert."
 
 	button_icon = 'icons/mob/actions/mage_conjure.dmi'
 	button_icon_state = "arcyne_forge"
@@ -504,7 +504,7 @@
 
 /datum/action/cooldown/spell/earthen_forge/void // lmao
 	name = "Void Forge"
-	desc = "Shape your ever-malleable form into a tool or weapon. When the item breaks, you will revert to your original form. Cast again to manually revert."
+	desc = "Shape your ever-malleable form into a tool or weapon. When the item breaks, you will revert to your original form. Resist to manually revert."
 
 /datum/action/cooldown/spell/arcyne_forge/elementalt2
 	name = "Greater Earthen Shaping"

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -39,7 +39,7 @@ o8o        `8    "888"  `Y8bood8P'  8""88888P'
         A fatal exception has occurred at 002B:C562F1B7 in TGUI. The current
         application will be terminated. Send the copy of the following stack
         trace to an authorized Nanotrasen incident handler at
-        https://github.com/Ochre-Valley/Ochre-Valley. Thank you for your
+        https://github.com/Azure-Peak/Azure-Peak. Thank you for your
         cooperation.
       </p>
       <div id="FatalError__stack" class="FatalError__stack"></div>


### PR DESCRIPTION
## About The Pull Request
(help it's becoming homestuck because people keep dming me exploits)

You know the drill. More fixes. This time, undead/vamp themed.
- Wounds that skip the "if this wound bleeds, don't apply it to bloodless mobs" check no longer cause bleeding. You could, in fact, ribcrack a lych and bleed them to death despite them being skeletons. This is no longer the case. Idk if this one has balance implications but it's very obviously a bug.
- Summoned skeletons now properly taint their gear as scavenged, and for summoned necro skellies specifically (not the player-controlled ones, the npcs), their gear dusts on death, to prevent people from repeatedly summoning and stripping them for sellable/salvagable iron and leather gear.
- The damage done when splashing a deadite or vamp with blessed water now has a cap on its scaling. Previously, it did fireloss equal to double the reagent amount... which meant with a pot, you could do things like this:
<img width="518" height="354" alt="image" src="https://github.com/user-attachments/assets/62e3b516-feba-4123-8cfd-07bcd3bb4f35" /><br/>
<img width="189" height="40" alt="image" src="https://github.com/user-attachments/assets/70c41e2f-b60b-4cd4-aa62-5221ab944715" /><br/>
...and then crit with a single punch<br/>
<img width="519" height="70" alt="image" src="https://github.com/user-attachments/assets/cd0e26ea-77ba-4828-aff2-d3c182f9bad5" /><br/>
...so yeah, now it's capped so you don't get any benefit for splashing someone with more than 10 drams. i don't think it'll be controversial to say "splash someone with water, something you cannot actually guard against" shouldn't do a ton of damage.
- Fixed earthen forge et al. telling you to cast the spell again to revert, when in fact you need to resist.
- TGUI errors no longer tell you to report them downstream.
- Breathless trait havers no longer breathe in spiky spores. Because they don't breathe. This is so incredibly niche i'm fairly sure none of you even know what spawns these. 

## Testing Evidence
these prs are impossible to get good screenshots of. here's me hitting myself with a lucerne to skullcrack, and not bleeding because skeleton
<img width="518" height="304" alt="image" src="https://github.com/user-attachments/assets/6fa644fc-7fee-4728-aefe-27d71e5260c6" />

## Why It's Good For The Game
Skeletons don't have blood and shouldn't bleed. That necro cheese is vile. And metachecking players with blessed water is bad enough - you shouldn't also be able to instagib them with upwards of 400 fireloss in a single unblockable action. That's fucked.

## Changelog

:cl:
fix: Skeletons no longer inexplicably bleed when their ribs or skull are broken.
fix: Necromancer summoned skeletons no longer drop gear on death, because people were exploiting it to repeatedly summon things and sell the gear.
fix: Conjured skeleton npcs of all types now properly mark their gear as scavenged.
fix: You can no longer nigh-instakill vampires and deadites by dumping 240 drams of blessed water on them. Don't ask.
fix: Elemental forge et al. no longer lie to you about how to revert. Resist to revert, you don't cast the spell again.
fix: The TGUI error screen no longer tells you to report issues downstream.
fix: Breathless trait now blocks "breathing in spiky spores".
/:cl:
